### PR TITLE
feat: 하나카드 데모 Express 백엔드 구현 및 프론트 실제 API 연동

### DIFF
--- a/demo/backend/.env.example
+++ b/demo/backend/.env.example
@@ -1,0 +1,29 @@
+# ──────────────────────────────────────────────
+# Oracle DB 접속 정보
+#   .env.example 을 복사해 .env 로 만들고 실제 값으로 채워 쓰세요.
+#   .env 는 .gitignore 에 반드시 추가하세요!
+# ──────────────────────────────────────────────
+
+# Oracle 계정
+DB_USER=your_db_user
+DB_PASSWORD=your_db_password
+
+# Easy Connect 형식: host:port/service_name
+# 예) 192.168.0.10:1521/ORCLPDB1
+DB_CONNECT_STRING=C:\instantclient_21_13
+
+# 커넥션 풀 크기 (선택 — 기본값이 있으므로 생략 가능)
+DB_POOL_MIN=2
+DB_POOL_MAX=10
+DB_POOL_INCREMENT=1
+
+# JWT 서명 비밀키
+JWT_SECRET=ENTER_YOUR_SECRET_KEY_HERE
+# JWT 만료 시간 (예: 30m, 8h, 1d)
+JWT_EXPIRES_IN=30m
+
+# Express 서버 포트 (기본 3001)
+PORT=3001
+
+# 프론트엔드 주소 (CORS 허용 Origin)
+CLIENT_ORIGIN=http://localhost:5173

--- a/demo/backend/.gitignore
+++ b/demo/backend/.gitignore
@@ -1,0 +1,2 @@
+.env
+demo/backend/.env

