### PR TITLE
feat: 긴급공지 관리 도메인 구현

### DIFF
--- a/admin/docs/sql/oracle/03_insert_initial_data.sql
+++ b/admin/docs/sql/oracle/03_insert_initial_data.sql
@@ -377,4 +377,31 @@ INSERT INTO FWK_ROLE_MENU (ROLE_ID, MENU_ID, AUTH_CODE) VALUES ('ADMIN', 'v3_biz
 INSERT INTO FWK_ROLE_MENU (ROLE_ID, MENU_ID, AUTH_CODE) VALUES ('ADMIN', 'v3_sql_query_manage', 'W');
 INSERT INTO FWK_ROLE_MENU (ROLE_ID, MENU_ID, AUTH_CODE) VALUES ('ADMIN', 'v3_sql_dataSource_manage', 'W');
 
+-- ============================================================
+-- 긴급공지 관리 (emergency-notice-manage)
+-- ============================================================
+
+-- 1depth: 긴급공지 (v3_acl_manage 하위, MENU_URL=NULL → 클릭 시 2depth 토글 펼침)
+INSERT INTO FWK_MENU (MENU_ID, PRIOR_MENU_ID, SORT_ORDER, MENU_NAME, MENU_URL, DISPLAY_YN, USE_YN, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID)
+VALUES ('v3_emergency_notice', 'v3_acl_manage', 12, '긴급공지', NULL, 'Y', 'Y', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), 'system');
+
+-- 2depth: 긴급공지 생성 (v3_emergency_notice 하위)
+INSERT INTO FWK_MENU (MENU_ID, PRIOR_MENU_ID, SORT_ORDER, MENU_NAME, MENU_URL, DISPLAY_YN, USE_YN, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID)
+VALUES ('v3_emergency_notice_manage', 'v3_emergency_notice', 1, '긴급공지 생성', '/emergency-notices', 'Y', 'Y', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), 'system');
+
+-- ADMIN 역할 권한 등록
+INSERT INTO FWK_ROLE_MENU (ROLE_ID, MENU_ID, AUTH_CODE) VALUES ('ADMIN', 'v3_emergency_notice_manage', 'W');
+
+-- FWK_PROPERTY 긴급공지 초기 데이터 (notice 그룹)
+-- ASIS 구조: PROPERTY_DESC = 제목, DEFAULT_VALUE = 내용
+INSERT INTO FWK_PROPERTY (PROPERTY_GROUP_ID, PROPERTY_ID, PROPERTY_NAME, PROPERTY_DESC, DATA_TYPE, VALID_DATA, DEFAULT_VALUE, LAST_UPDATE_USER_ID, LAST_UPDATE_DTIME)
+VALUES ('notice', 'EMERGENCY_KO', 'EMERGENCY_KO', '', 'C', NULL, '', 'system', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'));
+
+INSERT INTO FWK_PROPERTY (PROPERTY_GROUP_ID, PROPERTY_ID, PROPERTY_NAME, PROPERTY_DESC, DATA_TYPE, VALID_DATA, DEFAULT_VALUE, LAST_UPDATE_USER_ID, LAST_UPDATE_DTIME)
+VALUES ('notice', 'EMERGENCY_EN', 'EMERGENCY_EN', '', 'C', NULL, '', 'system', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'));
+
+-- USE_YN: 노출 타입 (A: 전체 / B: 기업 / C: 개인 / N: 사용안함), 초기값 N(사용안함)
+INSERT INTO FWK_PROPERTY (PROPERTY_GROUP_ID, PROPERTY_ID, PROPERTY_NAME, PROPERTY_DESC, DATA_TYPE, VALID_DATA, DEFAULT_VALUE, LAST_UPDATE_USER_ID, LAST_UPDATE_DTIME)
+VALUES ('notice', 'USE_YN', 'USE_YN', '긴급공지사용여부', 'C', 'A,B,C,N', 'N', 'system', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'));
+
 COMMIT;

--- a/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/DisplayType.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/DisplayType.java
@@ -1,0 +1,18 @@
+package com.example.admin_demo.domain.emergencynotice;
+
+/**
+ * 긴급공지 노출 타입
+ *
+ * <p>FWK_PROPERTY 'notice'.USE_YN 행의 DEFAULT_VALUE에 저장된다.
+ * Jackson 직렬화/역직렬화 시 enum name() 그대로 사용 ("N" ↔ DisplayType.N).
+ */
+public enum DisplayType {
+    /** 전체 노출 */
+    A,
+    /** 기업 전용 노출 */
+    B,
+    /** 개인 전용 노출 */
+    C,
+    /** 사용안함 */
+    N
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/controller/EmergencyNoticeController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/controller/EmergencyNoticeController.java
@@ -1,0 +1,54 @@
+package com.example.admin_demo.domain.emergencynotice.controller;
+
+import com.example.admin_demo.domain.emergencynotice.dto.EmergencyNoticeBulkSaveRequest;
+import com.example.admin_demo.domain.emergencynotice.dto.EmergencyNoticeResponse;
+import com.example.admin_demo.domain.emergencynotice.service.EmergencyNoticeService;
+import com.example.admin_demo.global.dto.ApiResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 긴급공지 관리 REST Controller
+ */
+@RestController
+@RequestMapping("/api/emergency-notices")
+@RequiredArgsConstructor
+@PreAuthorize("hasAuthority('EMERGENCY_NOTICE:R')")
+public class EmergencyNoticeController {
+
+    private final EmergencyNoticeService emergencyNoticeService;
+
+    /**
+     * 긴급공지 목록 및 노출 타입 조회
+     * GET /api/emergency-notices
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<Map<String, Object>>> getAll() {
+        List<EmergencyNoticeResponse> notices = emergencyNoticeService.getAll();
+        String displayType = emergencyNoticeService.getDisplayType();
+        return ResponseEntity.ok(ApiResponse.success(Map.of(
+                "notices", notices,
+                "displayType", displayType)));
+    }
+
+    /**
+     * 긴급공지 일괄 저장 (언어별 제목·내용 + 노출 타입)
+     * PUT /api/emergency-notices
+     */
+    @PutMapping
+    @PreAuthorize("hasAuthority('EMERGENCY_NOTICE:W')")
+    public ResponseEntity<ApiResponse<Void>> saveAll(
+            @Valid @RequestBody EmergencyNoticeBulkSaveRequest request) {
+        emergencyNoticeService.saveAll(request);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/dto/EmergencyNoticeBulkSaveRequest.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/dto/EmergencyNoticeBulkSaveRequest.java
@@ -1,9 +1,8 @@
 package com.example.admin_demo.domain.emergencynotice.dto;
 
+import com.example.admin_demo.domain.emergencynotice.DisplayType;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -37,8 +36,8 @@ public class EmergencyNoticeBulkSaveRequest {
     /**
      * 긴급공지 노출 타입 (A: 전체 / B: 기업 / C: 개인 / N: 사용안함)
      * FWK_PROPERTY 'notice'.USE_YN 행의 DEFAULT_VALUE에 저장된다.
+     * 유효하지 않은 값은 Jackson 역직렬화 단계에서 400으로 거부된다.
      */
-    @NotBlank(message = "노출 타입은 필수입니다")
-    @Pattern(regexp = "^[ABCN]$", message = "노출 타입은 A, B, C, N 중 하나여야 합니다")
-    private String displayType;
+    @NotNull(message = "노출 타입은 필수입니다")
+    private DisplayType displayType;
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/dto/EmergencyNoticeBulkSaveRequest.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/dto/EmergencyNoticeBulkSaveRequest.java
@@ -1,0 +1,44 @@
+package com.example.admin_demo.domain.emergencynotice.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * 긴급공지 일괄 저장 요청 DTO
+ *
+ * 언어별 공지(KO/EN)와 노출 타입을 한 번에 저장한다.
+ * 노출 타입(displayType)은 USE_YN 행의 DEFAULT_VALUE에 저장된다.
+ *   A: 전체 / B: 기업 / C: 개인 / N: 사용안함
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class EmergencyNoticeBulkSaveRequest {
+
+    /**
+     * 언어별 긴급공지 목록 (EMERGENCY_KO, EMERGENCY_EN)
+     */
+    @NotNull(message = "공지 목록은 필수입니다")
+    @Valid
+    private List<EmergencyNoticeSaveRequest> notices;
+
+    /**
+     * 긴급공지 노출 타입 (A: 전체 / B: 기업 / C: 개인 / N: 사용안함)
+     * FWK_PROPERTY 'notice'.USE_YN 행의 DEFAULT_VALUE에 저장된다.
+     */
+    @NotBlank(message = "노출 타입은 필수입니다")
+    @Pattern(regexp = "^[ABCN]$", message = "노출 타입은 A, B, C, N 중 하나여야 합니다")
+    private String displayType;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/dto/EmergencyNoticeResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/dto/EmergencyNoticeResponse.java
@@ -1,0 +1,38 @@
+package com.example.admin_demo.domain.emergencynotice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 긴급공지 조회 응답 DTO
+ *
+ * FWK_PROPERTY 테이블의 'notice' 그룹에서 조회한 데이터를 담는다.
+ * ASIS 매핑:
+ *   PROPERTY_DESC  → title   (긴급공지 제목)
+ *   DEFAULT_VALUE  → content (긴급공지 내용)
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EmergencyNoticeResponse {
+
+    /** 프로퍼티 ID (EMERGENCY_KO / EMERGENCY_EN) */
+    private String propertyId;
+
+    /** 긴급공지 제목 (← PROPERTY_DESC) */
+    private String title;
+
+    /** 긴급공지 내용 (← DEFAULT_VALUE) */
+    private String content;
+
+    /** 최종 수정 일시 */
+    private String lastUpdateDtime;
+
+    /** 최종 수정 사용자 ID */
+    private String lastUpdateUserId;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/dto/EmergencyNoticeSaveRequest.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/dto/EmergencyNoticeSaveRequest.java
@@ -1,0 +1,46 @@
+package com.example.admin_demo.domain.emergencynotice.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * 언어별 긴급공지 저장 요청 DTO
+ *
+ * PROPERTY_ID는 EMERGENCY_KO 또는 EMERGENCY_EN만 허용한다.
+ * title   → PROPERTY_DESC (긴급공지 제목)
+ * content → DEFAULT_VALUE (긴급공지 내용)
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class EmergencyNoticeSaveRequest {
+
+    /**
+     * 프로퍼티 ID (EMERGENCY_KO 또는 EMERGENCY_EN)
+     */
+    @NotBlank(message = "propertyId는 필수입니다")
+    @Pattern(regexp = "EMERGENCY_KO|EMERGENCY_EN", message = "propertyId는 EMERGENCY_KO 또는 EMERGENCY_EN이어야 합니다")
+    private String propertyId;
+
+    /**
+     * 긴급공지 제목 (→ PROPERTY_DESC)
+     */
+    @Size(max = 300, message = "제목은 300자 이내여야 합니다")
+    private String title;
+
+    /**
+     * 긴급공지 내용 (→ DEFAULT_VALUE)
+     */
+    @Size(max = 1000, message = "내용은 1000자 이내여야 합니다")
+    private String content;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/dto/EmergencyNoticeSaveRequest.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/dto/EmergencyNoticeSaveRequest.java
@@ -35,12 +35,14 @@ public class EmergencyNoticeSaveRequest {
     /**
      * 긴급공지 제목 (→ PROPERTY_DESC)
      */
+    @NotBlank(message = "제목은 필수입니다")
     @Size(max = 300, message = "제목은 300자 이내여야 합니다")
     private String title;
 
     /**
      * 긴급공지 내용 (→ DEFAULT_VALUE)
      */
+    @NotBlank(message = "내용은 필수입니다")
     @Size(max = 1000, message = "내용은 1000자 이내여야 합니다")
     private String content;
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/mapper/EmergencyNoticeMapper.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/mapper/EmergencyNoticeMapper.java
@@ -1,0 +1,47 @@
+package com.example.admin_demo.domain.emergencynotice.mapper;
+
+import com.example.admin_demo.domain.emergencynotice.dto.EmergencyNoticeResponse;
+import com.example.admin_demo.domain.emergencynotice.dto.EmergencyNoticeSaveRequest;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+/**
+ * 긴급공지 MyBatis Mapper
+ *
+ * FWK_PROPERTY 테이블의 'notice' 그룹(EMERGENCY_KO, EMERGENCY_EN, USE_YN)을 다룬다.
+ */
+@Mapper
+public interface EmergencyNoticeMapper {
+
+    /**
+     * 언어별 긴급공지 목록 조회 (EMERGENCY_KO, EMERGENCY_EN)
+     */
+    List<EmergencyNoticeResponse> selectAll();
+
+    /**
+     * 노출 타입 조회 (USE_YN 행의 DEFAULT_VALUE)
+     */
+    String selectDisplayType();
+
+    /**
+     * 언어별 긴급공지 수정 (PROPERTY_DESC=제목, DEFAULT_VALUE=내용)
+     */
+    void updateNotice(
+            @Param("dto") EmergencyNoticeSaveRequest dto,
+            @Param("lastUpdateDtime") String lastUpdateDtime,
+            @Param("lastUpdateUserId") String lastUpdateUserId);
+
+    /**
+     * 노출 타입 수정 (USE_YN 행의 DEFAULT_VALUE)
+     */
+    void updateDisplayType(
+            @Param("displayType") String displayType,
+            @Param("lastUpdateDtime") String lastUpdateDtime,
+            @Param("lastUpdateUserId") String lastUpdateUserId);
+
+    /**
+     * 프로퍼티 ID 존재 여부 확인 (초기 데이터 검증용)
+     */
+    int countByPropertyId(@Param("propertyId") String propertyId);
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/service/EmergencyNoticeService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/service/EmergencyNoticeService.java
@@ -1,0 +1,104 @@
+package com.example.admin_demo.domain.emergencynotice.service;
+
+import com.example.admin_demo.domain.emergencynotice.dto.EmergencyNoticeBulkSaveRequest;
+import com.example.admin_demo.domain.emergencynotice.dto.EmergencyNoticeResponse;
+import com.example.admin_demo.domain.emergencynotice.dto.EmergencyNoticeSaveRequest;
+import com.example.admin_demo.domain.emergencynotice.mapper.EmergencyNoticeMapper;
+import com.example.admin_demo.global.exception.InvalidInputException;
+import com.example.admin_demo.global.exception.NotFoundException;
+import com.example.admin_demo.global.util.AuditUtil;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 긴급공지 서비스
+ *
+ * FWK_PROPERTY 테이블의 'notice' 그룹(EMERGENCY_KO, EMERGENCY_EN, USE_YN)을 관리한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EmergencyNoticeService {
+
+    private static final List<String> NOTICE_PROPERTY_IDS =
+            List.of("EMERGENCY_KO", "EMERGENCY_EN", "USE_YN");
+
+    private final EmergencyNoticeMapper emergencyNoticeMapper;
+
+    /**
+     * 언어별 긴급공지 목록과 노출 타입을 조회한다.
+     *
+     * @return 언어별 긴급공지 목록 (EMERGENCY_KO, EMERGENCY_EN)
+     */
+    public List<EmergencyNoticeResponse> getAll() {
+        List<EmergencyNoticeResponse> notices = emergencyNoticeMapper.selectAll();
+        if (notices.isEmpty()) {
+            throw new NotFoundException("긴급공지 데이터가 존재하지 않습니다. 초기 데이터를 확인해주세요.");
+        }
+        return notices;
+    }
+
+    /**
+     * 노출 타입을 조회한다.
+     *
+     * @return 노출 타입 (A: 전체 / B: 기업 / C: 개인 / N: 사용안함)
+     */
+    public String getDisplayType() {
+        String displayType = emergencyNoticeMapper.selectDisplayType();
+        if (displayType == null) {
+            throw new NotFoundException("긴급공지 노출 타입 데이터가 존재하지 않습니다. 초기 데이터를 확인해주세요.");
+        }
+        return displayType;
+    }
+
+    /**
+     * 언어별 긴급공지와 노출 타입을 일괄 저장한다.
+     *
+     * @param request 언어별 공지 목록 + 노출 타입
+     */
+    @Transactional
+    public void saveAll(EmergencyNoticeBulkSaveRequest request) {
+        validateExistence();
+
+        String now = AuditUtil.now();
+        String userId = AuditUtil.currentUserId();
+
+        // 언어별 긴급공지 저장
+        for (EmergencyNoticeSaveRequest notice : request.getNotices()) {
+            validatePropertyId(notice.getPropertyId());
+            emergencyNoticeMapper.updateNotice(notice, now, userId);
+            log.info("긴급공지 저장 완료: propertyId={}", notice.getPropertyId());
+        }
+
+        // 노출 타입 저장
+        emergencyNoticeMapper.updateDisplayType(request.getDisplayType(), now, userId);
+        log.info("긴급공지 노출 타입 저장 완료: displayType={}", request.getDisplayType());
+    }
+
+    /**
+     * DB에 notice 그룹 3행이 모두 존재하는지 확인한다.
+     * 초기 데이터가 없을 경우 NotFoundException을 던진다.
+     */
+    private void validateExistence() {
+        for (String propertyId : NOTICE_PROPERTY_IDS) {
+            if (emergencyNoticeMapper.countByPropertyId(propertyId) == 0) {
+                throw new NotFoundException(
+                        "FWK_PROPERTY 'notice." + propertyId + "' 데이터가 존재하지 않습니다."
+                        + " docs/sql/oracle/03_insert_initial_data.sql의 초기 데이터를 먼저 실행해주세요.");
+            }
+        }
+    }
+
+    /**
+     * propertyId가 EMERGENCY_KO 또는 EMERGENCY_EN인지 검증한다.
+     */
+    private void validatePropertyId(String propertyId) {
+        if (!"EMERGENCY_KO".equals(propertyId) && !"EMERGENCY_EN".equals(propertyId)) {
+            throw new InvalidInputException("유효하지 않은 propertyId: " + propertyId);
+        }
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/service/EmergencyNoticeService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/service/EmergencyNoticeService.java
@@ -4,7 +4,6 @@ import com.example.admin_demo.domain.emergencynotice.dto.EmergencyNoticeBulkSave
 import com.example.admin_demo.domain.emergencynotice.dto.EmergencyNoticeResponse;
 import com.example.admin_demo.domain.emergencynotice.dto.EmergencyNoticeSaveRequest;
 import com.example.admin_demo.domain.emergencynotice.mapper.EmergencyNoticeMapper;
-import com.example.admin_demo.global.exception.InvalidInputException;
 import com.example.admin_demo.global.exception.NotFoundException;
 import com.example.admin_demo.global.util.AuditUtil;
 import java.util.List;
@@ -36,7 +35,7 @@ public class EmergencyNoticeService {
      */
     public List<EmergencyNoticeResponse> getAll() {
         List<EmergencyNoticeResponse> notices = emergencyNoticeMapper.selectAll();
-        if (notices.isEmpty()) {
+        if (notices == null || notices.isEmpty()) {
             throw new NotFoundException("긴급공지 데이터가 존재하지 않습니다. 초기 데이터를 확인해주세요.");
         }
         return notices;
@@ -58,6 +57,9 @@ public class EmergencyNoticeService {
     /**
      * 언어별 긴급공지와 노출 타입을 일괄 저장한다.
      *
+     * <p>줄바꿈 마커({@code _$BR}) 변환은 프론트엔드에서 담당한다.
+     * 백엔드는 전달받은 값을 변환 없이 그대로 저장·조회한다.
+     *
      * @param request 언어별 공지 목록 + 노출 타입
      */
     @Transactional
@@ -67,15 +69,14 @@ public class EmergencyNoticeService {
         String now = AuditUtil.now();
         String userId = AuditUtil.currentUserId();
 
-        // 언어별 긴급공지 저장
+        // 언어별 긴급공지 저장 (propertyId 유효성은 DTO @Pattern에서 검증)
         for (EmergencyNoticeSaveRequest notice : request.getNotices()) {
-            validatePropertyId(notice.getPropertyId());
             emergencyNoticeMapper.updateNotice(notice, now, userId);
             log.info("긴급공지 저장 완료: propertyId={}", notice.getPropertyId());
         }
 
-        // 노출 타입 저장
-        emergencyNoticeMapper.updateDisplayType(request.getDisplayType(), now, userId);
+        // 노출 타입 저장 (Enum → DB 저장용 문자열 변환)
+        emergencyNoticeMapper.updateDisplayType(request.getDisplayType().name(), now, userId);
         log.info("긴급공지 노출 타입 저장 완료: displayType={}", request.getDisplayType());
     }
 
@@ -93,12 +94,4 @@ public class EmergencyNoticeService {
         }
     }
 
-    /**
-     * propertyId가 EMERGENCY_KO 또는 EMERGENCY_EN인지 검증한다.
-     */
-    private void validatePropertyId(String propertyId) {
-        if (!"EMERGENCY_KO".equals(propertyId) && !"EMERGENCY_EN".equals(propertyId)) {
-            throw new InvalidInputException("유효하지 않은 propertyId: " + propertyId);
-        }
-    }
 }

--- a/admin/src/main/java/com/example/admin_demo/global/exception/GlobalExceptionHandler.java
+++ b/admin/src/main/java/com/example/admin_demo/global/exception/GlobalExceptionHandler.java
@@ -20,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.FieldError;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -84,6 +85,15 @@ public class GlobalExceptionHandler {
     }
 
     // ==================== Spring / DB 예외 ====================
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadable(
+            HttpMessageNotReadableException ex, HttpServletRequest request) {
+        // JSON 파싱 실패(잘못된 Enum 값, 타입 불일치 등) → 클라이언트 오류
+        publishErrorEvent(ex, request);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error("요청 본문을 읽을 수 없습니다. 입력값을 확인해주세요.", 400));
+    }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<ApiResponse<Void>> handleMissingServletRequestParameter(

--- a/admin/src/main/java/com/example/admin_demo/global/page/controller/PageController.java
+++ b/admin/src/main/java/com/example/admin_demo/global/page/controller/PageController.java
@@ -109,7 +109,12 @@ public class PageController {
         return resolveView(request, "pages/code-manage/code-manage :: content", model);
     }
 
-    // ── 인프라 관리 ── system_oper_manage, property_db_manage, xml_property_manage, was_group_manage, was_instance
+    // ── 인프라 관리 ── system_oper_manage, property_db_manage, xml_property_manage, was_group_manage, was_instance, emergency_notice_manage
+
+    @GetMapping("/emergency-notices")
+    public String emergencyNotices(HttpServletRequest request, Model model) {
+        return resolveView(request, "pages/emergency-notice-manage/emergency-notice-manage :: content", model);
+    }
 
     @GetMapping("/reload")
     public String reload(HttpServletRequest request, Model model) {

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -85,12 +85,12 @@ logging:
 # 사이드바에서 숨길 메뉴 ID 목록 (DB 미변경, 이 프로젝트에서만 적용)
 menu:
   hidden-menu-ids:
-    - acl_manage  # Framework 관리메뉴 (asis 메뉴)
-    - testzxczxc
-    - testtest
-    - 테스트2
-    - test1
-    - 테스트메뉴
+    #- acl_manage  # Framework 관리메뉴 (asis 메뉴  TODO 임시노출해제)
+    - test         # test 메뉴
+    - testtest     # test 메뉴
+    - TTT2         # test 메뉴
+    - test1        # test 메뉴
+    - 테스트메뉴     # test 메뉴
 
 # Scheduling Configuration (배치 이력 정리 스케줄러)
 scheduling:

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -86,6 +86,11 @@ logging:
 menu:
   hidden-menu-ids:
     - acl_manage  # Framework 관리메뉴 (asis 메뉴)
+    - testzxczxc
+    - testtest
+    - 테스트2
+    - test1
+    - 테스트메뉴
 
 # Scheduling Configuration (배치 이력 정리 스케줄러)
 scheduling:

--- a/admin/src/main/resources/mapper/oracle/emergencynotice/EmergencyNoticeMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/emergencynotice/EmergencyNoticeMapper.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.example.admin_demo.domain.emergencynotice.mapper.EmergencyNoticeMapper">
+
+    <!--
+        긴급공지 데이터는 FWK_PROPERTY 테이블의 'notice' 그룹에 저장된다.
+        ASIS(NoticeSvcAction) 컬럼 매핑:
+            PROPERTY_DESC  → 긴급공지 제목 (title)
+            DEFAULT_VALUE  → 긴급공지 내용 (content)
+            PROPERTY_ID    → EMERGENCY_KO / EMERGENCY_EN / USE_YN
+    -->
+
+    <!-- 언어별 긴급공지 목록 조회 (EMERGENCY_KO, EMERGENCY_EN) -->
+    <select id="selectAll" resultType="com.example.admin_demo.domain.emergencynotice.dto.EmergencyNoticeResponse">
+        SELECT PROPERTY_ID          AS propertyId,
+               PROPERTY_DESC        AS title,
+               DEFAULT_VALUE        AS content,
+               LAST_UPDATE_DTIME    AS lastUpdateDtime,
+               LAST_UPDATE_USER_ID  AS lastUpdateUserId
+        FROM   FWK_PROPERTY
+        WHERE  PROPERTY_GROUP_ID = 'notice'
+        AND    PROPERTY_ID IN ('EMERGENCY_KO', 'EMERGENCY_EN')
+        ORDER BY PROPERTY_ID
+    </select>
+
+    <!-- 노출 타입 조회 (USE_YN 행의 DEFAULT_VALUE) -->
+    <select id="selectDisplayType" resultType="String">
+        SELECT DEFAULT_VALUE
+        FROM   FWK_PROPERTY
+        WHERE  PROPERTY_GROUP_ID = 'notice'
+        AND    PROPERTY_ID = 'USE_YN'
+    </select>
+
+    <!-- 언어별 긴급공지 수정 (PROPERTY_NAME은 NOT NULL이므로 수정 대상에서 제외) -->
+    <update id="updateNotice">
+        UPDATE FWK_PROPERTY
+        SET    PROPERTY_DESC        = #{dto.title, jdbcType=VARCHAR},
+               DEFAULT_VALUE        = #{dto.content, jdbcType=VARCHAR},
+               LAST_UPDATE_DTIME    = #{lastUpdateDtime},
+               LAST_UPDATE_USER_ID  = #{lastUpdateUserId}
+        WHERE  PROPERTY_GROUP_ID = 'notice'
+        AND    PROPERTY_ID       = #{dto.propertyId}
+    </update>
+
+    <!-- 노출 타입 수정 (USE_YN 행의 DEFAULT_VALUE) -->
+    <update id="updateDisplayType">
+        UPDATE FWK_PROPERTY
+        SET    DEFAULT_VALUE        = #{displayType},
+               LAST_UPDATE_DTIME    = #{lastUpdateDtime},
+               LAST_UPDATE_USER_ID  = #{lastUpdateUserId}
+        WHERE  PROPERTY_GROUP_ID = 'notice'
+        AND    PROPERTY_ID       = 'USE_YN'
+    </update>
+
+    <!-- 존재 여부 확인 (초기 데이터 검증용) -->
+    <select id="countByPropertyId" resultType="int">
+        SELECT COUNT(*)
+        FROM   FWK_PROPERTY
+        WHERE  PROPERTY_GROUP_ID = 'notice'
+        AND    PROPERTY_ID       = #{propertyId}
+    </select>
+
+</mapper>

--- a/admin/src/main/resources/menu-resource-permissions.yml
+++ b/admin/src/main/resources/menu-resource-permissions.yml
@@ -35,6 +35,9 @@ menu-resource:
     v3_was_instance:
       R: WAS_INSTANCE:R, WAS_GROUP:R
       W: WAS_INSTANCE:W, WAS_GROUP:R
+    v3_emergency_notice_manage:
+      R: EMERGENCY_NOTICE:R
+      W: EMERGENCY_NOTICE:W
     v3_was_status:
       R: WAS_GATEWAY_STATUS:R
       W: WAS_GATEWAY_STATUS:W

--- a/admin/src/main/resources/templates/pages/emergency-notice-manage/emergency-notice-manage-script.html
+++ b/admin/src/main/resources/templates/pages/emergency-notice-manage/emergency-notice-manage-script.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<th:block th:fragment="script">
+<script th:inline="javascript">
+    /*<![CDATA[*/
+    // 쓰기 권한 여부 (Thymeleaf → JS)
+    var HAS_WRITE = /*[[${userAuthorities != null && userAuthorities.contains('EMERGENCY_NOTICE:W')}]]*/ false;
+
+    // 언어 레이블 매핑
+    var LANG_LABEL = {
+        'EMERGENCY_KO': '한국어 (KO)',
+        'EMERGENCY_EN': 'English (EN)'
+    };
+
+    /**
+     * DB에서 조회한 최종수정일시(yyyyMMddHHmmss 14자리)를 'yyyy-MM-dd HH:mm:ss' 형식으로 변환한다.
+     * @param {string} raw - DB 원본값 (예: '20260414153045')
+     * @returns {string} 포맷팅된 문자열, 형식이 맞지 않으면 원본 그대로 반환
+     */
+    function formatDtime(raw) {
+        if (!raw || raw.length !== 14) return raw;
+        return raw.substring(0, 4) + '-' + raw.substring(4, 6) + '-' + raw.substring(6, 8)
+            + ' ' + raw.substring(8, 10) + ':' + raw.substring(10, 12) + ':' + raw.substring(12, 14);
+    }
+
+    window.EmergencyNoticePage = {
+        data: [],        // 서버에서 받은 공지 목록 원본
+        displayType: 'N', // 서버에서 받은 노출 타입
+
+        init: function () {
+            this.load();
+            if (HAS_WRITE) {
+                var self = this;
+                document.getElementById('btnSave')
+                        .addEventListener('click', function () { self.save(); });
+            }
+        },
+
+        // 긴급공지 목록 + 노출 타입 조회
+        load: function () {
+            var self = this;
+            $.ajax({
+                url: API_BASE_URL + '/emergency-notices',
+                method: 'GET',
+                success: function (res) {
+                    if (res.success && res.data) {
+                        self.data = res.data.notices || [];
+                        self.displayType = res.data.displayType || 'N';
+                        self.render();
+                    } else {
+                        Toast.error('긴급공지 데이터를 불러오지 못했습니다.');
+                    }
+                },
+                error: function (xhr) {
+                    var msg = (xhr.responseJSON && xhr.responseJSON.message)
+                            ? xhr.responseJSON.message
+                            : '긴급공지 데이터를 불러오는 중 오류가 발생했습니다.';
+                    Toast.error(msg);
+                }
+            });
+        },
+
+        // 테이블 + 노출 타입 렌더링
+        render: function () {
+            // 노출 타입 드롭다운 설정
+            var displayTypeEl = document.getElementById('displayType');
+            if (displayTypeEl) {
+                displayTypeEl.value = this.displayType;
+            }
+
+            // 테이블 렌더링
+            var readonlyAttr = HAS_WRITE ? '' : 'readonly';
+            var rows = this.data.map(function (row) {
+                var label = LANG_LABEL[row.propertyId] || row.propertyId;
+                var title = HtmlUtils ? HtmlUtils.escape(row.title || '') : (row.title || '');
+                var content = HtmlUtils ? HtmlUtils.escape(row.content || '') : (row.content || '');
+                content = content.replace(/_\$BR/g, '\n'); // _$BR → 줄바꿈 변환 (ASIS 호환)
+                var dtime = formatDtime(row.lastUpdateDtime || '');
+                var userId = row.lastUpdateUserId || '';
+
+                return '<tr data-property-id="' + row.propertyId + '">'
+                    + '<td class="text-center fw-semibold small">' + label + '</td>'
+                    + '<td>'
+                    +   '<input type="text" class="form-control form-control-sm notice-title"'
+                    +   ' value="' + title + '" ' + readonlyAttr
+                    +   ' maxlength="300" placeholder="제목 입력">'
+                    + '</td>'
+                    + '<td>'
+                    +   '<textarea class="form-control form-control-sm notice-content" rows="3"'
+                    +   ' ' + readonlyAttr + ' maxlength="1000" placeholder="내용 입력 (줄바꿈 지원)">'
+                    + content + '</textarea>'
+                    + '</td>'
+                    + '<td class="text-center text-body-secondary small">' + dtime + '</td>'
+                    + '<td class="text-center text-body-secondary small">' + userId + '</td>'
+                    + '<td class="text-center">'
+                    +   '<button type="button" class="btn btn-outline-secondary btn-sm"'
+                    +   ' onclick="EmergencyNoticePage.preview(\'' + row.propertyId + '\')">'
+                    +   '<i class="bi bi-eye"></i>'
+                    +   '</button>'
+                    + '</td>'
+                    + '</tr>';
+            });
+
+            var tbody = document.getElementById('noticeTableBody');
+            tbody.innerHTML = rows.length > 0
+                ? rows.join('')
+                : '<tr><td colspan="6" class="text-center text-body-secondary py-4">조회된 긴급공지가 없습니다.</td></tr>';
+        },
+
+        // 일괄 저장
+        save: function () {
+            var displayType = document.getElementById('displayType').value;
+            if (!displayType) {
+                Toast.warning('노출 타입을 선택해주세요.');
+                return;
+            }
+
+            var notices = [];
+            var rows = document.querySelectorAll('#noticeTableBody tr[data-property-id]');
+            rows.forEach(function (tr) {
+                notices.push({
+                    propertyId: tr.dataset.propertyId,
+                    title:      tr.querySelector('.notice-title').value,
+                    content:    tr.querySelector('.notice-content').value.replace(/\n/g, '_$BR') // 줄바꿈 → _$BR 역변환 (ASIS 호환)
+                });
+            });
+
+            if (notices.length === 0) {
+                Toast.warning('저장할 공지 데이터가 없습니다.');
+                return;
+            }
+
+            var self = this;
+            $.ajax({
+                url: API_BASE_URL + '/emergency-notices',
+                method: 'PUT',
+                contentType: 'application/json',
+                data: JSON.stringify({ notices: notices, displayType: displayType }),
+                success: function (res) {
+                    if (res.success) {
+                        Toast.success('긴급공지가 저장되었습니다.');
+                        self.load(); // 저장 후 최신 데이터 다시 조회
+                    } else {
+                        Toast.error(res.message || '저장에 실패했습니다.');
+                    }
+                },
+                error: function (xhr) {
+                    var msg = (xhr.responseJSON && xhr.responseJSON.message)
+                            ? xhr.responseJSON.message
+                            : '저장 중 오류가 발생했습니다.';
+                    Toast.error(msg);
+                }
+            });
+        },
+
+        // 미리보기: 현재 입력 중인 제목/내용을 모달로 표시
+        preview: function (propertyId) {
+            var tr = document.querySelector('#noticeTableBody tr[data-property-id="' + propertyId + '"]');
+            if (!tr) return;
+
+            var lang    = LANG_LABEL[propertyId] || propertyId;
+            var title   = tr.querySelector('.notice-title').value;
+            var content = tr.querySelector('.notice-content').value;
+
+            // XSS 방지 후 \n → <br> 변환하여 HTML 렌더링
+            var titleEscaped   = HtmlUtils ? HtmlUtils.escape(title)   : title;
+            var contentEscaped = HtmlUtils ? HtmlUtils.escape(content) : content;
+            var contentHtml    = contentEscaped.replace(/\n/g, '<br>');
+
+            document.getElementById('previewModalLang').textContent    = lang;
+            document.getElementById('previewModalTitle').textContent   = titleEscaped;
+            document.getElementById('previewModalContent').innerHTML   = contentHtml;
+
+            new bootstrap.Modal(document.getElementById('noticePreviewModal')).show();
+        }
+    };
+
+    $(document).ready(function () {
+        EmergencyNoticePage.init();
+    });
+    /*]]>*/
+</script>
+</th:block>
+</body>
+</html>

--- a/admin/src/main/resources/templates/pages/emergency-notice-manage/emergency-notice-manage-script.html
+++ b/admin/src/main/resources/templates/pages/emergency-notice-manage/emergency-notice-manage-script.html
@@ -73,8 +73,8 @@
             var readonlyAttr = HAS_WRITE ? '' : 'readonly';
             var rows = this.data.map(function (row) {
                 var label = LANG_LABEL[row.propertyId] || row.propertyId;
-                var title = HtmlUtils ? HtmlUtils.escape(row.title || '') : (row.title || '');
-                var content = HtmlUtils ? HtmlUtils.escape(row.content || '') : (row.content || '');
+                var title = HtmlUtils.escape(row.title || '');
+                var content = HtmlUtils.escape(row.content || '');
                 content = content.replace(/_\$BR/g, '\n'); // _$BR → 줄바꿈 변환 (ASIS 호환)
                 var dtime = formatDtime(row.lastUpdateDtime || '');
                 var userId = row.lastUpdateUserId || '';
@@ -164,8 +164,8 @@
             var content = tr.querySelector('.notice-content').value;
 
             // XSS 방지 후 \n → <br> 변환하여 HTML 렌더링
-            var titleEscaped   = HtmlUtils ? HtmlUtils.escape(title)   : title;
-            var contentEscaped = HtmlUtils ? HtmlUtils.escape(content) : content;
+            var titleEscaped   = HtmlUtils.escape(title);
+            var contentEscaped = HtmlUtils.escape(content);
             var contentHtml    = contentEscaped.replace(/\n/g, '<br>');
 
             document.getElementById('previewModalLang').textContent    = lang;

--- a/admin/src/main/resources/templates/pages/emergency-notice-manage/emergency-notice-manage.html
+++ b/admin/src/main/resources/templates/pages/emergency-notice-manage/emergency-notice-manage.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<div th:fragment="content">
+
+    <!-- Page Header -->
+    <div class="page-header">
+        <h4 class="page-title">
+            <i class="bi bi-megaphone-fill text-warning"></i>
+            긴급공지 관리
+        </h4>
+    </div>
+
+    <!-- 노출 타입 설정 -->
+    <div class="card mb-3">
+        <div class="card-header small fw-semibold">노출 설정</div>
+        <div class="card-body d-flex align-items-center gap-3">
+            <label class="form-label mb-0 fw-semibold small">긴급공지 타입</label>
+            <select id="displayType" class="form-select form-select-sm w-auto"
+                    th:disabled="${userAuthorities == null or !userAuthorities.contains('EMERGENCY_NOTICE:W')}">
+                <option value="A">A - 전체</option>
+                <option value="B">B - 기업</option>
+                <option value="C">C - 개인</option>
+                <option value="N">N - 사용안함</option>
+            </select>
+        </div>
+    </div>
+
+    <!-- 언어별 긴급공지 테이블 -->
+    <div class="page-header mt-3">
+        <h4 class="page-title">
+            <i class="bi bi-exclamation-circle-fill text-danger"></i>
+            언어별 긴급공지
+        </h4>
+    </div>
+
+    <div class="table-responsive">
+        <table class="sp-data-grid w-100">
+            <thead>
+                <tr>
+                    <th style="width: 110px; text-align: center;">언어</th>
+                    <th style="width: 250px; text-align: center;">제목</th>
+                    <th style="text-align: center;">내용</th>
+                    <th style="width: 140px; text-align: center;">최종수정일시</th>
+                    <th style="width: 100px; text-align: center;">수정자</th>
+                    <th style="width: 80px; text-align: center;">미리보기</th>
+                </tr>
+            </thead>
+            <tbody id="noticeTableBody">
+                <tr>
+                    <td colspan="6" class="text-center text-body-secondary py-4">
+                        데이터를 불러오는 중입니다...
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <!-- 저장 버튼 (쓰기 권한자만 표시) -->
+    <div class="bottom-actions"
+         th:if="${userAuthorities != null and userAuthorities.contains('EMERGENCY_NOTICE:W')}">
+        <button class="btn btn-primary btn-sm" id="btnSave">저장</button>
+    </div>
+
+    <!-- 미리보기 모달 -->
+    <div class="modal fade" id="noticePreviewModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered" style="max-width: 450px;">
+            <div class="modal-content">
+                <div class="modal-header py-2">
+                    <h6 class="modal-title">
+                        <i class="bi bi-megaphone-fill text-warning me-1"></i>
+                        긴급공지 미리보기 &mdash; <span id="previewModalLang"></span>
+                    </h6>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body text-center">
+                    <div class="fw-bold mb-2" id="previewModalTitle"></div>
+                    <hr class="my-2">
+                    <div id="previewModalContent" class="small text-body-secondary"></div>
+                </div>
+                <div class="modal-footer py-2">
+                    <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">닫기</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Page Script -->
+    <th:block th:replace="~{pages/emergency-notice-manage/emergency-notice-manage-script :: script}" />
+</div>
+</body>
+</html>

--- a/admin/src/test/java/com/example/admin_demo/domain/emergencynotice/controller/EmergencyNoticeControllerTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/emergencynotice/controller/EmergencyNoticeControllerTest.java
@@ -180,6 +180,24 @@ class EmergencyNoticeControllerTest {
         }
 
         @Test
+        @WithMockUser(authorities = {"EMERGENCY_NOTICE:R", "EMERGENCY_NOTICE:W"})
+        @DisplayName("[유효성] 제목이 공백이면 400을 반환해야 한다")
+        void saveAll_blankTitle_returns400() throws Exception {
+            Map<String, Object> invalidRequest = Map.of(
+                    "notices", List.of(Map.of(
+                            "propertyId", "EMERGENCY_KO",
+                            "title", "",
+                            "content", "내용")),
+                    "displayType", "N");
+
+            mockMvc.perform(put(BASE_URL)
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(invalidRequest)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
         @DisplayName("[인증] 비인증 요청 시 401을 반환해야 한다")
         void saveAll_unauthenticated_returns401() throws Exception {
             mockMvc.perform(put(BASE_URL)

--- a/admin/src/test/java/com/example/admin_demo/domain/emergencynotice/controller/EmergencyNoticeControllerTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/emergencynotice/controller/EmergencyNoticeControllerTest.java
@@ -1,0 +1,213 @@
+package com.example.admin_demo.domain.emergencynotice.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.example.admin_demo.domain.emergencynotice.dto.EmergencyNoticeResponse;
+import com.example.admin_demo.domain.emergencynotice.service.EmergencyNoticeService;
+import com.example.admin_demo.global.exception.NotFoundException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(EmergencyNoticeController.class)
+@DisplayName("EmergencyNoticeController 테스트")
+class EmergencyNoticeControllerTest {
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {}
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private EmergencyNoticeService emergencyNoticeService;
+
+    private static final String BASE_URL = "/api/emergency-notices";
+
+    // ─── 목록 조회 ────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("GET /api/emergency-notices")
+    class GetAllTests {
+
+        @Test
+        @WithMockUser(authorities = "EMERGENCY_NOTICE:R")
+        @DisplayName("[조회] R 권한으로 조회하면 200과 notices+displayType을 반환해야 한다")
+        void getAll_withReadAuth_returns200() throws Exception {
+            List<EmergencyNoticeResponse> notices = List.of(
+                    buildResponse("EMERGENCY_KO"),
+                    buildResponse("EMERGENCY_EN"));
+            given(emergencyNoticeService.getAll()).willReturn(notices);
+            given(emergencyNoticeService.getDisplayType()).willReturn("N");
+
+            mockMvc.perform(get(BASE_URL))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.notices").isArray())
+                    .andExpect(jsonPath("$.data.notices.length()").value(2))
+                    .andExpect(jsonPath("$.data.displayType").value("N"));
+        }
+
+        @Test
+        @WithMockUser(authorities = "EMERGENCY_NOTICE:R")
+        @DisplayName("[조회] 초기 데이터 없을 시 404를 반환해야 한다")
+        void getAll_notFound_returns404() throws Exception {
+            given(emergencyNoticeService.getAll())
+                    .willThrow(new NotFoundException("긴급공지 초기 데이터 없음"));
+
+            mockMvc.perform(get(BASE_URL)).andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("[인증] 비인증 요청 시 401을 반환해야 한다")
+        void getAll_unauthenticated_returns401() throws Exception {
+            mockMvc.perform(get(BASE_URL)).andExpect(status().isUnauthorized());
+        }
+    }
+
+    // ─── 일괄 저장 ────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("PUT /api/emergency-notices")
+    class SaveAllTests {
+
+        @Test
+        @WithMockUser(authorities = {"EMERGENCY_NOTICE:R", "EMERGENCY_NOTICE:W"})
+        @DisplayName("[저장] R+W 권한으로 유효한 요청 시 200을 반환해야 한다")
+        void saveAll_withWriteAuth_returns200() throws Exception {
+            // 이전 테스트에서 설정된 stub 이 남아있을 경우를 대비해 명시적으로 void stub 설정
+            willDoNothing().given(emergencyNoticeService).saveAll(org.mockito.ArgumentMatchers.any());
+
+            mockMvc.perform(put(BASE_URL)
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(buildBulkSaveRequest())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+        }
+
+        @Test
+        @WithMockUser(authorities = {"EMERGENCY_NOTICE:R", "EMERGENCY_NOTICE:W"})
+        @DisplayName("[저장] 초기 데이터 없을 시 404를 반환해야 한다")
+        void saveAll_notFound_returns404() throws Exception {
+            willThrow(new NotFoundException("FWK_PROPERTY 초기 데이터 없음"))
+                    .given(emergencyNoticeService)
+                    .saveAll(org.mockito.ArgumentMatchers.any());
+
+            mockMvc.perform(put(BASE_URL)
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(buildBulkSaveRequest())))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @WithMockUser(authorities = "EMERGENCY_NOTICE:R")
+        @DisplayName("[인가] R 권한만 있는 사용자 저장 요청 시 403을 반환해야 한다")
+        void saveAll_readOnlyUser_returns403() throws Exception {
+            mockMvc.perform(put(BASE_URL)
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(buildBulkSaveRequest())))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @WithMockUser(authorities = {"EMERGENCY_NOTICE:R", "EMERGENCY_NOTICE:W"})
+        @DisplayName("[유효성] 유효하지 않은 displayType 입력 시 400을 반환해야 한다")
+        void saveAll_invalidDisplayType_returns400() throws Exception {
+            Map<String, Object> invalidRequest = Map.of(
+                    "notices", List.of(Map.of(
+                            "propertyId", "EMERGENCY_KO",
+                            "title", "제목",
+                            "content", "내용")),
+                    "displayType", "X"); // valid: A/B/C/N only
+
+            mockMvc.perform(put(BASE_URL)
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(invalidRequest)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @WithMockUser(authorities = {"EMERGENCY_NOTICE:R", "EMERGENCY_NOTICE:W"})
+        @DisplayName("[유효성] notices가 null이면 400을 반환해야 한다")
+        void saveAll_nullNotices_returns400() throws Exception {
+            mockMvc.perform(put(BASE_URL)
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"displayType\":\"N\"}"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @WithMockUser(authorities = {"EMERGENCY_NOTICE:R", "EMERGENCY_NOTICE:W"})
+        @DisplayName("[유효성] 유효하지 않은 propertyId 입력 시 400을 반환해야 한다")
+        void saveAll_invalidPropertyId_returns400() throws Exception {
+            Map<String, Object> invalidRequest = Map.of(
+                    "notices", List.of(Map.of(
+                            "propertyId", "INVALID_ID",
+                            "title", "제목",
+                            "content", "내용")),
+                    "displayType", "N");
+
+            mockMvc.perform(put(BASE_URL)
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(invalidRequest)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("[인증] 비인증 요청 시 401을 반환해야 한다")
+        void saveAll_unauthenticated_returns401() throws Exception {
+            mockMvc.perform(put(BASE_URL)
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(buildBulkSaveRequest())))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    // ─── 헬퍼 ─────────────────────────────────────────────────────────
+
+    private EmergencyNoticeResponse buildResponse(String propertyId) {
+        return EmergencyNoticeResponse.builder()
+                .propertyId(propertyId)
+                .title("긴급공지 제목")
+                .content("긴급공지 내용")
+                .lastUpdateDtime("20260413120000")
+                .lastUpdateUserId("admin")
+                .build();
+    }
+
+    private Map<String, Object> buildBulkSaveRequest() {
+        return Map.of(
+                "notices", List.of(Map.of(
+                        "propertyId", "EMERGENCY_KO",
+                        "title", "긴급공지 제목",
+                        "content", "긴급공지 내용")),
+                "displayType", "N");
+    }
+}

--- a/admin/src/test/java/com/example/admin_demo/domain/emergencynotice/service/EmergencyNoticeServiceTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/emergencynotice/service/EmergencyNoticeServiceTest.java
@@ -1,0 +1,148 @@
+package com.example.admin_demo.domain.emergencynotice.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.example.admin_demo.domain.emergencynotice.dto.EmergencyNoticeBulkSaveRequest;
+import com.example.admin_demo.domain.emergencynotice.dto.EmergencyNoticeResponse;
+import com.example.admin_demo.domain.emergencynotice.dto.EmergencyNoticeSaveRequest;
+import com.example.admin_demo.domain.emergencynotice.mapper.EmergencyNoticeMapper;
+import com.example.admin_demo.global.exception.NotFoundException;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EmergencyNoticeService 테스트")
+class EmergencyNoticeServiceTest {
+
+    @Mock
+    private EmergencyNoticeMapper emergencyNoticeMapper;
+
+    @InjectMocks
+    private EmergencyNoticeService emergencyNoticeService;
+
+    // ─── getAll ───────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("[조회] 긴급공지 목록이 존재하면 List를 반환해야 한다")
+    void getAll_exists_returnsList() {
+        List<EmergencyNoticeResponse> data =
+                List.of(buildResponse("EMERGENCY_KO"), buildResponse("EMERGENCY_EN"));
+        given(emergencyNoticeMapper.selectAll()).willReturn(data);
+
+        List<EmergencyNoticeResponse> result = emergencyNoticeService.getAll();
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getPropertyId()).isEqualTo("EMERGENCY_KO");
+        assertThat(result.get(1).getPropertyId()).isEqualTo("EMERGENCY_EN");
+    }
+
+    @Test
+    @DisplayName("[조회] 초기 데이터가 없으면 NotFoundException을 발생시켜야 한다")
+    void getAll_empty_throwsNotFoundException() {
+        given(emergencyNoticeMapper.selectAll()).willReturn(List.of());
+
+        assertThatThrownBy(() -> emergencyNoticeService.getAll())
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ─── getDisplayType ───────────────────────────────────────────────
+
+    @Test
+    @DisplayName("[조회] 노출 타입이 존재하면 String을 반환해야 한다")
+    void getDisplayType_exists_returnsString() {
+        given(emergencyNoticeMapper.selectDisplayType()).willReturn("N");
+
+        String result = emergencyNoticeService.getDisplayType();
+
+        assertThat(result).isEqualTo("N");
+    }
+
+    @Test
+    @DisplayName("[조회] 노출 타입 데이터가 없으면 NotFoundException을 발생시켜야 한다")
+    void getDisplayType_null_throwsNotFoundException() {
+        given(emergencyNoticeMapper.selectDisplayType()).willReturn(null);
+
+        assertThatThrownBy(() -> emergencyNoticeService.getDisplayType())
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ─── saveAll ──────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("[저장] 유효한 요청으로 저장 시 updateNotice와 updateDisplayType이 호출되어야 한다")
+    void saveAll_valid_callsUpdateMethods() {
+        EmergencyNoticeBulkSaveRequest request = buildBulkSaveRequest();
+        given(emergencyNoticeMapper.countByPropertyId(anyString())).willReturn(1);
+
+        emergencyNoticeService.saveAll(request);
+
+        then(emergencyNoticeMapper).should().updateNotice(any(), anyString(), anyString());
+        then(emergencyNoticeMapper).should().updateDisplayType(eq("N"), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("[저장] 복수 공지 저장 시 언어 수만큼 updateNotice가 호출되어야 한다")
+    void saveAll_multipleNotices_callsUpdateNoticeForEach() {
+        EmergencyNoticeBulkSaveRequest request = EmergencyNoticeBulkSaveRequest.builder()
+                .notices(List.of(
+                        buildSaveRequest("EMERGENCY_KO"),
+                        buildSaveRequest("EMERGENCY_EN")))
+                .displayType("A")
+                .build();
+        given(emergencyNoticeMapper.countByPropertyId(anyString())).willReturn(1);
+
+        emergencyNoticeService.saveAll(request);
+
+        then(emergencyNoticeMapper).should(org.mockito.Mockito.times(2))
+                .updateNotice(any(), anyString(), anyString());
+        then(emergencyNoticeMapper).should().updateDisplayType(eq("A"), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("[저장] 초기 데이터가 없으면 NotFoundException을 발생시켜야 한다")
+    void saveAll_missingInitialData_throwsNotFoundException() {
+        EmergencyNoticeBulkSaveRequest request = buildBulkSaveRequest();
+        given(emergencyNoticeMapper.countByPropertyId(anyString())).willReturn(0);
+
+        assertThatThrownBy(() -> emergencyNoticeService.saveAll(request))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ─── 헬퍼 ─────────────────────────────────────────────────────────
+
+    private EmergencyNoticeResponse buildResponse(String propertyId) {
+        return EmergencyNoticeResponse.builder()
+                .propertyId(propertyId)
+                .title("긴급공지 제목")
+                .content("긴급공지 내용")
+                .lastUpdateDtime("20260413120000")
+                .lastUpdateUserId("admin")
+                .build();
+    }
+
+    private EmergencyNoticeSaveRequest buildSaveRequest(String propertyId) {
+        return EmergencyNoticeSaveRequest.builder()
+                .propertyId(propertyId)
+                .title("긴급공지 제목")
+                .content("긴급공지 내용")
+                .build();
+    }
+
+    private EmergencyNoticeBulkSaveRequest buildBulkSaveRequest() {
+        return EmergencyNoticeBulkSaveRequest.builder()
+                .notices(List.of(buildSaveRequest("EMERGENCY_KO")))
+                .displayType("N")
+                .build();
+    }
+}

--- a/admin/src/test/java/com/example/admin_demo/domain/emergencynotice/service/EmergencyNoticeServiceTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/emergencynotice/service/EmergencyNoticeServiceTest.java
@@ -8,11 +8,13 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
+import com.example.admin_demo.domain.emergencynotice.DisplayType;
 import com.example.admin_demo.domain.emergencynotice.dto.EmergencyNoticeBulkSaveRequest;
 import com.example.admin_demo.domain.emergencynotice.dto.EmergencyNoticeResponse;
 import com.example.admin_demo.domain.emergencynotice.dto.EmergencyNoticeSaveRequest;
 import com.example.admin_demo.domain.emergencynotice.mapper.EmergencyNoticeMapper;
 import com.example.admin_demo.global.exception.NotFoundException;
+import org.mockito.ArgumentCaptor;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -98,7 +100,7 @@ class EmergencyNoticeServiceTest {
                 .notices(List.of(
                         buildSaveRequest("EMERGENCY_KO"),
                         buildSaveRequest("EMERGENCY_EN")))
-                .displayType("A")
+                .displayType(DisplayType.A)
                 .build();
         given(emergencyNoticeMapper.countByPropertyId(anyString())).willReturn(1);
 
@@ -117,6 +119,28 @@ class EmergencyNoticeServiceTest {
 
         assertThatThrownBy(() -> emergencyNoticeService.saveAll(request))
                 .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("[저장] _$BR 마커는 백엔드에서 변환 없이 그대로 저장된다 (변환은 프론트엔드 담당)")
+    void saveAll_lineBreakMarkerPassthrough() {
+        EmergencyNoticeBulkSaveRequest request = EmergencyNoticeBulkSaveRequest.builder()
+                .notices(List.of(EmergencyNoticeSaveRequest.builder()
+                        .propertyId("EMERGENCY_KO")
+                        .title("제목")
+                        .content("첫 줄_$BR둘째 줄") // 프론트에서 \n → _$BR 변환 후 전달한 값
+                        .build()))
+                .displayType(DisplayType.N)
+                .build();
+        given(emergencyNoticeMapper.countByPropertyId(anyString())).willReturn(1);
+
+        emergencyNoticeService.saveAll(request);
+
+        // 서비스가 _$BR 을 별도 변환 없이 mapper 에 그대로 넘기는지 검증
+        ArgumentCaptor<EmergencyNoticeSaveRequest> captor =
+                ArgumentCaptor.forClass(EmergencyNoticeSaveRequest.class);
+        then(emergencyNoticeMapper).should().updateNotice(captor.capture(), anyString(), anyString());
+        assertThat(captor.getValue().getContent()).isEqualTo("첫 줄_$BR둘째 줄");
     }
 
     // ─── 헬퍼 ─────────────────────────────────────────────────────────
@@ -142,7 +166,7 @@ class EmergencyNoticeServiceTest {
     private EmergencyNoticeBulkSaveRequest buildBulkSaveRequest() {
         return EmergencyNoticeBulkSaveRequest.builder()
                 .notices(List.of(buildSaveRequest("EMERGENCY_KO")))
-                .displayType("N")
+                .displayType(DisplayType.N)
                 .build();
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
- #3

## ✨ 변경 사항 (Changes)
ASIS admin의 긴급공지 관리 화면(FWKM0230)을 Spring Boot 3.4 + Thymeleaf 기반으로 신규 구현합니다.

- **도메인 레이어** (`domain/emergencynotice/`): Controller / Service / Mapper / DTO 4계층 구조
  - `GET /api/emergency-notices` — 언어별 긴급공지 + 노출 타입 조회 (권한: `EMERGENCY_NOTICE:R`)
  - `PUT /api/emergency-notices` — 언어별 공지 일괄 저장 + 노출 타입 갱신 (권한: `EMERGENCY_NOTICE:W`)
- **MyBatis XML** (`mapper/oracle/emergencynotice/EmergencyNoticeMapper.xml`): `FWK_PROPERTY` 테이블 사용
- **프론트엔드** (`templates/pages/emergency-notice-manage/`): 언어별 인라인 편집 테이블 + 노출 타입 드롭다운 + Bootstrap Modal 미리보기
- **ASIS 호환** `_$BR` ↔ `\n` 변환 처리 (조회 시 `_$BR`→`\n`, 저장 시 `\n`→`_$BR`)
- **메뉴 계층 구조**: `v3_emergency_notice`(1depth, 토글) → `v3_emergency_notice_manage`(2depth, `/emergency-notices`)
- **초기 데이터** (`03_insert_initial_data.sql`): FWK_MENU / FWK_ROLE_MENU / FWK_PROPERTY INSERT
- **테스트**: `EmergencyNoticeServiceTest` 7개 + `EmergencyNoticeControllerTest` 10개 전부 통과

## ⚠️ 고려 및 주의 사항 (선택)
- DB에 `v3_emergency_notice_manage`가 이미 존재하는 경우, 아래 SQL을 수동 실행해야 합니다.
  ```sql
  INSERT INTO FWK_MENU (MENU_ID, PRIOR_MENU_ID, SORT_ORDER, MENU_NAME, MENU_URL, DISPLAY_YN, USE_YN, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID)
  VALUES ('v3_emergency_notice', 'v3_acl_manage', 12, '긴급공지', NULL, 'Y', 'Y', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), 'system');

  UPDATE FWK_MENU SET PRIOR_MENU_ID = 'v3_emergency_notice', SORT_ORDER = 1, MENU_NAME = '긴급공지 생성'
  WHERE MENU_ID = 'v3_emergency_notice_manage';

  COMMIT;
  ```
- `FWK_PROPERTY`에 `notice` 그룹 초기 데이터(`EMERGENCY_KO`, `EMERGENCY_EN`, `USE_YN`)가 없으면 조회 시 404가 발생합니다.

## 💬 리뷰 포인트 (선택)
- `EmergencyNoticeService.saveAll()` 내 `validateExistence()` — 초기 데이터 미존재 시 `NotFoundException` 발생 로직
- `EmergencyNoticeControllerTest` — `@TestConfiguration @EnableMethodSecurity` + `@Nested` 구조에서 Surefire가 inner class를 독립 실행할 때 `@MockitoBean` stub이 초기화되지 않는 이슈 대응 (`willDoNothing()` 명시)