--- a/demo/backend/README.md
+++ b/demo/backend/README.md
@@ -1,0 +1,320 @@
+# HNC Demo Backend
+
+하나카드 데모 앱의 Express 기반 백엔드 서버입니다.  
+Oracle DB(`D_SPIDERLINK`)의 POC 테이블을 REST API로 노출하며, JWT 인증으로 보호합니다.
+
+---
+
+## 기술 스택
+
+| 항목 | 버전 |
+|------|------|
+| Node.js | 18+ 권장 |
+| Express | 4.x |
+| oracledb | 6.x (Thick Mode) |
+| jsonwebtoken | 9.x |
+| dotenv | 16.x |
+| nodemon | 3.x (개발용) |
+
+---
+
+## 디렉토리 구조
+
+```
+demo/backend/
+├── server.js          # 서버 진입점 + 모든 API 엔드포인트
+├── db.js              # Oracle 커넥션 풀 관리 (initPool / withConnection / closePool)
+├── utils/
+│   ├── cardBrand.js   # 카드번호 BIN 기반 브랜드 식별 + 번호 마스킹
+│   └── logger.js      # 메서드·상태코드 컬러 API 로거 미들웨어
+├── .env               # 실제 환경 변수 (Git 제외 — 절대 커밋 금지)
+├── .env.example       # 환경 변수 예시 (이 파일을 복사해서 .env 생성)
+├── .gitignore
+└── package.json
+```
+
+---
+
+## 환경 설정
+
+### 1. Oracle Instant Client 설치
+
+`oracledb` Thick Mode는 Oracle Instant Client가 필요합니다.  
+접속 대상 Oracle 서버가 **11g(XE)** 이므로 Thin Mode를 지원하지 않습니다.
+
+- [Oracle Instant Client 다운로드](https://www.oracle.com/database/technologies/instant-client/downloads.html)
+- Windows 기준 예시 경로: `C:\instantclient_21_13`
+
+### 2. .env 파일 생성
+
+```bash
+cp .env.example .env
+```
+
+`.env` 파일을 열어 실제 값으로 채웁니다.
+
+```dotenv
+# Oracle Instant Client 경로 (미설정 시 시스템 PATH 자동 탐색)
+ORACLE_CLIENT_PATH=C:\instantclient_21_13
+
+# Oracle 계정
+DB_USER=your_db_user
+DB_PASSWORD=your_db_password
+
+# Easy Connect 형식: host:port/service_name
+DB_CONNECT_STRING=localhost:1521/XE
+
+# 커넥션 풀 크기 (선택 — 기본값 사용 가능)
+DB_POOL_MIN=2
+DB_POOL_MAX=10
+DB_POOL_INCREMENT=1
+
+# JWT 서명 비밀키 (충분히 길고 무작위한 값 사용)
+JWT_SECRET=ENTER_YOUR_SECRET_KEY_HERE
+# JWT 만료 시간 (예: 30m, 8h, 1d)
+JWT_EXPIRES_IN=30m
+
+# Express 서버 포트 (기본 3001)
+PORT=3001
+
+# 프론트엔드 주소 (CORS 허용 Origin)
+CLIENT_ORIGIN=http://localhost:5173
+```
+
+> **주의:** `.env`에는 DB 비밀번호와 JWT 시크릿이 포함됩니다. 절대 Git에 커밋하지 마세요.
+
+### 3. 패키지 설치
+
+```bash
+npm install
+```
+
+---
+
+## 실행
+
+```bash
+# 개발 모드 (nodemon — 파일 변경 시 자동 재시작)
+npm run dev
+
+# 운영 모드
+npm start
+```
+
+서버가 정상 기동되면 콘솔에 아래 메시지가 출력됩니다.
+
+```
+[DB] Thick Mode 초기화 완료 (Oracle Client 경로: C:\instantclient_21_13)
+[DB] Oracle 커넥션 풀 생성 완료
+[Server] http://localhost:3001 에서 실행 중
+```
+
+---
+
+## API 목록
+
+모든 보호 라우트는 `Authorization: Bearer <token>` 헤더가 필요합니다.
+
+### 인증
+
+| 메서드 | 경로 | 인증 | 설명 |
+|--------|------|------|------|
+| POST | `/api/auth/login` | 불필요 | 로그인 — JWT 발급 |
+
+**요청 Body**
+```json
+{ "userId": "string", "password": "string" }
+```
+
+**응답 (성공 200)**
+```json
+{
+  "success": true,
+  "token": "eyJ...",
+  "userId": "user01",
+  "userName": "홍길동",
+  "userGrade": "A"
+}
+```
+
+---
+
+### 카드
+
+| 메서드 | 경로 | 인증 | 설명 |
+|--------|------|------|------|
+| GET | `/api/cards` | 필요 | 로그인 사용자의 카드 목록 |
+
+**응답 (성공 200)**
+```json
+{
+  "cards": [
+    {
+      "id": "카드번호",
+      "name": "카드구분",
+      "brand": "VISA",
+      "maskedNumber": "4111-11**-****-1111",
+      "balance": 500000,
+      "expiry": "2612",
+      "paymentBank": "하나은행",
+      "paymentAccount": "123-456-789012",
+      "paymentDay": "15",
+      "limitAmount": 3000000,
+      "usedAmount": 2500000
+    }
+  ]
+}
+```
+
+---
+
+### 이용내역
+
+| 메서드 | 경로 | 인증 | 설명 |
+|--------|------|------|------|
+| GET | `/api/transactions` | 필요 | 로그인 사용자의 이용내역 조회 |
+
+**Query Parameters (모두 선택)**
+
+| 파라미터 | 타입 | 설명 |
+|----------|------|------|
+| `cardId` | string | 카드번호 필터. 없거나 `all`이면 전체 |
+| `period` | string | `thisMonth` \| `1month` \| `3months` \| `custom` |
+| `customMonth` | string | `YYYY-MM` (`period=custom`일 때 사용) |
+| `usageType` | string | `lump`(일시불) \| `installment`(할부) \| `cancel`(취소) |
+
+**응답 (성공 200)**
+```json
+{
+  "transactions": [
+    {
+      "id": "카드번호-이용일자-승인시각-0",
+      "merchant": "스타벅스 강남점",
+      "amount": 6500,
+      "date": "2026.04.14 10:30",
+      "type": "일시불",
+      "approvalNumber": "12345678",
+      "status": "승인",
+      "cardName": "하나 VIVA 카드"
+    }
+  ],
+  "totalCount": 42,
+  "paymentSummary": { "date": "4월 15일", "totalAmount": 350000 }
+}
+```
+
+---
+
+### 결제예정금액
+
+| 메서드 | 경로 | 인증 | 설명 |
+|--------|------|------|------|
+| GET | `/api/payment-statement` | 필요 | 결제예정금액 및 명세서 데이터 |
+
+**응답 (성공 200)**
+```json
+{
+  "dueDate": "260415",
+  "totalAmount": 350000,
+  "items": [
+    {
+      "cardNo": "4111111111111111",
+      "cardName": "하나 VIVA 카드",
+      "amount": 350000,
+      "dueDate": "260415"
+    }
+  ],
+  "cardInfo": {
+    "paymentBank": "하나은행",
+    "paymentAccount": "123-456-789012",
+    "paymentDay": "15"
+  }
+}
+```
+
+---
+
+### 카드별 이용내역 (페이징)
+
+| 메서드 | 경로 | 인증 | 설명 |
+|--------|------|------|------|
+| GET | `/api/cards/:cardId/transactions` | 필요 | 특정 카드의 이용내역 페이징 조회 |
+
+**Query Parameters**
+
+| 파라미터 | 기본값 | 설명 |
+|----------|--------|------|
+| `page` | 1 | 페이지 번호 (1-based) |
+| `pageSize` | 20 | 페이지당 건수 (최대 100) |
+| `fromDate` | - | 조회 시작일 `YYYYMMDD` |
+| `toDate` | - | 조회 종료일 `YYYYMMDD` |
+
+---
+
+### 개발용 (운영 배포 전 제거 필요)
+
+| 메서드 | 경로 | 설명 |
+|--------|------|------|
+| GET | `/api/dev/tables` | `D_SPIDERLINK`의 POC 테이블 목록 |
+| GET | `/api/dev/columns/:tbl` | 특정 테이블의 컬럼 목록 |
+| GET | `/api/dev/raw` | `POC_카드사용내역` 샘플 5건 조회 |
+
+---
+
+## DB 테이블 구조
+
+서버가 참조하는 `D_SPIDERLINK` 스키마의 POC 테이블입니다.
+
+| 테이블 | 설명 |
+|--------|------|
+| `POC_USER` | 사용자 계정 (`USER_ID`, `PASSWORD`, `LOG_YN` 등) |
+| `POC_카드리스트` | 카드 목록 (`카드번호`, `카드구분`, `한도금액`, `사용금액` 등) |
+| `POC_카드사용내역` | 이용내역 (`이용자`, `이용일자`, `이용가맹점`, `이용금액` 등) |
+
+---
+
+## 주요 모듈 설명
+
+### `db.js` — Oracle 커넥션 풀
+
+```js
+const { initPool, withConnection, closePool } = require('./db');
+
+// 앱 기동 시 한 번만 호출
+await initPool();
+
+// 쿼리 실행 — 커넥션 획득·반납 자동 처리
+const result = await withConnection((conn) =>
+  conn.execute('SELECT * FROM MY_TABLE WHERE ID = :id', { id: 1 })
+);
+
+// 앱 종료 시 호출
+await closePool();
+```
+
+### `utils/cardBrand.js` — 브랜드 식별 + 마스킹
+
+```js
+const { detectBrand, maskCardNumber } = require('./utils/cardBrand');
+
+detectBrand('4111111111111111')   // → 'VISA'
+detectBrand('5500000000000004')   // → 'Mastercard'
+maskCardNumber('4111111111111111') // → '4111-11**-****-1111'
+```
+
+---
+
+## 에러 응답 형식
+
+모든 API 에러는 아래 형식으로 반환됩니다.
+
+| 상태 코드 | 상황 |
+|-----------|------|
+| 400 | 요청 파라미터 누락 |
+| 401 | 토큰 없음 또는 만료 |
+| 403 | 비활성 계정 |
+| 500 | DB 오류 등 서버 내부 오류 |
+
+```json
+{ "error": "에러 메시지" }
+```

--- a/demo/backend/db.js
+++ b/demo/backend/db.js
@@ -1,0 +1,100 @@
+/**
+ * @file db.js
+ * @description Oracle DB 커넥션 풀 관리 모듈
+ *
+ * Thick Mode 사용 — Oracle Instant Client가 필요합니다.
+ *   이유: 접속 대상 Oracle 서버가 11g(XE)로, Thin Mode 는 Oracle 12.1 이상만 지원합니다.
+ *
+ * .env 에 ORACLE_CLIENT_PATH 를 설정하면 해당 경로의 Instant Client 를 사용합니다.
+ * ORACLE_CLIENT_PATH 가 없으면 시스템 PATH 에서 자동 탐색합니다.
+ *
+ * 사용 흐름:
+ *   1. 앱 기동 시 initPool() 한 번 호출
+ *   2. 쿼리가 필요한 곳에서 withConnection(fn) 을 사용하면
+ *      커넥션 획득 → 쿼리 실행 → 자동 반납까지 처리됩니다.
+ */
+
+'use strict';
+
+const oracledb = require('oracledb');
+
+// ── Thick Mode 초기화 ────────────────────────────────────────────────────────
+// initOracleClient() 는 require() 직후, 다른 oracledb 호출보다 먼저 실행해야 합니다.
+const clientOpts = {};
+if (process.env.ORACLE_CLIENT_PATH) {
+  clientOpts.libDir = process.env.ORACLE_CLIENT_PATH;
+}
+oracledb.initOracleClient(clientOpts);
+console.log('[DB] Thick Mode 초기화 완료 (Oracle Client 경로:', clientOpts.libDir || 'PATH 자동탐색', ')');
+
+// ── 전역 출력 형식 설정 ──────────────────────────────────────────────────────
+
+// DATE/TIMESTAMP → JSON 직렬화 시 타임존 문제를 피하기 위해 문자열로 수신
+oracledb.fetchTypeHandler = function (metadata) {
+  if (metadata.dbType === oracledb.DB_TYPE_DATE ||
+      metadata.dbType === oracledb.DB_TYPE_TIMESTAMP) {
+    return { type: oracledb.STRING, converter: (v) => (v ? String(v) : null) };
+  }
+};
+
+// 결과를 컬럼명 키의 오브젝트 배열로 반환 (기본값 ARRAY 대신)
+oracledb.outFormat = oracledb.OUT_FORMAT_OBJECT;
+
+// ── 풀 싱글톤 ────────────────────────────────────────────────────────────────
+/** @type {oracledb.Pool | null} */
+let _pool = null;
+
+/**
+ * 커넥션 풀을 생성합니다. 앱 기동 시 딱 한 번 호출하세요.
+ *
+ * @returns {Promise<oracledb.Pool>}
+ */
+async function initPool() {
+  if (_pool) return _pool;
+
+  _pool = await oracledb.createPool({
+    user:          process.env.DB_USER,
+    password:      process.env.DB_PASSWORD,
+    connectString: process.env.DB_CONNECT_STRING,
+
+    poolMin:       Number(process.env.DB_POOL_MIN)       || 2,
+    poolMax:       Number(process.env.DB_POOL_MAX)       || 10,
+    poolIncrement: Number(process.env.DB_POOL_INCREMENT) || 1,
+    poolTimeout:   60,
+    enableStatistics: false,
+  });
+
+  console.log('[DB] Oracle 커넥션 풀 생성 완료');
+  return _pool;
+}
+
+/**
+ * 커넥션을 풀에서 빌려 callback(conn) 을 실행하고, 완료 후 자동 반납합니다.
+ *
+ * @template T
+ * @param {(conn: oracledb.Connection) => Promise<T>} callback
+ * @returns {Promise<T>}
+ */
+async function withConnection(callback) {
+  if (!_pool) throw new Error('[DB] 풀이 초기화되지 않았습니다. initPool() 을 먼저 호출하세요.');
+
+  const conn = await _pool.getConnection();
+  try {
+    return await callback(conn);
+  } finally {
+    await conn.close();
+  }
+}
+
+/**
+ * 앱 종료 시 풀을 정상 해제합니다.
+ */
+async function closePool() {
+  if (_pool) {
+    await _pool.close(10);
+    _pool = null;
+    console.log('[DB] Oracle 커넥션 풀 종료 완료');
+  }
+}
+
+module.exports = { initPool, withConnection, closePool };

--- a/demo/backend/package-lock.json
+++ b/demo/backend/package-lock.json
@@ -1,0 +1,1417 @@
+{
+  "name": "hnc-demo-backend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hnc-demo-backend",
+      "version": "1.0.0",
+      "dependencies": {
+        "cors": "^2.8.5",
+        "dotenv": "^16.4.5",
+        "express": "^4.18.3",
+        "jsonwebtoken": "^9.0.3",
+        "morgan": "^1.10.1",
+        "oracledb": "^6.10.0"
+      },
+      "devDependencies": {
+        "nodemon": "^3.1.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/morgan": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
+      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/morgan/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemon": {
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
+      "integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^10.2.1",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nodemon/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/oracledb": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/oracledb/-/oracledb-6.10.0.tgz",
+      "integrity": "sha512-kGUumXmrEWbSpBuKJyb9Ip3rXcNgKK6grunI3/cLPzrRvboZ6ZoLi9JQ+z6M/RIG924tY8BLflihL4CKKQAYMA==",
+      "hasInstallScript": true,
+      "license": "(Apache-2.0 OR UPL-1.0)",
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/demo/backend/package.json
+++ b/demo/backend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "hnc-demo-backend",
+  "version": "1.0.0",
+  "description": "HNC Demo Backend - Oracle DB 연동 Express 서버",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.18.3",
+    "jsonwebtoken": "^9.0.3",
+    "morgan": "^1.10.1",
+    "oracledb": "^6.10.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.0"
+  }
+}

--- a/demo/backend/server.js
+++ b/demo/backend/server.js
@@ -1,0 +1,712 @@
+/**
+ * @file server.js
+ * @description Express 서버 진입점 + 카드 관련 API 엔드포인트
+ *
+ * API 목록
+ *   GET  /api/cards               카드 목록 (슬라이더·드롭다운용)
+ *   GET  /api/cards/:cardId/transactions  카드별 이용내역
+ *
+ * DB ↔ 프론트 매핑 규칙 (이 파일 하단 mapper 함수 참고)
+ *   Oracle 컬럼명(UPPER_SNAKE)  →  React 프롭(camelCase)
+ */
+
+"use strict";
+
+require("dotenv").config();
+
+const express = require("express");
+const cors = require("cors");
+const { apiLogger } = require("./utils/logger");
+const jwt = require("jsonwebtoken");
+const { initPool, withConnection, closePool } = require("./db");
+const { detectBrand, maskCardNumber } = require("./utils/cardBrand");
+
+const JWT_SECRET = process.env.JWT_SECRET || "dev-secret";
+const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "8h";
+
+/** 보호 라우트에 적용할 JWT 검증 미들웨어 */
+function verifyToken(req, res, next) {
+  const auth = req.headers.authorization;
+  if (!auth?.startsWith("Bearer ")) {
+    return res.status(401).json({ error: "인증이 필요합니다." });
+  }
+  try {
+    req.user = jwt.verify(auth.slice(7), JWT_SECRET);
+    next();
+  } catch {
+    return res
+      .status(401)
+      .json({ error: "토큰이 만료되었거나 유효하지 않습니다." });
+  }
+}
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+// ── 미들웨어 ─────────────────────────────────────────────────────────────────
+
+app.use(
+  cors({
+    origin: (origin, cb) => {
+      // 서버 간 호출(origin 없음) 또는 localhost 계열은 허용
+      if (!origin || /^https?:\/\/localhost(:\d+)?$/.test(origin))
+        return cb(null, true);
+      cb(new Error(`CORS blocked: ${origin}`));
+    },
+  }),
+);
+app.use(express.json());
+app.use(apiLogger);
+
+// ── 개발용: D_SPIDERLINK의 POC_ 테이블 목록 및 컬럼 확인 ────────────────────
+app.get("/api/dev/raw", async (_req, res) => {
+  try {
+    const result = await withConnection((conn) =>
+      conn.execute(
+        `SELECT "이용자", "이용일자", "승인시각", "결제예정일"
+           FROM D_SPIDERLINK.POC_카드사용내역
+          WHERE ROWNUM <= 5`,
+      ),
+    );
+    res.json({ rows: result.rows });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get("/api/dev/tables", async (_req, res) => {
+  try {
+    const result = await withConnection((conn) =>
+      conn.execute(
+        `SELECT TABLE_NAME FROM ALL_TABLES
+          WHERE OWNER = 'D_SPIDERLINK'
+            AND TABLE_NAME LIKE 'POC%'
+          ORDER BY TABLE_NAME`,
+      ),
+    );
+    res.json({ tables: (result.rows || []).map((r) => r.TABLE_NAME) });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get("/api/dev/columns/:tbl", async (req, res) => {
+  try {
+    const tbl = req.params.tbl.toUpperCase();
+    const result = await withConnection((conn) =>
+      conn.execute(
+        `SELECT COLUMN_NAME, DATA_TYPE
+           FROM ALL_TAB_COLUMNS
+          WHERE OWNER = 'D_SPIDERLINK'
+            AND TABLE_NAME = '${tbl}'
+          ORDER BY COLUMN_ID`,
+      ),
+    );
+    res.json({ table: tbl, columns: result.rows });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ── 인증 ─────────────────────────────────────────────────────────────────────
+
+/**
+ * POST /api/auth/login
+ * Body: { userId: string, password: string }
+ * - LOG_YN = 'N' 계정은 비활성 처리
+ * - 성공 시 LAST_LOGIN_DTIME 업데이트
+ */
+app.post("/api/auth/login", async (req, res) => {
+  const { userId, password } = req.body ?? {};
+
+  if (!userId || !password) {
+    return res
+      .status(400)
+      .json({ success: false, message: "아이디와 비밀번호를 입력하세요." });
+  }
+
+  try {
+    const result = await withConnection(async (conn) => {
+      return conn.execute(
+        `SELECT USER_ID, USER_NAME, USER_GRADE, LOG_YN
+           FROM D_SPIDERLINK.POC_USER
+          WHERE USER_ID = :userId AND PASSWORD = :password`,
+        { userId, password },
+      );
+    });
+
+    const row = result.rows?.[0];
+
+    if (!row) {
+      return res.status(401).json({
+        success: false,
+        message: "아이디 또는 비밀번호가 틀렸습니다.",
+      });
+    }
+
+    if (row.LOG_YN !== "Y") {
+      return res.status(403).json({
+        success: false,
+        message: "사용이 정지된 계정입니다. 관리자에게 문의하세요.",
+      });
+    }
+
+    // 마지막 로그인 시각 업데이트 (실패해도 로그인은 허용)
+    withConnection((conn) =>
+      conn.execute(
+        `UPDATE D_SPIDERLINK.POC_USER
+          SET LAST_LOGIN_DTIME = TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS')
+        WHERE USER_ID = :userId`,
+        { userId },
+        { autoCommit: true },
+      ),
+    ).catch((e) =>
+      console.warn("[login] LAST_LOGIN_DTIME 업데이트 실패:", e.message),
+    );
+
+    const token = jwt.sign(
+      {
+        userId: row.USER_ID,
+        userName: row.USER_NAME,
+        userGrade: row.USER_GRADE,
+      },
+      JWT_SECRET,
+      { expiresIn: JWT_EXPIRES_IN },
+    );
+
+    return res.json({
+      success: true,
+      token,
+      userId: row.USER_ID,
+      userName: row.USER_NAME,
+      userGrade: row.USER_GRADE,
+    });
+  } catch (err) {
+    console.error("[POST /api/auth/login]", err);
+    return res
+      .status(500)
+      .json({ success: false, message: "서버 오류가 발생했습니다." });
+  }
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// Mapper: DB 로우(row) → 프론트 JSON
+//
+// Oracle 테이블 컬럼명과 React 타입 필드명이 다를 때
+// 이 함수들이 그 간극을 메웁니다.
+// DB 컬럼명이 바뀌어도 mapper 만 수정하면 프론트 인터페이스는 그대로 유지됩니다.
+// ════════════════════════════════════════════════════════════════════════════
+
+/**
+ * TB_CARD_INFO 로우 → 프론트 Card 객체
+ *
+ * DB 컬럼 예시:
+ *   CARD_ID       VARCHAR2(20)   PK
+ *   CARD_NM       VARCHAR2(100)  카드 한글명
+ *   CARD_EN_NM    VARCHAR2(100)  카드 영문명
+ *   CARD_BRAND_CD VARCHAR2(10)   브랜드 코드 (VISA / MC)
+ *   CARD_MASK_NO  VARCHAR2(30)   마스킹 카드번호
+ *   ACNT_BAL_AMT  NUMBER(15)     연결계좌 잔액
+ *   USE_YN        CHAR(1)        사용여부
+ *
+ * @param {object} row - oracledb OUT_FORMAT_OBJECT 로우
+ * @returns {object} 프론트 Card 타입
+ */
+// POC_카드리스트 row → 프론트 CardItem
+function mapCard(row) {
+  const cardNo = String(row["카드번호"] ?? "");
+  const limit = Number(row["한도금액"] ?? 0);
+  const used = Number(row["사용금액"] ?? 0);
+  return {
+    id: cardNo,
+    name: row["카드구분"] ?? "",
+    brand: detectBrand(cardNo),
+    maskedNumber: maskCardNumber(cardNo),
+    balance: limit - used,
+    // 카드 상세 정보
+    expiry: row["유효기간"] ?? "",
+    paymentBank: row["결제은행명"] ?? "",
+    paymentAccount: String(row["결제계좌"] ?? ""),
+    paymentDay: row["결제일"] ?? "",
+    limitAmount: limit,
+    usedAmount: used,
+  };
+}
+
+/**
+ * TB_CARD_TX 로우 → 프론트 Transaction 객체
+ *
+ * DB 컬럼 예시:
+ *   TX_ID         VARCHAR2(30)   PK
+ *   CARD_ID       VARCHAR2(20)   FK → TB_CARD_INFO
+ *   CARD_NM       VARCHAR2(100)  카드명 (조인 또는 중복 보관)
+ *   MERCHANT_NM   VARCHAR2(200)  가맹점명
+ *   TX_AMT        NUMBER(15,2)   거래금액 (취소는 음수)
+ *   TX_DT         VARCHAR2(10)   거래일 (YYYY.MM.DD)
+ *   PAY_TYPE_CD   VARCHAR2(20)   결제유형 코드
+ *   APRVL_NO      VARCHAR2(30)   승인번호
+ *   TX_STAT_CD    VARCHAR2(10)   거래상태 코드
+ *
+ * @param {object} row
+ * @returns {object} 프론트 Transaction 타입
+ */
+function mapTransaction(row) {
+  return {
+    id: row.TX_ID,
+    merchant: row.MERCHANT_NM,
+    amount: row.TX_AMT,
+    date: row.TX_DT,
+    // 코드값 → 화면 표시 레이블 변환
+    type: mapPayTypeCode(row.PAY_TYPE_CD),
+    approvalNumber: row.APRVL_NO,
+    status: mapTxStatCode(row.TX_STAT_CD),
+    cardName: row.CARD_NM,
+  };
+}
+
+/** 결제유형 코드 → 표시 문자열 */
+function mapPayTypeCode(code) {
+  const map = {
+    LUMP: "일시불",
+    INSTALL_03: "할부(3개월)",
+    INSTALL_06: "할부(6개월)",
+    INSTALL_12: "할부(12개월)",
+    CANCEL: "취소",
+  };
+  return map[code] ?? code;
+}
+
+/** 거래상태 코드 → 표시 문자열 */
+function mapTxStatCode(code) {
+  const map = {
+    APPROVED: "승인",
+    CONFIRMED: "결제확정",
+    CANCELLED: "취소",
+  };
+  return map[code] ?? code;
+}
+
+/**
+ * 날짜(YYYYMMDD) + 시각(HHmmss) → 'YYYY.MM.DD HH:mm'
+ * @param {string|null} date
+ * @param {string|null} time
+ */
+function formatDateTime(date, time) {
+  const d = String(date ?? "").replace(/\D/g, "");
+  const t = String(time ?? "").replace(/\D/g, "");
+  // YYYYMMDD(8자리) 또는 YYMMDD(6자리) 모두 처리
+  let datePart = d;
+  if (d.length === 8)       // YYYYMMDD
+    datePart = `${d.slice(0, 4)}.${d.slice(4, 6)}.${d.slice(6, 8)}`;
+  else if (d.length === 6)  // YYMMDD
+    datePart = `20${d.slice(0, 2)}.${d.slice(2, 4)}.${d.slice(4, 6)}`;
+  const timePart = t.length >= 4 ? `${t.slice(0, 2)}:${t.slice(2, 4)}` : "";
+  return timePart ? `${datePart} ${timePart}` : datePart;
+}
+
+/**
+ * 날짜 문자열(YYYYMMDD 또는 YYMMDD) → 'M월 D일' (paymentSummary.date 용)
+ * @param {string|null} raw
+ */
+function formatDateKo(raw) {
+  if (!raw) return "";
+  const s = String(raw).replace(/\D/g, "");
+  if (s.length === 8)  // YYYYMMDD
+    return `${Number(s.slice(4, 6))}월 ${Number(s.slice(6, 8))}일`;
+  if (s.length === 6)  // YYMMDD
+    return `${Number(s.slice(2, 4))}월 ${Number(s.slice(4, 6))}일`;
+  return String(raw);
+}
+
+/**
+ * POC_카드사용내역 로우 → 프론트 Transaction 객체
+ *
+ * DB 컬럼:
+ *   카드번호    VARCHAR2  카드번호 (ID 합성 키)
+ *   이용일자    VARCHAR2  거래일 (YYYYMMDD)
+ *   이용가맹점  VARCHAR2  가맹점명
+ *   이용금액    NUMBER    결제금액
+ *   할부개월    NUMBER    할부 개월 수 (0 또는 1 = 일시불)
+ *   승인여부    CHAR      Y=승인, N=취소
+ *   카드명      VARCHAR2  카드명
+ *   승인시각    VARCHAR2  승인 시각 (HHmmss)
+ *
+ * @param {object} row
+ * @param {number} idx  - 동일 카드+시각 중복 방지용 인덱스
+ */
+function mapUsageTransaction(row, idx) {
+  const approved = row["승인여부"] === "Y";
+  const installment = Number(row["할부개월"] ?? 0);
+  const type = !approved
+    ? "취소"
+    : installment > 1
+      ? `할부(${installment}개월)`
+      : "일시불";
+
+  return {
+    id: `${row["카드번호"]}-${row["이용일자"]}-${row["승인시각"]}-${idx}`,
+    merchant: row["이용가맹점"] ?? "",
+    amount: approved
+      ? Number(row["이용금액"] ?? 0)
+      : -Number(row["이용금액"] ?? 0), // 취소는 음수
+    date: formatDateTime(row["이용일자"], row["승인시각"]),
+    type,
+    approvalNumber: String(row["승인번호"] ?? ""),
+    status: approved ? "승인" : "취소",
+    cardName: row["카드명"] ?? "",
+  };
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// API 엔드포인트
+// ════════════════════════════════════════════════════════════════════════════
+
+/**
+ * GET /api/cards
+ * 로그인 사용자가 보유한 카드 목록을 반환합니다.
+ *
+ * Query Params:
+ *   userId  (선택) — 특정 사용자 카드만 조회. 없으면 전체 반환.
+ *
+ * Response 200:
+ *   {
+ *     cards: Array<{
+ *       id: string, name: string, cardEnName: string,
+ *       brand: 'VISA' | 'Mastercard', maskedNumber: string, balance: number
+ *     }>
+ *   }
+ */
+app.get("/api/cards", verifyToken, async (req, res) => {
+  try {
+    const userId = req.user.userId; // JWT에서 추출
+
+    const result = await withConnection((conn) =>
+      conn.execute(
+        `SELECT "카드번호", "카드구분", "유효기간", "결제은행명", "결제계좌", "결제일", "한도금액", "사용금액"
+           FROM D_SPIDERLINK.POC_카드리스트
+          WHERE "사용자아이디" = :userId
+          ORDER BY "결제순번" NULLS LAST`,
+        { userId },
+      ),
+    );
+
+    const cards = (result.rows || []).map(mapCard);
+    res.json({ cards });
+  } catch (err) {
+    console.error("[GET /api/cards]", err);
+    res.status(500).json({ error: "DB 조회 중 오류가 발생했습니다." });
+  }
+});
+
+/**
+ * 검색 기간(period) → { fromDate, toDate } YYYYMMDD 문자열 변환
+ *
+ * @param {string} period      - 'thisMonth' | '1month' | '3months' | 'custom'
+ * @param {string} customMonth - 'YYYY-MM' (period === 'custom' 일 때만 사용)
+ */
+function getDateRange(period, customMonth) {
+  const pad = (n) => String(n).padStart(2, "0");
+  const ymd = (d) =>
+    `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}`;
+  const now = new Date();
+
+  if (period === "thisMonth") {
+    const y = now.getFullYear(),
+      m = pad(now.getMonth() + 1);
+    return { fromDate: `${y}${m}01`, toDate: `${y}${m}31` };
+  }
+  if (period === "1month") {
+    const from = new Date(now);
+    from.setMonth(from.getMonth() - 1);
+    return { fromDate: ymd(from), toDate: ymd(now) };
+  }
+  if (period === "3months") {
+    const from = new Date(now);
+    from.setMonth(from.getMonth() - 3);
+    return { fromDate: ymd(from), toDate: ymd(now) };
+  }
+  if (period === "custom" && customMonth) {
+    const [y, m] = customMonth.split("-");
+    return { fromDate: `${y}${m}01`, toDate: `${y}${m}31` };
+  }
+  return { fromDate: null, toDate: null };
+}
+
+/**
+ * GET /api/transactions
+ * 로그인 사용자의 카드 이용내역을 반환합니다. (POC_카드사용내역)
+ *
+ * Query Params (모두 선택):
+ *   cardId      — 카드번호 필터. 없거나 'all' 이면 전체
+ *   period      — 'thisMonth' | '1month' | '3months' | 'custom'
+ *   customMonth — 'YYYY-MM' (period=custom 일 때)
+ *   usageType   — 'lump' | 'installment' | 'cancel' (없거나 'all' 이면 전체)
+ *
+ * Response 200:
+ *   { transactions, totalCount, paymentSummary: { date, totalAmount } }
+ */
+app.get("/api/transactions", verifyToken, async (req, res) => {
+  try {
+    const userId = req.user.userId;
+    const { cardId, period, customMonth, usageType } = req.query;
+
+    // ── 날짜 범위 계산 ────────────────────────────────────────────
+    const { fromDate, toDate } = getDateRange(period, customMonth);
+
+    // ── 동적 WHERE 절 구성 ───────────────────────────────────────
+    let sql = `
+      SELECT "카드번호", "이용일자", "이용가맹점", "이용금액",
+             "할부개월", "승인여부", "카드명", "승인시각", "결제예정일", "승인번호"
+        FROM D_SPIDERLINK.POC_카드사용내역
+       WHERE "이용자" = :userId`;
+    const binds = { userId };
+
+    if (cardId && cardId !== "all") {
+      sql += ` AND "카드번호" = :cardId`;
+      binds.cardId = cardId;
+    }
+    if (fromDate) {
+      sql += ` AND "이용일자" >= :fromDate`;
+      binds.fromDate = fromDate;
+    }
+    if (toDate) {
+      sql += ` AND "이용일자" <= :toDate`;
+      binds.toDate = toDate;
+    }
+    if (usageType === "lump") {
+      sql += ` AND "할부개월" <= 1 AND "승인여부" = 'Y'`;
+    } else if (usageType === "installment") {
+      sql += ` AND "할부개월" > 1 AND "승인여부" = 'Y'`;
+    } else if (usageType === "cancel") {
+      sql += ` AND "승인여부" = 'N'`;
+    }
+
+    sql += ` ORDER BY "이용일자" DESC, "승인시각" DESC`;
+
+    const result = await withConnection((conn) => conn.execute(sql, binds));
+    const rows = result.rows || [];
+    const transactions = rows.map(mapUsageTransaction);
+
+    const upcomingDate = rows
+      .map((r) => r["결제예정일"])
+      .filter(Boolean)
+      .sort()[0];
+    const totalAmount = transactions
+      .filter((t) => t.status === "승인")
+      .reduce((sum, t) => sum + t.amount, 0);
+
+    res.json({
+      transactions,
+      totalCount: transactions.length,
+      paymentSummary: { date: formatDateKo(upcomingDate), totalAmount },
+    });
+  } catch (err) {
+    console.error("[GET /api/transactions]", err);
+    res.status(500).json({ error: "DB 조회 중 오류가 발생했습니다." });
+  }
+});
+
+/**
+ * GET /api/payment-statement
+ * 결제예정금액 / 이용대금명세서 탭 데이터를 반환합니다.
+ *
+ * Response 200:
+ *   {
+ *     dueDate: string,          // YYMMDD (결제예정일)
+ *     totalAmount: number,      // 승인 건 이용금액 합계
+ *     items: [{ cardNo, cardName, amount }],
+ *     cardInfo: { paymentBank, paymentAccount, paymentDay }
+ *   }
+ */
+app.get("/api/payment-statement", verifyToken, async (req, res) => {
+  try {
+    const userId = req.user.userId;
+
+    const [txResult, cardResult] = await withConnection((conn) =>
+      Promise.all([
+        // 승인된 거래만 카드별 집계
+        conn.execute(
+          `SELECT "카드번호", "카드명", "이용금액", "결제예정일"
+             FROM D_SPIDERLINK.POC_카드사용내역
+            WHERE "이용자" = :userId AND "승인여부" = 'Y'`,
+          { userId },
+        ),
+        // 첫 번째 카드의 결제정보 (infoSections 용)
+        conn.execute(
+          `SELECT "결제은행명", "결제계좌", "결제일"
+             FROM D_SPIDERLINK.POC_카드리스트
+            WHERE "사용자아이디" = :userId
+              AND ROWNUM = 1
+            ORDER BY "결제순번" NULLS LAST`,
+          { userId },
+        ),
+      ]),
+    );
+
+    const txRows   = txResult.rows   || [];
+    const cardRows = cardResult.rows  || [];
+
+    // ── 가장 많이 등장하는 결제예정일 ──────────────────────────
+    const dueDateCount = {};
+    txRows.forEach((r) => {
+      const d = r["결제예정일"];
+      if (d) dueDateCount[d] = (dueDateCount[d] || 0) + 1;
+    });
+    const dueDate =
+      Object.entries(dueDateCount).sort((a, b) => b[1] - a[1])[0]?.[0] ?? "";
+
+    // ── 카드+결제예정일 조합별 이용금액 합계 (결제일이 다를 수 있음) ──
+    const cardMap = {};
+    txRows.forEach((r) => {
+      const key = `${r["카드번호"]}_${r["결제예정일"] ?? ""}`;
+      if (!cardMap[key])
+        cardMap[key] = { cardNo: r["카드번호"], cardName: r["카드명"] ?? "", amount: 0, dueDate: r["결제예정일"] ?? "" };
+      cardMap[key].amount += Number(r["이용금액"] ?? 0);
+    });
+    const items       = Object.values(cardMap);
+    const totalAmount = items.reduce((sum, item) => sum + item.amount, 0);
+
+    // ── 결제정보 (첫 번째 카드 기준) ──────────────────────────
+    const ci = cardRows[0];
+    const cardInfo = ci
+      ? {
+          paymentBank:    ci["결제은행명"] ?? "",
+          paymentAccount: String(ci["결제계좌"] ?? ""),
+          paymentDay:     ci["결제일"] ?? "",
+        }
+      : null;
+
+    res.json({ dueDate, totalAmount, items, cardInfo });
+  } catch (err) {
+    console.error("[GET /api/payment-statement]", err);
+    res.status(500).json({ error: "DB 조회 중 오류가 발생했습니다." });
+  }
+});
+
+/**
+ * GET /api/cards/:cardId/transactions
+ * 특정 카드의 이용내역을 페이징하여 반환합니다.
+ *
+ * Path Params:
+ *   cardId — 카드 ID
+ *
+ * Query Params:
+ *   page     (기본 1)   — 페이지 번호 (1-based)
+ *   pageSize (기본 20)  — 페이지 당 건수
+ *   fromDate (선택)     — 조회 시작일 YYYYMMDD
+ *   toDate   (선택)     — 조회 종료일 YYYYMMDD
+ *
+ * Response 200:
+ *   {
+ *     transactions: Transaction[],
+ *     totalCount: number,
+ *     page: number,
+ *     pageSize: number
+ *   }
+ */
+app.get("/api/cards/:cardId/transactions", verifyToken, async (req, res) => {
+  try {
+    const { cardId } = req.params;
+    const page = Math.max(1, Number(req.query.page) || 1);
+    const pageSize = Math.min(100, Number(req.query.pageSize) || 20);
+    const { fromDate, toDate } = req.query;
+
+    const offset = (page - 1) * pageSize;
+
+    const result = await withConnection(async (conn) => {
+      // ── 전체 건수 ──────────────────────────────────────────────────
+      let countSql = `
+        SELECT COUNT(*) AS TOTAL_CNT
+        FROM TB_CARD_TX
+        WHERE CARD_ID = :cardId
+      `;
+      const binds = { cardId };
+
+      if (fromDate) {
+        countSql += " AND TX_DT >= :fromDate";
+        binds.fromDate = fromDate;
+      }
+      if (toDate) {
+        countSql += " AND TX_DT <= :toDate";
+        binds.toDate = toDate;
+      }
+
+      const countRes = await conn.execute(countSql, binds);
+      const totalCount = countRes.rows[0]?.TOTAL_CNT ?? 0;
+
+      // ── 페이징 데이터 ──────────────────────────────────────────────
+      // Oracle 12c+ OFFSET/FETCH 문법 사용
+      let dataSql = `
+        SELECT
+          TX_ID,
+          CARD_NM,
+          MERCHANT_NM,
+          TX_AMT,
+          TX_DT,
+          PAY_TYPE_CD,
+          APRVL_NO,
+          TX_STAT_CD
+        FROM TB_CARD_TX
+        WHERE CARD_ID = :cardId
+      `;
+
+      if (fromDate) {
+        dataSql += " AND TX_DT >= :fromDate";
+      }
+      if (toDate) {
+        dataSql += " AND TX_DT <= :toDate";
+      }
+
+      dataSql += `
+        ORDER BY TX_DT DESC, TX_ID DESC
+        OFFSET :offset ROWS FETCH NEXT :pageSize ROWS ONLY
+      `;
+      binds.offset = offset;
+      binds.pageSize = pageSize;
+
+      const dataRes = await conn.execute(dataSql, binds);
+
+      return { rows: dataRes.rows, totalCount };
+    });
+
+    res.json({
+      transactions: (result.rows || []).map(mapTransaction),
+      totalCount: result.totalCount,
+      page,
+      pageSize,
+    });
+  } catch (err) {
+    console.error("[GET /api/cards/:cardId/transactions]", err);
+    res.status(500).json({ error: "DB 조회 중 오류가 발생했습니다." });
+  }
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 서버 기동 — DB 풀이 준비된 후에만 listen
+// ════════════════════════════════════════════════════════════════════════════
+
+async function start() {
+  try {
+    await initPool(); // ① 커넥션 풀 먼저 생성
+
+    app.listen(PORT, () => {
+      // ② 풀 준비 완료 후 서버 오픈
+      console.log(`[Server] http://localhost:${PORT} 에서 실행 중`);
+    });
+  } catch (err) {
+    console.error("[Server] 기동 실패:", err);
+    process.exit(1);
+  }
+}
+
+// ── 정상 종료 훅 ─────────────────────────────────────────────────────────────
+async function shutdown(signal) {
+  console.log(`\n[Server] ${signal} 수신 — 정상 종료 시작`);
+  await closePool();
+  process.exit(0);
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));
+
+start();

--- a/demo/backend/utils/cardBrand.js
+++ b/demo/backend/utils/cardBrand.js
@@ -1,0 +1,109 @@
+'use strict';
+
+/**
+ * @file utils/cardBrand.js
+ * @description 카드번호(IIN/BIN) 기반 브랜드 식별 유틸리티
+ *
+ * 숫자만 추출 후 앞자리 패턴을 순서대로 검사합니다.
+ * 범위가 좁은(더 구체적인) 규칙을 먼저 배치해야 오판을 막을 수 있습니다.
+ */
+
+/** 지원 브랜드 상수 */
+// 값을 프론트 CardBrand 타입과 일치시킵니다: 'VISA' | 'Mastercard' | 'AMEX' | 'JCB' | 'UnionPay'
+const BRAND = Object.freeze({
+  VISA:       'VISA',
+  MASTERCARD: 'Mastercard',
+  AMEX:       'AMEX',
+  DISCOVER:   'Discover',   // CardBrand 외 — 프론트에서 Unknown 처리
+  JCB:        'JCB',
+  UNIONPAY:   'UnionPay',
+  DINERS:     'Diners Club', // CardBrand 외 — 프론트에서 Unknown 처리
+  UNKNOWN:    'Unknown',
+});
+
+/**
+ * 카드번호에서 브랜드를 식별합니다.
+ *
+ * @param {string|number} cardNumber - 카드번호 (하이픈·공백 포함 가능)
+ * @returns {string} BRAND 상수 중 하나
+ *
+ * @example
+ * detectBrand('4111-1111-1111-1111') // 'Visa'
+ * detectBrand('5500000000000004')     // 'Mastercard'
+ * detectBrand('378282246310005')      // 'Amex'
+ */
+function detectBrand(cardNumber) {
+  // 숫자만 추출
+  const num = String(cardNumber).replace(/\D/g, '');
+  if (!num) return BRAND.UNKNOWN;
+
+  const len = num.length;
+
+  // ── Amex (15자리, 34/37 시작) ────────────────────────────────────────────
+  if (/^3[47]/.test(num) && len === 15) return BRAND.AMEX;
+
+  // ── Diners Club (14자리) ─────────────────────────────────────────────────
+  if (/^30[0-5]/.test(num) && len === 14) return BRAND.DINERS;
+  if (/^3[68]/.test(num)   && len === 14) return BRAND.DINERS;
+
+  // ── JCB (16자리, 3528–3589) ──────────────────────────────────────────────
+  if (len === 16) {
+    const prefix4 = parseInt(num.slice(0, 4), 10);
+    if (prefix4 >= 3528 && prefix4 <= 3589) return BRAND.JCB;
+  }
+
+  // ── Discover ─────────────────────────────────────────────────────────────
+  if (/^6011/.test(num)) return BRAND.DISCOVER;
+  if (/^65/.test(num))   return BRAND.DISCOVER;
+  if (/^64[4-9]/.test(num)) return BRAND.DISCOVER;
+  // China UnionPay 와 겹치는 622126–622925 범위 → Discover 우선
+  if (len >= 6) {
+    const prefix6 = parseInt(num.slice(0, 6), 10);
+    if (prefix6 >= 622126 && prefix6 <= 622925) return BRAND.DISCOVER;
+  }
+
+  // ── UnionPay (62 시작, Discover 범위 제외 후) ────────────────────────────
+  if (/^62/.test(num)) return BRAND.UNIONPAY;
+
+  // ── Mastercard ───────────────────────────────────────────────────────────
+  // 전통 범위: 51–55
+  if (/^5[1-5]/.test(num) && len === 16) return BRAND.MASTERCARD;
+  // 신규 범위: 2221–2720
+  if (len >= 4) {
+    const prefix4 = parseInt(num.slice(0, 4), 10);
+    if (prefix4 >= 2221 && prefix4 <= 2720 && len === 16) return BRAND.MASTERCARD;
+  }
+
+  // ── Visa (4 시작, 13/16/19자리) ──────────────────────────────────────────
+  if (/^4/.test(num) && [13, 16, 19].includes(len)) return BRAND.VISA;
+
+  return BRAND.UNKNOWN;
+}
+
+/**
+ * 카드번호를 마스킹합니다.
+ * Amex(15자리)는 4-6-5, 그 외는 4-4-4-4 포맷을 따릅니다.
+ *
+ * @param {string|number} cardNumber
+ * @returns {string} 예) '4111-11**-****-1111'
+ */
+function maskCardNumber(cardNumber) {
+  const num = String(cardNumber).replace(/\D/g, '');
+  if (!num) return '';
+
+  if (num.length === 15) {
+    // Amex: XXXX-XXXXXX-XXXXX → 앞 4 + 중간 2자리 노출, 나머지 마스킹, 뒤 4 노출
+    return `${num.slice(0, 4)}-${num.slice(4, 6)}****-*${num.slice(11)}`;
+  }
+
+  // 16자리 기준 4-4-4-4
+  const padded = num.padEnd(16, '0');
+  return [
+    padded.slice(0, 4),
+    padded.slice(4, 6) + '**',
+    '****',
+    padded.slice(12, 16),
+  ].join('-');
+}
+
+module.exports = { detectBrand, maskCardNumber, BRAND };

--- a/demo/backend/utils/logger.js
+++ b/demo/backend/utils/logger.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const C = {
+  reset:  '\x1b[0m',  bold: '\x1b[1m',   dim:  '\x1b[2m',
+  cyan:   '\x1b[36m', green:'\x1b[32m',  yellow:'\x1b[33m',
+  red:    '\x1b[31m', blue: '\x1b[34m',  gray:  '\x1b[90m', white:'\x1b[37m',
+};
+
+const METHOD_COLOR = { GET: C.cyan, POST: C.yellow, PUT: C.blue, DELETE: C.red, PATCH: C.blue };
+
+function statusColor(c) { return c >= 500 ? C.red : c >= 400 ? C.yellow : C.green; }
+
+function timestamp() {
+  return new Date().toLocaleString('ko-KR', {
+    year:'numeric', month:'2-digit', day:'2-digit',
+    hour:'2-digit', minute:'2-digit', second:'2-digit', hour12: false,
+  });
+}
+
+function apiLogger(req, res, next) {
+  const start = Date.now();
+  const originalJson = res.json.bind(res);
+  res.json = (body) => { res._logBody = body; return originalJson(body); };
+
+  res.on('finish', () => {
+    const ms = Date.now() - start;
+    const mc = METHOD_COLOR[req.method] ?? C.white;
+    const sc = statusColor(res.statusCode);
+    const inJson  = req.body && Object.keys(req.body).length ? JSON.stringify(req.body) : null;
+    const outJson = res._logBody !== undefined ? JSON.stringify(res._logBody) : null;
+
+    const parts = [
+      `${C.gray}[${timestamp()}]${C.reset}`,
+      `${mc}${C.bold}${req.method}${C.reset}`,
+      `${C.white}${req.originalUrl}${C.reset}`,
+      `${sc}${C.bold}${res.statusCode}${C.reset}`,
+      `${C.gray}${ms}ms${C.reset}`,
+    ];
+    if (inJson)  parts.push(`${C.cyan}▶${C.reset} ${C.dim}${inJson}${C.reset}`);
+    if (outJson) parts.push(`${sc}◀${C.reset} ${C.dim}${outJson}${C.reset}`);
+
+    console.log(parts.join('  '));
+  });
+
+  next();
+}
+
+module.exports = { apiLogger };

--- a/demo/front/src/App.tsx
+++ b/demo/front/src/App.tsx
@@ -1,6 +1,8 @@
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { pageRoutes, modalRoutes } from '@/routes'
+import { AuthProvider, useAuth } from '@/contexts/AuthContext'
+import { PATHS } from '@/constants/paths'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -22,12 +24,17 @@ const queryClient = new QueryClient({
  * 새 모달이 필요하면 routes.tsx 의 modalRoutes 에만 추가하면 된다.
  */
 function AppRoutes() {
-  const location = useLocation()
+  const location   = useLocation()
   const background = (location.state as { background?: Location })?.background
+  const { isLoggedIn } = useAuth()
+
+  // 로그인 안 된 상태에서 로그인 페이지 외 접근 시 리다이렉트
+  if (!isLoggedIn && location.pathname !== PATHS.LOGIN) {
+    return <Navigate to={PATHS.LOGIN} replace />
+  }
 
   return (
     <>
-      {/* 일반 페이지 라우트 — 모달 열린 동안에는 background 위치로 고정 */}
       <Routes location={background ?? location}>
         <Route path="/" element={<Navigate to="/login" replace />} />
         {pageRoutes.map(({ path, element }) => (
@@ -35,7 +42,6 @@ function AppRoutes() {
         ))}
       </Routes>
 
-      {/* 모달 라우트 — background 가 있을 때만 렌더링 */}
       {background && (
         <Routes>
           {modalRoutes.map(({ path, element }) => (
@@ -50,9 +56,11 @@ function AppRoutes() {
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <AppRoutes />
-      </BrowserRouter>
+      <AuthProvider>
+        <BrowserRouter>
+          <AppRoutes />
+        </BrowserRouter>
+      </AuthProvider>
     </QueryClientProvider>
   )
 }

--- a/demo/front/src/contexts/AuthContext.tsx
+++ b/demo/front/src/contexts/AuthContext.tsx
@@ -1,0 +1,77 @@
+/**
+ * @file AuthContext.tsx
+ * @description 로그인 상태 전역 관리
+ *
+ * - 로그인 정보(userId, userName, userGrade, token)를 localStorage에 저장해
+ *   새로고침 후에도 세션이 유지됩니다.
+ * - useAuth() 훅으로 어느 컴포넌트에서든 로그인 상태를 읽고 login/logout을 호출합니다.
+ */
+import { createContext, useContext, useState, type ReactNode } from 'react';
+
+const STORAGE_KEY = 'hnc_auth';
+
+export interface AuthUser {
+  userId:    string;
+  userName:  string;
+  userGrade: string;
+  token:     string;
+}
+
+interface AuthContextValue {
+  user:          AuthUser | null;
+  isLoggedIn:    boolean;
+  login:         (user: AuthUser) => void;
+  logout:        () => void;
+  /** Authorization 헤더를 자동 첨부하고, 401 시 alert + 로그아웃 처리 */
+  fetchWithAuth: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+function readStorage(): AuthUser | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as AuthUser) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(readStorage);
+
+  const login = (user: AuthUser) => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(user));
+    setUser(user);
+  };
+
+  const logout = () => {
+    localStorage.removeItem(STORAGE_KEY);
+    setUser(null);
+  };
+
+  const fetchWithAuth = async (input: RequestInfo, init: RequestInit = {}): Promise<Response> => {
+    const token = (JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null') as AuthUser | null)?.token;
+    const res = await fetch(input, {
+      ...init,
+      headers: { ...init.headers, ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+    });
+    if (res.status === 401) {
+      alert('세션이 만료되었습니다. 다시 로그인해 주세요.');
+      logout();
+    }
+    return res;
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, isLoggedIn: !!user, login, logout, fetchWithAuth }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth는 AuthProvider 내부에서만 사용할 수 있습니다.');
+  return ctx;
+}

--- a/demo/front/src/pages/card/CardDashboardPage/index.tsx
+++ b/demo/front/src/pages/card/CardDashboardPage/index.tsx
@@ -32,7 +32,7 @@
  * @param activeBottomTab  - 하단 탭바 활성 ID (기본: 'my')
  * @param onBottomNavChange - 하단 탭바 탭 변경 핸들러
  */
-import React, { useState } from 'react';
+import React, { useState } from "react";
 import {
   Bell,
   Menu,
@@ -53,59 +53,60 @@ import {
   ShoppingBag,
   PieChart,
   Building2,
-} from 'lucide-react';
+} from "lucide-react";
 
-import { HomePageLayout } from '@cl/layout/HomePageLayout';
-import { BottomNav } from '@cl/layout/BottomNav';
-import { Button } from '@cl/core/Button';
-import { SectionHeader } from '@cl/modules/common/SectionHeader';
-import { StatementHeroCard } from '@cl/biz/card/StatementHeroCard';
-import { LoanMenuBar } from '@cl/biz/card/LoanMenuBar';
-import { SummaryCard } from '@cl/biz/card/SummaryCard';
-import { QuickMenuGrid } from '@cl/biz/common/QuickMenuGrid';
-import { QuickShortcutCard } from '@cl/biz/card/QuickShortcutCard';
-import { BannerCarousel } from '@cl/biz/common/BannerCarousel';
-import { BalanceToggle } from '@cl/modules/common/BalanceToggle';
+import { HomePageLayout } from "@cl/layout/HomePageLayout";
+import { BottomNav } from "@cl/layout/BottomNav";
+import { Button } from "@cl/core/Button";
+import { SectionHeader } from "@cl/modules/common/SectionHeader";
+import { StatementHeroCard } from "@cl/biz/card/StatementHeroCard";
+import { LoanMenuBar } from "@cl/biz/card/LoanMenuBar";
+import { SummaryCard } from "@cl/biz/card/SummaryCard";
+import { QuickMenuGrid } from "@cl/biz/common/QuickMenuGrid";
+import { QuickShortcutCard } from "@cl/biz/card/QuickShortcutCard";
+import { BannerCarousel } from "@cl/biz/common/BannerCarousel";
+import { BalanceToggle } from "@cl/modules/common/BalanceToggle";
 
-import type { CardDashboardPageProps } from './types';
-import { cn } from '@lib/cn';
-import { Typography } from '@cl/core/Typography';
+import type { CardDashboardPageProps } from "./types";
+import { cn } from "@lib/cn";
+import { Typography } from "@cl/core/Typography";
 
 /** 하단 탭바 항목 정의 */
 const BOTTOM_NAV_ITEMS = (onBottomNavChange: (id: string) => void) => [
   {
-    id: 'my',
+    id: "my",
     icon: <User className="size-5" />,
-    label: '마이',
-    onClick: () => onBottomNavChange('my'),
+    label: "마이",
+    onClick: () => onBottomNavChange("my"),
   },
   {
-    id: 'benefit',
+    id: "benefit",
     icon: <Gift className="size-5" />,
-    label: '혜택/실적',
-    onClick: () => onBottomNavChange('benefit'),
+    label: "혜택/실적",
+    onClick: () => onBottomNavChange("benefit"),
   },
   {
-    id: 'payment',
+    id: "payment",
     icon: <Wallet className="size-5" />,
-    label: '결제',
-    onClick: () => onBottomNavChange('payment'),
+    label: "결제",
+    onClick: () => onBottomNavChange("payment"),
   },
   {
-    id: 'shopping',
+    id: "shopping",
     icon: <ShoppingBag className="size-5" />,
-    label: '쇼핑/여행',
-    onClick: () => onBottomNavChange('shopping'),
+    label: "쇼핑/여행",
+    onClick: () => onBottomNavChange("shopping"),
   },
   {
-    id: 'asset',
+    id: "asset",
     icon: <PieChart className="size-5" />,
-    label: '자산',
-    onClick: () => onBottomNavChange('asset'),
+    label: "자산",
+    onClick: () => onBottomNavChange("asset"),
   },
 ];
 
 export function CardDashboardPage({
+  userName,
   onNotification,
   onMenu,
   onStatementDetail,
@@ -132,7 +133,9 @@ export function CardDashboardPage({
   onBottomNavChange,
 }: CardDashboardPageProps) {
   /** Storybook 확인용 내부 상태 — 실제 앱에서는 Hook에서 관리 */
-  const [activeBottomTab, setActiveBottomTab] = useState(activeBottomTabProp ?? 'my');
+  const [activeBottomTab, setActiveBottomTab] = useState(
+    activeBottomTabProp ?? "my",
+  );
   /** 금액 숨김 여부 — 토글 버튼으로 대시보드 전체 금액을 일괄 마스킹 */
   const [amountHidden, setAmountHidden] = useState(false);
 
@@ -144,61 +147,61 @@ export function CardDashboardPage({
   /** QuickMenuGrid 항목 — iconShape="rounded"로 사각형 아이콘 */
   const quickMenuItems = [
     {
-      id: 'performance',
+      id: "performance",
       icon: <BarChart2 className="size-5" />,
-      label: '카드별 실적',
+      label: "카드별 실적",
       onClick: onCardPerformance,
-      iconShape: 'rounded' as const,
+      iconShape: "rounded" as const,
     },
     {
-      id: 'history',
+      id: "history",
       icon: <List className="size-5" />,
-      label: '이용내역',
+      label: "이용내역",
       onClick: onUsageHistory,
-      iconShape: 'rounded' as const,
+      iconShape: "rounded" as const,
     },
     {
-      id: 'my-cards',
+      id: "my-cards",
       icon: <CreditCard className="size-5" />,
-      label: '보유카드',
+      label: "보유카드",
       onClick: onMyCards,
-      iconShape: 'rounded' as const,
+      iconShape: "rounded" as const,
     },
     {
-      id: 'coupons',
+      id: "coupons",
       icon: <Ticket className="size-5" />,
-      label: '쿠폰함',
+      label: "쿠폰함",
       onClick: onCoupons,
-      iconShape: 'rounded' as const,
+      iconShape: "rounded" as const,
     },
     {
-      id: 'limit',
+      id: "limit",
       icon: <Gauge className="size-5" />,
-      label: '한도조회',
+      label: "한도조회",
       onClick: onLimitCheck,
-      iconShape: 'rounded' as const,
+      iconShape: "rounded" as const,
     },
     {
-      id: 'installment',
+      id: "installment",
       icon: <Percent className="size-5" />,
-      label: '무이자할부',
+      label: "무이자할부",
       onClick: onInstallment,
-      iconShape: 'rounded' as const,
+      iconShape: "rounded" as const,
     },
     {
-      id: 'apply',
+      id: "apply",
       icon: <Plus className="size-5" />,
-      label: '카드신청',
+      label: "카드신청",
       onClick: onCardApply,
-      iconShape: 'rounded' as const,
+      iconShape: "rounded" as const,
     },
   ];
 
   /** 헤더 아이콘 버튼 공통 스타일 */
   const iconBtnCls = cn(
-    'flex items-center justify-center size-9 rounded-full',
-    'text-text-muted hover:bg-surface-raised hover:text-text-heading',
-    'transition-colors duration-150',
+    "flex items-center justify-center size-9 rounded-full",
+    "text-text-muted hover:bg-surface-raised hover:text-text-heading",
+    "transition-colors duration-150",
   );
 
   return (
@@ -230,6 +233,15 @@ export function CardDashboardPage({
         }
         withBottomNav
       >
+        {/* ── 인사말 ────────────────────────────────────── */}
+        {userName && (
+          <div className="px-standard pt-standard">
+            <Typography variant="heading" color="heading">
+              안녕하세요, {userName} 님!
+            </Typography>
+          </div>
+        )}
+
         {/* ── 이번 달 명세서 히어로 카드 ────────────────── */}
         <div className="px-standard pt-standard">
           <StatementHeroCard
@@ -245,21 +257,21 @@ export function CardDashboardPage({
           <LoanMenuBar
             items={[
               {
-                id: 'short-loan',
+                id: "short-loan",
                 icon: <CreditCard size={14} />,
-                label: '단기카드대출(현금서비스)',
+                label: "단기카드대출(현금서비스)",
                 onClick: onShortLoan,
               },
               {
-                id: 'long-loan',
+                id: "long-loan",
                 icon: <Banknote size={14} />,
-                label: '장기카드대출(카드론)',
+                label: "장기카드대출(카드론)",
                 onClick: onLongLoan,
               },
               {
-                id: 'revolving',
+                id: "revolving",
                 icon: <RefreshCw size={14} />,
-                label: '일부결제금액이월약정(리볼빙)',
+                label: "일부결제금액이월약정(리볼빙)",
                 onClick: onRevolving,
               },
             ]}
@@ -275,9 +287,9 @@ export function CardDashboardPage({
             hidden={amountHidden}
             icon={<Building2 size={36} />}
             actions={[
-              { label: '내 계좌', onClick: onMyAccount ?? (() => {}) },
-              { label: '금융진단', onClick: onDiagnosis ?? (() => {}) },
-              { label: '보험진단', onClick: onInsuranceDiag ?? (() => {}) },
+              { label: "내 계좌", onClick: onMyAccount ?? (() => {}) },
+              { label: "금융진단", onClick: onDiagnosis ?? (() => {}) },
+              { label: "보험진단", onClick: onInsuranceDiag ?? (() => {}) },
             ]}
           />
         </div>
@@ -291,9 +303,13 @@ export function CardDashboardPage({
             hidden={amountHidden}
             icon={<Wallet size={32} />}
             actions={[
-              { label: '가계부', onClick: onHouseholdBook ?? (() => {}) },
-              { label: '소비브리핑', onClick: onSpendingBriefing ?? (() => {}), active: true },
-              { label: '고정지출', onClick: onFixedExpenses ?? (() => {}) },
+              { label: "가계부", onClick: onHouseholdBook ?? (() => {}) },
+              {
+                label: "소비브리핑",
+                onClick: onSpendingBriefing ?? (() => {}),
+                active: true,
+              },
+              { label: "고정지출", onClick: onFixedExpenses ?? (() => {}) },
             ]}
           />
         </div>
@@ -332,22 +348,22 @@ export function CardDashboardPage({
           <BannerCarousel
             items={[
               {
-                id: 'event-1',
-                variant: 'promo',
-                title: '카드 신규 발급 이벤트',
-                description: '첫 달 연회비 면제 + 캐시백 최대 3만원',
+                id: "event-1",
+                variant: "promo",
+                title: "카드 신규 발급 이벤트",
+                description: "첫 달 연회비 면제 + 캐시백 최대 3만원",
               },
               {
-                id: 'event-2',
-                variant: 'promo',
-                title: '무이자 할부 혜택',
-                description: '5만원 이상 결제 시 2~3개월 무이자',
+                id: "event-2",
+                variant: "promo",
+                title: "무이자 할부 혜택",
+                description: "5만원 이상 결제 시 2~3개월 무이자",
               },
               {
-                id: 'event-3',
-                variant: 'promo',
-                title: '카드 이용 실적 안내',
-                description: '이번 달 실적을 확인하고 혜택을 챙겨보세요',
+                id: "event-3",
+                variant: "promo",
+                title: "카드 이용 실적 안내",
+                description: "이번 달 실적을 확인하고 혜택을 챙겨보세요",
               },
             ]}
           />
@@ -355,12 +371,18 @@ export function CardDashboardPage({
 
         {/* ── 금액 보기/숨기기 — 스크롤 콘텐츠 맨 아래 ── */}
         <div className="flex justify-center py-sm">
-          <BalanceToggle hidden={amountHidden} onToggle={() => setAmountHidden((prev) => !prev)} />
+          <BalanceToggle
+            hidden={amountHidden}
+            onToggle={() => setAmountHidden((prev) => !prev)}
+          />
         </div>
       </HomePageLayout>
 
       {/* ── 하단 고정 탭바 ──────────────────────────────── */}
-      <BottomNav items={BOTTOM_NAV_ITEMS(handleBottomNavChange)} activeId={activeBottomTab} />
+      <BottomNav
+        items={BOTTOM_NAV_ITEMS(handleBottomNavChange)}
+        activeId={activeBottomTab}
+      />
     </div>
   );
 }

--- a/demo/front/src/pages/card/CardDashboardPage/types.ts
+++ b/demo/front/src/pages/card/CardDashboardPage/types.ts
@@ -6,6 +6,9 @@
 export interface CardDashboardPageProps {
   /** 뒤로가기 없음 — 홈 루트 화면이므로 onBack 불필요 */
 
+  /** 로그인 사용자명 — StatementHeroCard 위 인사말에 표시 */
+  userName?: string;
+
   /** 알림 아이콘 클릭 */
   onNotification?: () => void;
   /** 메뉴 아이콘 클릭 */

--- a/demo/front/src/pages/card/MyCardManagementPage/index.tsx
+++ b/demo/front/src/pages/card/MyCardManagementPage/index.tsx
@@ -37,6 +37,7 @@ export function MyCardManagementPage({
   cards,
   initialCardId,
   managementRows,
+  onCardSelect,
   onBack,
   onClose,
 }: MyCardManagementPageProps) {
@@ -100,7 +101,7 @@ export function MyCardManagementPage({
                   key={card.id}
                   label={card.name}
                   isSelected={isSelected}
-                  onClick={() => setSelectedCardId(card.id)}
+                  onClick={() => { setSelectedCardId(card.id); onCardSelect?.(card.id); }}
                 />
               );
             })}

--- a/demo/front/src/pages/card/MyCardManagementPage/types.ts
+++ b/demo/front/src/pages/card/MyCardManagementPage/types.ts
@@ -25,6 +25,8 @@ export interface MyCardManagementPageProps {
   initialCardId?:     string;
   /** 카드 관리 네비게이션 행 목록 */
   managementRows:     CardManagementNavRow[];
+  /** 카드 선택 변경 시 호출 — 선택된 카드 ID 전달 */
+  onCardSelect?:      (cardId: string) => void;
   /** 뒤로가기 클릭 */
   onBack?:            () => void;
   /** 닫기(X) 클릭 */

--- a/demo/front/src/pages/card/UsageHistoryPage/index.tsx
+++ b/demo/front/src/pages/card/UsageHistoryPage/index.tsx
@@ -142,7 +142,7 @@ export function UsageHistoryPage({
           <div className="flex flex-col gap-md bg-surface rounded-2xl shadow-card px-md py-lg">
             <div className="flex flex-col gap-xs">
               <Typography variant="caption" color="muted">
-                {paymentSummary.date} 출금예정
+                {paymentSummary.date ? `${paymentSummary.date} 출금예정` : '출금예정일 정보 없음'}
               </Typography>
               <Typography variant="subheading" weight="bold" color="heading" numeric>
                 {formatAmount(paymentSummary.totalAmount)}

--- a/demo/front/src/pages/common/LoginPage/index.tsx
+++ b/demo/front/src/pages/common/LoginPage/index.tsx
@@ -29,6 +29,10 @@ import type { LoginPageProps } from "./types";
 export type { LoginPageProps } from "./types";
 
 export function LoginPage({
+  userId = '',
+  password = '',
+  onUserIdChange,
+  onPasswordChange,
   hasError = false,
   showPassword = false,
   onTogglePassword,
@@ -79,14 +83,16 @@ export function LoginPage({
             label="아이디"
             type="text"
             placeholder="아이디를 입력하세요"
-            defaultValue="hanabank_user"
+            value={userId}
+            onChange={(e) => onUserIdChange?.(e.target.value)}
             fullWidth
           />
           <Input
             label="비밀번호"
             type={showPassword ? "text" : "password"}
             placeholder="비밀번호를 입력하세요"
-            defaultValue="password123"
+            value={password}
+            onChange={(e) => onPasswordChange?.(e.target.value)}
             fullWidth
             validationState={hasError ? "error" : "default"}
             helperText={

--- a/demo/front/src/pages/common/LoginPage/types.ts
+++ b/demo/front/src/pages/common/LoginPage/types.ts
@@ -4,6 +4,14 @@
  */
 
 export interface LoginPageProps {
+  /** 아이디 입력값 */
+  userId?: string;
+  /** 비밀번호 입력값 */
+  password?: string;
+  /** 아이디 변경 핸들러 */
+  onUserIdChange?: (value: string) => void;
+  /** 비밀번호 변경 핸들러 */
+  onPasswordChange?: (value: string) => void;
   /** true 시 비밀번호 에러 상태(빨간 테두리 + 안내 문구) 표시 */
   hasError?: boolean;
   /** true 시 비밀번호 평문 표시 */

--- a/demo/front/src/routes/RouteWrappers.tsx
+++ b/demo/front/src/routes/RouteWrappers.tsx
@@ -11,8 +11,9 @@
  * - 일반 페이지: XxxRoute (예: LoginRoute)
  * - 모달 오버레이: XxxModal (예: HanaCardMenuModal)
  */
-import { useState }                        from 'react';
+import { useState, useEffect }             from 'react';
 import { useNavigate, useLocation }        from 'react-router-dom';
+import { useAuth }                         from '@/contexts/AuthContext';
 import { Landmark, Building, Receipt, FileText, Wallet, Settings, Gift, CreditCard, Headphones } from 'lucide-react';
 
 import { LoginPage }                from '@/pages/common/LoginPage';
@@ -28,19 +29,21 @@ import { ImmediatePayCompletePage } from '@/pages/card/ImmediatePayCompletePage'
 import { MyCardManagementPage }     from '@/pages/card/MyCardManagementPage';
 import { UserManagementPage }       from '@/pages/card/UserManagementPage';
 import { PinConfirmSheet }          from '@cl/modules/common/PinConfirmSheet';
+import { BottomSheet }              from '@cl/modules/common/BottomSheet';
+import { CardInfoPanel }            from '@cl/biz/card/CardInfoPanel';
 import { ModalSlideOver }           from '@cl/layout/ModalSlideOver';
 
-import type { MenuItem } from '@/pages/card/HanaCardMenuPage/types';
-import { PATHS }         from '@/constants/paths';
+import type { MenuItem }     from '@/pages/card/HanaCardMenuPage/types';
+import type { CardItem }     from '@/pages/card/MyCardManagementPage/types';
+import type { Transaction, SearchFilter }              from '@/pages/card/UsageHistoryPage/types';
+import type { PaymentTabData, StatementTabData, CardPaymentEntry } from '@/pages/card/PaymentStatementPage/types';
+import { PATHS }          from '@/constants/paths';
 import {
-  MOCK_TRANSACTIONS,
   MOCK_CARD_OPTIONS,
   MOCK_CARDS_VISUAL,
   MOCK_CARDS_SIMPLE,
   MOCK_USERS,
   MOCK_MANAGEMENT_ROWS,
-  MOCK_PAYMENT_ITEMS,
-  MOCK_INFO_SECTIONS,
   MOCK_CAUTIONS,
 } from '@/mocks/cardMocks';
 
@@ -49,13 +52,43 @@ import {
 /* ------------------------------------------------------------------ */
 
 export function LoginRoute() {
-  const navigate = useNavigate();
+  const navigate       = useNavigate();
+  const { login }      = useAuth();
+  const [userId,       setUserId]       = useState('');
+  const [password,     setPassword]     = useState('');
   const [showPassword, setShowPassword] = useState(false);
+  const [hasError,     setHasError]     = useState(false);
+
+  const handleLogin = async () => {
+    setHasError(false);
+    try {
+      const res  = await fetch('http://localhost:3001/api/auth/login', {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify({ userId, password }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        login({ userId: data.userId, userName: data.userName, userGrade: data.userGrade, token: data.token });
+        navigate(PATHS.CARD.DASHBOARD);
+      } else {
+        setHasError(true);
+      }
+    } catch {
+      setHasError(true);
+    }
+  };
+
   return (
     <LoginPage
+      userId={userId}
+      password={password}
+      onUserIdChange={setUserId}
+      onPasswordChange={setPassword}
+      hasError={hasError}
       showPassword={showPassword}
       onTogglePassword={() => setShowPassword((v) => !v)}
-      onLogin={() => navigate(PATHS.CARD.DASHBOARD)}
+      onLogin={handleLogin}
     />
   );
 }
@@ -68,9 +101,11 @@ export function LoginRoute() {
 export function CardDashboardRoute() {
   const navigate  = useNavigate();
   const location  = useLocation();
+  const { user }  = useAuth();
 
   return (
     <CardDashboardPage
+      userName={user?.userName}
       onMenu={()             => navigate(PATHS.CARD.MENU, { state: { background: location } })}
       onNotification={()     => {}}
       onStatementDetail={()  => navigate(PATHS.CARD.PAYMENT_STATEMENT)}
@@ -94,18 +129,70 @@ export function CardDashboardRoute() {
 
 /** 분할납부·즉시결제 클릭 시 즉시결제 안내로 이동 */
 export function UsageHistoryRoute() {
-  const navigate = useNavigate();
+  const navigate                = useNavigate();
+  const { user, fetchWithAuth } = useAuth();
+  const [transactions,   setTransactions]   = useState<Transaction[]>([]);
+  const [totalCount,     setTotalCount]     = useState(0);
+  const [paymentSummary, setPaymentSummary] = useState({ date: '', totalAmount: 0 });
+  const [cardOptions,    setCardOptions]    = useState(MOCK_CARD_OPTIONS);
+  const [loading,        setLoading]        = useState(true);
+
+  /** SearchFilter → query string 변환 후 이용내역 재조회 */
+  const fetchTransactions = (filter?: SearchFilter) => {
+    const params = new URLSearchParams();
+    if (filter) {
+      if (filter.selectedCard && filter.selectedCard !== 'all')
+        params.set('cardId', filter.selectedCard);
+      if (filter.period) params.set('period', filter.period);
+      if (filter.customMonth) params.set('customMonth', filter.customMonth);
+      if (filter.usageType && filter.usageType !== 'all')
+        params.set('usageType', filter.usageType);
+    }
+    const qs = params.toString() ? `?${params}` : '';
+    fetchWithAuth(`http://localhost:3001/api/transactions${qs}`)
+      .then((r) => r.json())
+      .then((data) => {
+        setTransactions(data.transactions ?? []);
+        setTotalCount(data.totalCount ?? 0);
+        setPaymentSummary(data.paymentSummary ?? { date: '', totalAmount: 0 });
+      })
+      .catch(console.error);
+  };
+
+  useEffect(() => {
+    if (!user?.token) return;
+    Promise.all([
+      fetchWithAuth('http://localhost:3001/api/transactions').then((r) => r.json()),
+      fetchWithAuth('http://localhost:3001/api/cards').then((r) => r.json()),
+    ])
+      .then(([txData, cardData]) => {
+        setTransactions(txData.transactions ?? []);
+        setTotalCount(txData.totalCount ?? 0);
+        setPaymentSummary(txData.paymentSummary ?? { date: '', totalAmount: 0 });
+        setCardOptions(
+          (cardData.cards ?? []).map((c: { id: string; name: string }) => ({
+            value: c.id,
+            label: c.name,
+          })),
+        );
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, [user?.token]);
+
+  if (loading) return null;
+
   return (
     <UsageHistoryPage
-      transactions={MOCK_TRANSACTIONS}
-      totalCount={25}
-      paymentSummary={{ date: '2026년 4월 14일', totalAmount: 350_000 }}
-      cardOptions={MOCK_CARD_OPTIONS}
+      transactions={transactions}
+      totalCount={totalCount}
+      paymentSummary={paymentSummary}
+      cardOptions={cardOptions}
       onBack={()               => navigate(-1)}
       onClose={()              => navigate(PATHS.CARD.DASHBOARD, { replace: true })}
       onLoadMore={()           => {}}
       onRevolving={()          => {}}
-      onSearch={()             => {}}
+      onSearch={fetchTransactions}
       onInstallment={()        => navigate(PATHS.CARD.IMMEDIATE_PAYMENT)}
       onImmediatePayment={()   => navigate(PATHS.CARD.IMMEDIATE_PAYMENT)}
     />
@@ -118,27 +205,114 @@ export function UsageHistoryRoute() {
 
 /** 즉시결제·분할납부 클릭 시 즉시결제 안내로 이동 */
 export function PaymentStatementRoute() {
-  const navigate = useNavigate();
+  const navigate                = useNavigate();
+  const { user, fetchWithAuth } = useAuth();
+  const [paymentData,   setPaymentData]   = useState<PaymentTabData | null>(null);
+  const [statementData, setStatementData] = useState<StatementTabData | null>(null);
+  const [cardOptions,   setCardOptions]   = useState(MOCK_CARD_OPTIONS);
+  const [loading,       setLoading]       = useState(true);
+
+  useEffect(() => {
+    if (!user?.token) return;
+    Promise.all([
+      fetchWithAuth('http://localhost:3001/api/payment-statement').then((r) => r.json()),
+      fetchWithAuth('http://localhost:3001/api/cards').then((r) => r.json()),
+    ])
+      .then(([stmtData, cardData]) => {
+        // ── dueDate(YYMMDD 또는 YYYYMMDD) → dateFull / dateYM / dateMD ──
+        const raw = String(stmtData.dueDate ?? '');
+        let dateFull = '';
+        let dateYM   = '';
+        let dateMD   = '';
+        if (raw.length === 6) {
+          /* YYMMDD: DB 결제예정일 형식 */
+          const y = `20${raw.slice(0, 2)}`;
+          const m = raw.slice(2, 4);
+          const d = raw.slice(4, 6);
+          dateFull = `${y}.${m}.${d}`;
+          dateYM   = `${raw.slice(0, 2)}년 ${Number(m)}월`;
+          dateMD   = `${m}.${d}`;
+        } else if (raw.length === 8) {
+          /* YYYYMMDD */
+          const y = raw.slice(0, 4);
+          const m = raw.slice(4, 6);
+          const d = raw.slice(6, 8);
+          dateFull = `${y}.${m}.${d}`;
+          dateYM   = `${y.slice(2)}년 ${Number(m)}월`;
+          dateMD   = `${m}.${d}`;
+        }
+
+        // ── items → CardPaymentEntry[] ─────────────────────────────
+        const paymentItems: CardPaymentEntry[] = (stmtData.items ?? []).map(
+          (item: { cardNo: string; cardName: string; amount: number; dueDate: string }) => {
+            /* dueDate(YYMMDD or YYYYMMDD) → "M월 D일 결제" */
+            const raw = String(item.dueDate ?? '');
+            let dueDateLabel = '';
+            if (raw.length === 6) {
+              dueDateLabel = `${Number(raw.slice(2, 4))}월 ${Number(raw.slice(4, 6))}일 결제`;
+            } else if (raw.length === 8) {
+              dueDateLabel = `${Number(raw.slice(4, 6))}월 ${Number(raw.slice(6, 8))}일 결제`;
+            }
+            return {
+              id:         `${item.cardNo}_${item.dueDate}`,
+              icon:       <CreditCard className="size-5" />,
+              cardEnName: dueDateLabel,
+              cardName:   item.cardName,
+              amount:     item.amount,
+            };
+          },
+        );
+
+        // ── cardInfo → CardInfoSection[] ──────────────────────────
+        const ci = stmtData.cardInfo;
+        const infoSections = ci
+          ? [
+              {
+                title: '결제정보',
+                rows: [
+                  { label: '결제은행명', value: ci.paymentBank },
+                  { label: '결제계좌',   value: ci.paymentAccount },
+                  { label: '결제일',     value: `${ci.paymentDay}일` },
+                ],
+              },
+            ]
+          : [];
+
+        setPaymentData({
+          dateFull,
+          dateYM,
+          dateMD,
+          totalAmount:  stmtData.totalAmount ?? 0,
+          revolving:    0,
+          cardLoan:     0,
+          cashAdvance:  0,
+          infoSections,
+          paymentItems,
+        });
+        setStatementData({
+          totalAmount:  stmtData.totalAmount ?? 0,
+          badge:        '예정',
+          paymentItems,
+          infoSections,
+        });
+        setCardOptions(
+          (cardData.cards ?? []).map((c: { id: string; name: string }) => ({
+            value: c.id,
+            label: c.name,
+          })),
+        );
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, [user?.token, fetchWithAuth]);
+
+  if (loading || !paymentData || !statementData) return null;
+
   return (
     <PaymentStatementPage
-      cardOptions={MOCK_CARD_OPTIONS}
-      paymentData={{
-        dateFull:     '2026.04.14',
-        dateYM:       '26년 4월',
-        dateMD:       '04.08',
-        totalAmount:  350000,
-        revolving:    0,
-        cardLoan:     0,
-        cashAdvance:  0,
-        infoSections: MOCK_INFO_SECTIONS,
-        paymentItems: MOCK_PAYMENT_ITEMS,
-      }}
-      statementData={{
-        totalAmount:  350000,
-        badge:        '예정',
-        paymentItems: MOCK_PAYMENT_ITEMS,
-        infoSections: MOCK_INFO_SECTIONS,
-      }}
+      cardOptions={cardOptions}
+      paymentData={paymentData}
+      statementData={statementData}
       onBack={()              => navigate(-1)}
       onClose={()             => navigate(PATHS.CARD.DASHBOARD, { replace: true })}
       onCardChange={()        => {}}
@@ -276,15 +450,120 @@ export function ImmediatePayCompleteRoute() {
 /* 카드 관리 / 사용자 관리                                               */
 /* ------------------------------------------------------------------ */
 
+/** brand 값 → 카드 배경 그라디언트 */
+const CARD_GRADIENTS: Record<string, string> = {
+  VISA:       'linear-gradient(135deg, #008485, #14b8a6)',
+  Mastercard: 'linear-gradient(135deg, #1a1a2e, #16213e)',
+  AMEX:       'linear-gradient(135deg, #2d6a4f, #1b4332)',
+  JCB:        'linear-gradient(135deg, #1e40af, #1e3a8a)',
+  UnionPay:   'linear-gradient(135deg, #c0392b, #96281b)',
+};
+
+/** GET /api/cards 응답의 카드 전체 필드 */
+interface ApiCardFull {
+  id:             string;
+  name:           string;
+  brand:          string;
+  maskedNumber:   string;
+  balance:        number;
+  expiry:         string;
+  paymentBank:    string;
+  paymentAccount: string;
+  paymentDay:     string;
+  limitAmount:    number;
+  usedAmount:     number;
+}
+
 export function MyCardManagementRoute() {
-  const navigate = useNavigate();
+  const navigate              = useNavigate();
+  const { user, fetchWithAuth } = useAuth();
+  const [cards, setCards]     = useState<CardItem[]>(MOCK_CARDS_VISUAL);
+  const [rawCards, setRawCards] = useState<ApiCardFull[]>([]);
+  const [loading, setLoading] = useState(true);
+  /** 칩 탭에서 선택된 카드 ID — onCardSelect 콜백으로 동기화 */
+  const [selectedCardId, setSelectedCardId] = useState('');
+  const [modalOpen, setModalOpen] = useState(false);
+
+  useEffect(() => {
+    if (!user?.token) return;
+    fetchWithAuth('http://localhost:3001/api/cards')
+      .then((r) => r.json())
+      .then(({ cards: raw }: { cards: ApiCardFull[] }) => {
+        setRawCards(raw);
+        setCards(
+          raw.map((c) => ({
+            id:      c.id,
+            name:    c.name,
+            brand:   c.brand as 'VISA' | 'Mastercard' | 'AMEX' | 'JCB' | 'UnionPay',
+            image:   (
+              <div style={{
+                width: '100%', height: '100%', borderRadius: 12,
+                background: CARD_GRADIENTS[c.brand] ?? 'linear-gradient(135deg, #374151, #1f2937)',
+              }} />
+            ),
+            balance: c.balance,
+          }))
+        );
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, [user?.token]);
+
+  if (loading) return null;
+
+  /** 현재 선택된 카드의 전체 API 데이터 (선택 전에는 첫 번째 카드 사용) */
+  const activeCard = rawCards.find((c) => c.id === selectedCardId) ?? rawCards[0];
+
+  /** 모달에 표시할 카드정보 섹션 */
+  const cardInfoSections = activeCard ? [
+    {
+      title: '카드정보',
+      rows: [
+        { label: '카드번호', value: activeCard.maskedNumber },
+        { label: '카드구분', value: activeCard.name },
+        { label: '유효기간', value: activeCard.expiry },
+      ],
+    },
+    {
+      title: '결제정보',
+      rows: [
+        { label: '결제은행명', value: activeCard.paymentBank },
+        { label: '결제계좌',   value: activeCard.paymentAccount },
+        { label: '결제일',     value: `${activeCard.paymentDay}일` },
+        { label: '한도금액',   value: `${activeCard.limitAmount.toLocaleString()}원` },
+        { label: '사용금액',   value: `${activeCard.usedAmount.toLocaleString()}원` },
+      ],
+    },
+  ] : [];
+
+  /**
+   * 관리 행 목록 — 선택된 카드 데이터로 동적 구성
+   *   - 0번 "카드정보 확인": subText = 마스킹 카드번호, onClick = 모달 오픈
+   *   - 1번 "결제계좌": subText = 결제은행명 + 계좌번호
+   */
+  const managementRows = MOCK_MANAGEMENT_ROWS.map((row, i) => {
+    if (i === 0) return { ...row, subText: activeCard?.maskedNumber, onClick: () => setModalOpen(true) };
+    if (i === 1) return { ...row, subText: activeCard ? `${activeCard.paymentBank} ${activeCard.paymentAccount}` : row.subText };
+    return row;
+  });
+
   return (
-    <MyCardManagementPage
-      cards={MOCK_CARDS_VISUAL}
-      managementRows={MOCK_MANAGEMENT_ROWS}
-      onBack={()  => navigate(-1)}
-      onClose={() => navigate(PATHS.CARD.DASHBOARD, { replace: true })}
-    />
+    <>
+      <MyCardManagementPage
+        cards={cards}
+        managementRows={managementRows}
+        onCardSelect={setSelectedCardId}
+        onBack={()  => navigate(-1)}
+        onClose={() => navigate(PATHS.CARD.DASHBOARD, { replace: true })}
+      />
+      <BottomSheet
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        title="카드정보 확인"
+      >
+        <CardInfoPanel sections={cardInfoSections} />
+      </BottomSheet>
+    </>
   );
 }
 
@@ -312,7 +591,8 @@ export function UserManagementRoute() {
  * - 메뉴 항목 클릭: replace: true — 뒤로가기 시 메뉴가 히스토리에 남지 않도록 한다.
  */
 export function HanaCardMenuModal() {
-  const navigate = useNavigate();
+  const navigate    = useNavigate();
+  const { logout }  = useAuth();
 
   const menuItems: MenuItem[] = [
     { id: 'usage-history',    category: 'history',    label: '이용내역',         icon: <Receipt    className="size-5" />, onClick: () => navigate(PATHS.CARD.USAGE_HISTORY,       { replace: true }) },
@@ -340,7 +620,7 @@ export function HanaCardMenuModal() {
         menuItems={menuItems}
         onBack={()          => navigate(-1)}
         onProfileManage={()  => {}}
-        onLogout={()        => navigate(PATHS.LOGIN, { replace: true })}
+        onLogout={() => { logout(); navigate(PATHS.LOGIN, { replace: true }); }}
       />
     </ModalSlideOver>
   );

--- a/reactive-springware/component-library/biz/card/CardLinkedBalance/index.tsx
+++ b/reactive-springware/component-library/biz/card/CardLinkedBalance/index.tsx
@@ -36,7 +36,7 @@ export function CardLinkedBalance({
 }: CardLinkedBalanceProps) {
   return (
     <div className={cn('flex flex-col gap-xs', className)}>
-      <span className="text-xs sm:text-sm text-text-muted">연결계좌 잔액</span>
+      <span className="text-xs sm:text-sm text-text-muted">사용가능 한도 금액</span>
 
       {/* 금액 + 보기/숨기기 배지 버튼 */}
       <div className="flex items-center gap-xs">

--- a/reactive-springware/component-library/biz/card/UsageTransactionItem/index.tsx
+++ b/reactive-springware/component-library/biz/card/UsageTransactionItem/index.tsx
@@ -21,10 +21,10 @@
 import React, { useState } from 'react';
 import { cn } from '@lib/cn';
 
-import { Typography }         from '../../../core/Typography';
-import { BottomSheet }        from '../../../modules/common/BottomSheet';
+import { Typography } from '../../../core/Typography';
+import { BottomSheet } from '../../../modules/common/BottomSheet';
 import { CollapsibleSection } from '../../../modules/common/CollapsibleSection';
-import { Divider }            from '../../../modules/common/Divider';
+import { Divider } from '../../../modules/common/Divider';
 
 import type { Transaction, UsageTransactionItemProps } from './types';
 
@@ -48,7 +48,7 @@ function DetailSheet({
   const isRefund = tx.amount < 0;
 
   const rows = [
-    { label: '거래일',   value: tx.date },
+    { label: '거래일시', value: tx.date },
     { label: '거래구분', value: tx.type },
     { label: '승인번호', value: tx.approvalNumber },
     { label: '거래상태', value: tx.status },
@@ -58,24 +58,31 @@ function DetailSheet({
   return (
     <BottomSheet open={open} onClose={onClose} title="이용내역 상세" snap="auto">
       <div className="flex flex-col items-center gap-xs pb-lg">
-        <Typography variant="body" color="muted">{tx.merchant}</Typography>
+        <Typography variant="body" color="muted">
+          {tx.merchant}
+        </Typography>
         <Typography
           variant="heading"
           weight="bold"
           numeric
           className={isRefund ? 'text-brand' : 'text-text-heading'}
         >
-          {isRefund ? '-' : ''}{formatAmount(tx.amount)}
+          {isRefund ? '-' : ''}
+          {formatAmount(tx.amount)}
         </Typography>
       </div>
 
       <Divider />
 
-      <div className="flex flex-col gap-sm p-lg">
+      <div className="flex flex-col gap-sm pt-lg">
         {rows.map(({ label, value }) => (
           <div key={label} className="flex justify-between items-center">
-            <Typography variant="body-sm" color="muted">{label}</Typography>
-            <Typography variant="body-sm" color="heading">{value}</Typography>
+            <Typography variant="body-sm" color="muted">
+              {label}
+            </Typography>
+            <Typography variant="body-sm" color="heading">
+              {value}
+            </Typography>
           </div>
         ))}
       </div>
@@ -90,20 +97,32 @@ function DetailSheet({
           <div className="flex flex-col gap-sm">
             {tx.merchantInfo.address && (
               <div className="flex justify-between gap-md">
-                <Typography variant="caption" color="muted" className="shrink-0">주소</Typography>
-                <Typography variant="caption" color="heading" className="text-right">{tx.merchantInfo.address}</Typography>
+                <Typography variant="caption" color="muted" className="shrink-0">
+                  주소
+                </Typography>
+                <Typography variant="caption" color="heading" className="text-right">
+                  {tx.merchantInfo.address}
+                </Typography>
               </div>
             )}
             {tx.merchantInfo.phone && (
               <div className="flex justify-between">
-                <Typography variant="caption" color="muted">전화번호</Typography>
-                <Typography variant="caption" color="heading">{tx.merchantInfo.phone}</Typography>
+                <Typography variant="caption" color="muted">
+                  전화번호
+                </Typography>
+                <Typography variant="caption" color="heading">
+                  {tx.merchantInfo.phone}
+                </Typography>
               </div>
             )}
             {tx.merchantInfo.businessType && (
               <div className="flex justify-between">
-                <Typography variant="caption" color="muted">업종</Typography>
-                <Typography variant="caption" color="heading">{tx.merchantInfo.businessType}</Typography>
+                <Typography variant="caption" color="muted">
+                  업종
+                </Typography>
+                <Typography variant="caption" color="heading">
+                  {tx.merchantInfo.businessType}
+                </Typography>
               </div>
             )}
           </div>
@@ -117,7 +136,7 @@ function DetailSheet({
 
 export function UsageTransactionItem({ tx, onClick }: UsageTransactionItemProps) {
   const [open, setOpen] = useState(false);
-  const isRefund    = tx.amount < 0;
+  const isRefund = tx.amount < 0;
   const isClickable = !!onClick;
 
   const rowContent = (
@@ -135,7 +154,8 @@ export function UsageTransactionItem({ tx, onClick }: UsageTransactionItemProps)
         weight="bold"
         className={cn('shrink-0', isRefund ? 'text-brand' : 'text-text-heading')}
       >
-        {isRefund ? '-' : ''}{formatAmount(tx.amount)}
+        {isRefund ? '-' : ''}
+        {formatAmount(tx.amount)}
       </Typography>
     </>
   );
@@ -150,7 +170,10 @@ export function UsageTransactionItem({ tx, onClick }: UsageTransactionItemProps)
       {isClickable ? (
         <button
           type="button"
-          onClick={() => { setOpen(true); onClick(); }}
+          onClick={() => {
+            setOpen(true);
+            onClick();
+          }}
           className={rowCls}
         >
           {rowContent}
@@ -160,9 +183,7 @@ export function UsageTransactionItem({ tx, onClick }: UsageTransactionItemProps)
       )}
 
       {/* onClick이 있을 때만 상세 BottomSheet 렌더링 */}
-      {isClickable && (
-        <DetailSheet tx={tx} open={open} onClose={() => setOpen(false)} />
-      )}
+      {isClickable && <DetailSheet tx={tx} open={open} onClose={() => setOpen(false)} />}
     </>
   );
 }

--- a/reactive-springware/component-library/modules/common/BottomSheet/index.tsx
+++ b/reactive-springware/component-library/modules/common/BottomSheet/index.tsx
@@ -141,7 +141,7 @@ export function BottomSheet({
          *   - 헤더 없음: 드래그 핸들 pb-1(4px) + 본문 pt-md(12px) = 16px 간격
          */}
         <div
-          className="flex-1 min-h-0 overflow-y-auto [&::-webkit-scrollbar]:hidden pt-md pb-md"
+          className="flex-1 min-h-0 overflow-y-auto [&::-webkit-scrollbar]:hidden p-md"
           style={{ scrollbarWidth: 'none' }}
         >
           {children}

--- a/reactive-springware/component-library/pages/card/MyCardManagementPage/index.tsx
+++ b/reactive-springware/component-library/pages/card/MyCardManagementPage/index.tsx
@@ -37,10 +37,16 @@ export function MyCardManagementPage({
   cards,
   initialCardId,
   managementRows,
+  onCardSelect,
   onBack,
   onClose,
 }: MyCardManagementPageProps) {
   const [selectedCardId, setSelectedCardId] = useState(initialCardId ?? cards[0]?.id);
+
+  const handleCardSelect = (id: string) => {
+    setSelectedCardId(id);
+    onCardSelect?.(id);
+  };
   const [balanceHidden, setBalanceHidden] = useState(false);
   const [isCompact, setIsCompact] = useState(false);
 
@@ -96,7 +102,7 @@ export function MyCardManagementPage({
                   key={card.id}
                   label={card.name}
                   isSelected={isSelected}
-                  onClick={() => setSelectedCardId(card.id)}
+                  onClick={() => handleCardSelect(card.id)}
                 />
               );
             })}

--- a/reactive-springware/component-library/pages/card/MyCardManagementPage/types.ts
+++ b/reactive-springware/component-library/pages/card/MyCardManagementPage/types.ts
@@ -25,6 +25,8 @@ export interface MyCardManagementPageProps {
   initialCardId?:     string;
   /** 카드 관리 네비게이션 행 목록 */
   managementRows:     CardManagementNavRow[];
+  /** 카드 선택 변경 시 호출 — 선택된 카드 ID 전달 */
+  onCardSelect?:      (cardId: string) => void;
   /** 뒤로가기 클릭 */
   onBack?:            () => void;
   /** 닫기(X) 클릭 */


### PR DESCRIPTION
## Summary

- `demo/backend` Express 서버 신규 구현 (Oracle DB 연동, JWT 인증, 카드·이용내역·결제예정 API)
- `demo/front` 목 데이터 → 실제 API 연동 (AuthContext, 이용내역·결제예정·내카드관리 페이지)
- `component-library` 카드 관련 컴포넌트 UI 수정 (레이블·패딩·onCardSelect 콜백)

## Test plan

- [ ] `demo/backend` — `.env.example`을 `.env`로 복사 후 Oracle 접속 정보 입력, `npm run dev`로 서버 기동 확인
- [ ] `POST /api/auth/login` — 올바른/잘못된 계정으로 각각 테스트
- [ ] 로그인 후 대시보드에 사용자명 인사말 표시 확인
- [ ] 이용내역 페이지 — 실제 DB 데이터 렌더링 및 필터(카드·기간·유형) 재조회 확인
- [ ] 결제예정금액 페이지 — 실제 DB 데이터 렌더링 확인
- [ ] 내카드관리 — 카드 선택 시 카드정보 BottomSheet 표시 확인
- [ ] 새로고침 후 로그인 세션 유지 확인
- [ ] 로그아웃 후 로그인 페이지 리다이렉트 및 직접 URL 접근 차단 확인
- [ ] `.env` 파일이 커밋에 포함되지 않았는지 확인

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)