### PR TITLE
feat: React Generate 메뉴 구현 및 Figma/Claude API 연동 (#4)

### DIFF
--- a/admin/.env.example
+++ b/admin/.env.example
@@ -40,6 +40,9 @@ LOG_DEST_RDB_ERROR=true
 LOGSTASH_HOST=localhost
 LOGSTASH_PORT=5000
 
+# === Claude API (React Generate) ===
+CLAUDE_API_KEY=sk-ant-api03-...
+
 # === Test (E2E/API) ===
 # E2E 테스트 계정은 e2e/docker/e2e-seed.sql에서 Oracle 컨테이너에 직접 시드.
 # e2e/fixtures/test-accounts.ts 참조. 별도 환경변수 불필요.

--- a/admin/.env.example
+++ b/admin/.env.example
@@ -40,7 +40,11 @@ LOG_DEST_RDB_ERROR=true
 LOGSTASH_HOST=localhost
 LOGSTASH_PORT=5000
 
-# === Claude API (React Generate) ===
+# === Figma API (React Generate — 디자인 노드 조회) ===
+# Figma 계정 → Settings → Security → Personal access tokens 에서 발급
+FIGMA_ACCESS_TOKEN=figd_...
+
+# === Claude API (React Generate — React 코드 생성) ===
 CLAUDE_API_KEY=sk-ant-api03-...
 
 # === Test (E2E/API) ===

--- a/admin/docs/plan-react-generate-claude-api.md
+++ b/admin/docs/plan-react-generate-claude-api.md
@@ -1,0 +1,302 @@
+# React Generate — Claude API 연동 구현 계획
+
+> 관련 이슈: #4  
+> 작성일: 2026-04-13
+
+---
+
+## 1. 목표
+
+관리자 화면(`react-generate` 메뉴)에서 Figma URL과 요구사항을 입력하면,  
+Claude API가 `reactive-springware` 컴포넌트 라이브러리 기반의 React 코드를 생성하고 DB에 저장한다.
+
+---
+
+## 2. 전체 아키텍처
+
+```
+reactive-springware (빌드 시)
+  └── scripts/
+        ├── extract-components.ts   → component-library의 types.ts 파싱
+        ├── extract-design-tokens.ts → figma-tokens/*.json 파싱
+        └── extract-component-map.ts → docs/component-map.md 복사·가공
+              ↓ 생성
+        generated/
+          ├── component-types.md
+          ├── design-tokens.md
+          └── component-map.md
+                ↓ 복사 (빌드 후 훅 또는 수동)
+admin (런타임)
+  └── resources/prompts/
+        ├── CLAUDE.md              (reactive-springware CLAUDE.md)
+        ├── component-types.md
+        ├── design-tokens.md
+        └── component-map.md
+              ↓ 읽기
+        domain/reactgenerate/ai/
+          ├── prompt/PromptLoader   → 파일 로드
+          ├── prompt/PromptBuilder  → system prompt 조립
+          └── ClaudeApiClient       → Claude API 호출
+              ↓
+        ReactGenerateService        → 코드 추출 + DB 저장 (status: pending)
+```
+
+---
+
+## 3. 작업 단위
+
+### Phase 1. reactive-springware — 빌드 스크립트
+
+#### 목적
+
+Claude API system prompt에 포함할 컴포넌트 컨텍스트를 **빌드 시점에** 마크다운 파일로 추출한다.  
+런타임에 TypeScript 파일을 직접 읽을 수 없는 Java 백엔드를 위해 텍스트 형태로 변환한다.
+
+#### 스크립트별 역할
+
+| 스크립트 | 입력 | 출력 | 설명 |
+|---|---|---|---|
+| `extract-components.ts` | `component-library/**/types.ts` | `component-types.md` | 각 컴포넌트의 interface·type을 파싱하여 props 목록 문서화 |
+| `extract-design-tokens.ts` | `design-tokens/figma-tokens/*.json` | `design-tokens.md` | semantic 토큰 및 primitive 토큰을 계층 구조로 문서화 |
+| `extract-component-map.ts` | `docs/component-map.md` | `component-map.md` | 기존 문서를 그대로 복사하거나 최신화 후 generated에 배치 |
+
+#### `component-types.md` 출력 예시
+
+```markdown
+## Button
+
+### Props
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| variant | 'primary' \| 'outline' \| 'ghost' \| 'danger' | 'primary' | 버튼 외형 |
+| size | 'sm' \| 'md' \| 'lg' | 'md' | 버튼 크기 |
+| loading | boolean | false | 로딩 스피너 표시 |
+| fullWidth | boolean | false | w-full 적용 |
+...
+
+## Input
+...
+```
+
+#### `design-tokens.md` 출력 예시
+
+```markdown
+## Semantic Tokens
+- --color-primary: var(--primitive-blue-500)
+- --color-surface: var(--primitive-gray-50)
+...
+
+## Brand Tokens (hana)
+- --brand-primary: #008080
+...
+```
+
+#### 스크립트 실행 방법
+
+`package.json`에 스크립트 추가:
+```json
+{
+  "scripts": {
+    "generate:prompts": "ts-node scripts/extract-components.ts && ts-node scripts/extract-design-tokens.ts && ts-node scripts/extract-component-map.ts"
+  }
+}
+```
+
+> **Note**: CI/CD 파이프라인 또는 로컬 빌드 후 `generated/` 파일을  
+> `admin/src/main/resources/prompts/`로 복사하는 훅을 추가한다.
+
+---
+
+### Phase 2. admin — PromptLoader / PromptBuilder
+
+#### PromptLoader
+
+`resources/prompts/` 디렉토리에서 파일을 읽어 문자열로 반환한다.
+
+- 파일은 Spring classpath 리소스로 관리 (`ClassPathResource`)
+- 각 파일은 애플리케이션 시작 시 한 번만 로드하고 캐싱 (`@PostConstruct`)
+- 파일이 없을 경우 빈 문자열 반환 (graceful degradation)
+
+```
+PromptLoader
+  - loadClaudeMd()         → CLAUDE.md 전체 내용
+  - loadComponentTypes()   → component-types.md 전체 내용
+  - loadDesignTokens()     → design-tokens.md 전체 내용
+  - loadComponentMap()     → component-map.md 전체 내용
+```
+
+#### PromptBuilder
+
+`PromptLoader`에서 받은 내용을 조합하여 system prompt 문자열을 생성한다.
+
+- 각 섹션에 구분자(`---`)와 헤더를 붙여 Claude가 맥락을 구분할 수 있도록 구성
+- 섹션 순서: CLAUDE.md → component-types → design-tokens → component-map
+
+```
+PromptBuilder
+  - buildSystemPrompt()    → 섹션 조합 후 완성된 system prompt 반환
+  - buildUserPrompt(figmaUrl, requirements) → user prompt 생성
+```
+
+**system prompt 구조 예시:**
+
+```
+[역할 정의]
+당신은 Figma 디자인을 React 컴포넌트로 변환하는 전문가입니다.
+반드시 아래에 제공된 컴포넌트 라이브러리만 사용하여 코드를 생성하세요.
+
+--- CLAUDE.md ---
+{CLAUDE.md 내용}
+
+--- Component Library ---
+{component-types.md 내용}
+
+--- Design Tokens ---
+{design-tokens.md 내용}
+
+--- Component Map (Figma → React 매핑 전략) ---
+{component-map.md 내용}
+```
+
+**user prompt 구조 예시:**
+
+```
+Generate a React component from the following Figma design.
+
+Figma URL: {figmaUrl}
+
+Requirements:
+{requirements}
+
+Rules:
+- 반드시 위 컴포넌트 라이브러리의 컴포넌트만 사용할 것
+- 디자인 토큰(CSS 변수)을 활용하고 하드코딩 금지
+- TypeScript로 작성하고 props interface를 포함할 것
+- 접근성(aria 속성)을 고려할 것
+```
+
+---
+
+### Phase 3. admin — Claude API Client
+
+Claude API(`/v1/messages`)를 호출하는 HTTP 클라이언트를 구현한다.
+
+#### 설정
+
+`application.yml`에 추가:
+
+```yaml
+claude:
+  api:
+    url: https://api.anthropic.com/v1/messages
+    key: ${CLAUDE_API_KEY}
+    model: claude-opus-4-6          # 또는 claude-sonnet-4-6
+    max-tokens: 8192
+```
+
+`.env`에 추가:
+```
+CLAUDE_API_KEY=sk-ant-...
+```
+
+#### 요청 / 응답 구조
+
+Claude API 요청 (`POST /v1/messages`):
+```json
+{
+  "model": "claude-opus-4-6",
+  "max_tokens": 8192,
+  "system": "{system prompt}",
+  "messages": [
+    { "role": "user", "content": "{user prompt}" }
+  ]
+}
+```
+
+Claude API 응답에서 코드 추출:
+- `content[0].text` 에서 마크다운 코드 블록(` ```tsx ... ``` `) 파싱
+- 코드 블록이 없을 경우 전체 텍스트를 그대로 사용
+
+#### ClaudeApiClient 구조
+
+```
+ClaudeApiClient
+  - generate(systemPrompt, userPrompt) → 생성된 React 코드 문자열 반환
+```
+
+- `RestTemplate` 또는 `WebClient` 사용 (기존 `RestTemplateConfig` 재사용 우선)
+- API 오류 시 `InternalException` throw
+- 타임아웃 설정 필수 (Claude 응답이 수 초 소요)
+
+---
+
+### Phase 4. admin — Service 연결 및 DB 저장
+
+#### 코드 생성 흐름
+
+```
+ReactGenerateService.generate(request)
+  1. PromptBuilder.buildSystemPrompt()
+  2. PromptBuilder.buildUserPrompt(figmaUrl, requirements)
+  3. ClaudeApiClient.generate(systemPrompt, userPrompt)
+  4. 응답 코드 추출
+  5. DB 저장 (status: pending)
+  6. ReactGenerateResponse 반환
+```
+
+#### DB 테이블 설계 (안)
+
+```sql
+CREATE TABLE REACT_GENERATE_HIS (
+    ID            VARCHAR2(36)   PRIMARY KEY,   -- UUID
+    FIGMA_URL     VARCHAR2(1000) NOT NULL,
+    SYSTEM_PROMPT CLOB,                         -- 디버깅용 저장
+    USER_PROMPT   CLOB,
+    REACT_CODE    CLOB,
+    PREVIEW_HTML  CLOB,
+    STATUS        VARCHAR2(20)   DEFAULT 'PENDING',  -- PENDING / APPROVED / REJECTED
+    APPROVED_BY   VARCHAR2(100),
+    APPROVED_AT   VARCHAR2(14),
+    CREATED_BY    VARCHAR2(100),
+    CREATED_AT    VARCHAR2(14)   NOT NULL
+);
+```
+
+- 현재 인메모리(`ConcurrentHashMap`) → Mapper로 교체
+- `ReactGenerateMapper` 추가 (insert, selectById, updateStatus)
+- Oracle DDL: `docs/sql/oracle/`, MySQL DDL: `docs/sql/mysql/`에 추가
+
+---
+
+## 4. 구현 순서
+
+```
+1. [reactive-springware] 추출 스크립트 작성 및 generated/ 파일 생성
+2. [admin] resources/prompts/ 파일 배치
+3. [admin] PromptLoader 구현 (파일 로드 + 캐싱)
+4. [admin] PromptBuilder 구현 (system/user prompt 조립)
+5. [admin] ClaudeApiClient 구현 (API 호출 + 코드 추출)
+6. [admin] DB 테이블 DDL 작성 + Mapper 구현
+7. [admin] ReactGenerateService 연결 (인메모리 → Mapper + Claude API)
+8. 통합 테스트 (실제 Figma URL + Claude API 호출)
+```
+
+---
+
+## 5. 고려 사항
+
+### 프롬프트 파일 관리
+- `generated/` 파일은 컴포넌트 라이브러리 변경 시마다 재생성 필요
+- CI/CD에서 `generate:prompts` 스크립트를 자동 실행하고, 결과물을 admin 리소스로 복사하는 파이프라인 구성 검토
+
+### Claude API 응답 시간
+- 코드 생성 요청은 수 초~수십 초 소요될 수 있음
+- 관리자 화면에서 `생성 중...` 스피너는 이미 구현되어 있으나, 타임아웃 처리 및 재시도 UX 추가 검토
+
+### 토큰 비용
+- system prompt가 길어질수록 비용 증가
+- `component-types.md`에 포함할 컴포넌트 범위를 필요한 것만 선별하거나, 입력 카테고리별로 로드 범위 조정 가능
+
+### 보안
+- `CLAUDE_API_KEY`는 반드시 환경변수로 관리, 코드·커밋에 포함 금지
+- system prompt에 내부 코드가 포함되므로 외부 노출 금지

--- a/admin/docs/sql/mysql/01_create_tables.sql
+++ b/admin/docs/sql/mysql/01_create_tables.sql
@@ -1027,3 +1027,25 @@ CREATE TABLE FWK_TRANS_DATA_HIS (
     TRAN_TIME                  VARCHAR(14)    NOT NULL,
     PRIMARY KEY (TRAN_SEQ, TRAN_ID, TRAN_TYPE)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+
+-- =============================================================
+-- 15. React Generate (1 table)
+-- =============================================================
+
+CREATE TABLE REACT_GENERATE_HIS (
+    ID                         VARCHAR(36)    NOT NULL,
+    FIGMA_URL                  VARCHAR(1000)  NOT NULL,
+    REQUIREMENTS               LONGTEXT,
+    SYSTEM_PROMPT              LONGTEXT,
+    USER_PROMPT                LONGTEXT,
+    REACT_CODE                 LONGTEXT,
+    PREVIEW_HTML               LONGTEXT,
+    STATUS                     VARCHAR(20)    NOT NULL DEFAULT 'GENERATED',
+    APPROVED_BY                VARCHAR(100),
+    APPROVED_AT                VARCHAR(14),
+    CREATED_BY                 VARCHAR(100)   NOT NULL,
+    CREATED_AT                 VARCHAR(14)    NOT NULL,
+    PRIMARY KEY (ID),
+    CONSTRAINT CHK_REACT_GEN_STATUS CHECK (STATUS IN ('GENERATED', 'PENDING_APPROVAL', 'APPROVED', 'REJECTED'))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/admin/docs/sql/oracle/01_create_tables.sql
+++ b/admin/docs/sql/oracle/01_create_tables.sql
@@ -1172,3 +1172,25 @@ CREATE TABLE FWK_LOG (
     LOG_DATA                   CLOB,
     CONSTRAINT PK_FWK_LOG PRIMARY KEY (LOG_SNO)
 );
+
+
+-- =============================================================
+-- 15. React Generate (1 table)
+-- =============================================================
+
+CREATE TABLE REACT_GENERATE_HIS (
+    ID                         VARCHAR2(36)   NOT NULL,
+    FIGMA_URL                  VARCHAR2(1000) NOT NULL,
+    REQUIREMENTS               CLOB,
+    SYSTEM_PROMPT              CLOB,                         -- 디버깅 및 감사용 저장
+    USER_PROMPT                CLOB,
+    REACT_CODE                 CLOB,
+    PREVIEW_HTML               CLOB,
+    STATUS                     VARCHAR2(20)   DEFAULT 'GENERATED' NOT NULL,  -- GENERATED / PENDING_APPROVAL / APPROVED / REJECTED
+    APPROVED_BY                VARCHAR2(100),
+    APPROVED_AT                VARCHAR2(14),
+    CREATED_BY                 VARCHAR2(100)  NOT NULL,
+    CREATED_AT                 VARCHAR2(14)   NOT NULL,
+    CONSTRAINT PK_REACT_GENERATE_HIS PRIMARY KEY (ID),
+    CONSTRAINT CHK_REACT_GEN_STATUS CHECK (STATUS IN ('GENERATED', 'PENDING_APPROVAL', 'APPROVED', 'REJECTED'))
+);

--- a/admin/src/main/java/com/example/admin_demo/domain/menu/service/MenuService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/menu/service/MenuService.java
@@ -10,13 +10,13 @@ import com.example.admin_demo.domain.menu.mapper.UserMenuMapper;
 import com.example.admin_demo.domain.role.dto.RoleMenuResponse;
 import com.example.admin_demo.domain.role.mapper.RoleMenuMapper;
 import com.example.admin_demo.domain.user.mapper.UserMapper;
+import com.example.admin_demo.global.config.MenuProperties;
 import com.example.admin_demo.global.dto.PageRequest;
 import com.example.admin_demo.global.dto.PageResponse;
 import com.example.admin_demo.global.exception.DuplicateException;
 import com.example.admin_demo.global.exception.InternalException;
 import com.example.admin_demo.global.exception.InvalidInputException;
 import com.example.admin_demo.global.exception.NotFoundException;
-import com.example.admin_demo.global.config.MenuProperties;
 import com.example.admin_demo.global.util.AuditUtil;
 import com.example.admin_demo.global.util.ExcelColumnDefinition;
 import com.example.admin_demo.global.util.ExcelExportUtil;
@@ -341,9 +341,7 @@ public class MenuService {
             }
         }
 
-        return menus.stream()
-                .filter(m -> !toHide.contains(m.getMenuId()))
-                .collect(Collectors.toList());
+        return menus.stream().filter(m -> !toHide.contains(m.getMenuId())).collect(Collectors.toList());
     }
 
     private List<MenuHierarchyResponse> buildMenuHierarchy(

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/ai/ClaudeApiClient.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/ai/ClaudeApiClient.java
@@ -1,0 +1,128 @@
+package com.example.admin_demo.domain.reactgenerate.ai;
+
+import com.example.admin_demo.global.exception.InternalException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Claude API(/v1/messages)를 호출하여 React 코드를 생성하는 클라이언트.
+ *
+ * <p>기존 RestTemplate 빈은 read timeout이 10초로 짧아 Claude 응답에 부적합하므로,
+ * ClaudeApiProperties에 정의된 별도 타임아웃으로 RestTemplate을 직접 구성한다.
+ *
+ * <p>API 오류 발생 시 {@link InternalException}으로 변환하여 상위에 전파한다.
+ */
+@Slf4j
+@Component
+@EnableConfigurationProperties(ClaudeApiProperties.class)
+public class ClaudeApiClient {
+
+    /** 응답에서 코드 블록을 추출하는 정규식. ```tsx ... ``` 또는 ```typescript ... ``` 형태 */
+    private static final Pattern CODE_BLOCK_PATTERN =
+            Pattern.compile("```(?:tsx|typescript|jsx|js)?\\s*\\n([\\s\\S]*?)\\n```");
+
+    private final RestTemplate restTemplate;
+    private final ClaudeApiProperties props;
+
+    public ClaudeApiClient(RestTemplateBuilder builder, ClaudeApiProperties props) {
+        this.props = props;
+        // Claude API 전용 타임아웃 설정 (코드 생성은 수십 초 소요 가능)
+        this.restTemplate = builder.connectTimeout(Duration.ofSeconds(props.getConnectTimeoutSeconds()))
+                .readTimeout(Duration.ofSeconds(props.getReadTimeoutSeconds()))
+                .build();
+    }
+
+    /**
+     * system prompt와 user prompt를 Claude API에 전달하여 생성된 React 코드를 반환한다.
+     *
+     * <p>응답 텍스트에서 마크다운 코드 블록(```tsx ... ```)을 추출한다.
+     * 코드 블록이 없으면 전체 응답 텍스트를 그대로 반환한다.
+     *
+     * @param systemPrompt 컴포넌트 라이브러리 컨텍스트가 포함된 system prompt
+     * @param userPrompt   Figma URL과 요구사항이 포함된 user prompt
+     * @return 생성된 React 코드 문자열
+     * @throws InternalException Claude API 호출 실패 시
+     */
+    public String generate(String systemPrompt, String userPrompt) {
+        HttpHeaders headers = buildHeaders();
+
+        Map<String, Object> body = Map.of(
+                "model", props.getModel(),
+                "max_tokens", props.getMaxTokens(),
+                "system", systemPrompt,
+                "messages", List.of(Map.of("role", "user", "content", userPrompt)));
+
+        log.info(
+                "Claude API 호출 시작 — model: {}, system prompt: {}자, user prompt: {}자",
+                props.getModel(),
+                systemPrompt.length(),
+                userPrompt.length());
+
+        try {
+            ResponseEntity<Map> response =
+                    restTemplate.postForEntity(props.getUrl(), new HttpEntity<>(body, headers), Map.class);
+
+            String rawText = extractText(response.getBody());
+            log.info("Claude API 응답 수신 — {}자", rawText.length());
+
+            return extractCodeBlock(rawText);
+
+        } catch (RestClientException e) {
+            log.error("Claude API 호출 실패", e);
+            throw new InternalException("React 코드 생성 중 오류가 발생했습니다.");
+        }
+    }
+
+    /** Claude API 인증 헤더 구성 */
+    private HttpHeaders buildHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("x-api-key", props.getKey());
+        headers.set("anthropic-version", "2023-06-01");
+        return headers;
+    }
+
+    /**
+     * Claude API 응답 body에서 텍스트를 추출한다.
+     * 응답 구조: { "content": [ { "type": "text", "text": "..." } ] }
+     */
+    @SuppressWarnings("unchecked")
+    private String extractText(Map<?, ?> body) {
+        if (body == null) {
+            throw new InternalException("Claude API 응답이 비어있습니다.");
+        }
+        try {
+            List<Map<String, Object>> content = (List<Map<String, Object>>) body.get("content");
+            return (String) content.get(0).get("text");
+        } catch (Exception e) {
+            log.error("Claude API 응답 파싱 실패: {}", body);
+            throw new InternalException("Claude API 응답을 파싱할 수 없습니다.");
+        }
+    }
+
+    /**
+     * 마크다운 코드 블록에서 코드만 추출한다.
+     * 코드 블록이 없으면 원본 텍스트를 그대로 반환한다.
+     */
+    private String extractCodeBlock(String text) {
+        Matcher matcher = CODE_BLOCK_PATTERN.matcher(text);
+        if (matcher.find()) {
+            return matcher.group(1).trim();
+        }
+        // 코드 블록이 없으면 전체 텍스트 사용 (Claude가 형식을 지키지 않은 경우 대비)
+        return text.trim();
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/ai/ClaudeApiProperties.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/ai/ClaudeApiProperties.java
@@ -1,0 +1,87 @@
+package com.example.admin_demo.domain.reactgenerate.ai;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * application.yml의 claude.api.* 설정을 바인딩하는 프로퍼티 클래스.
+ *
+ * <pre>{@code
+ * claude:
+ *   api:
+ *     url: https://api.anthropic.com/v1/messages
+ *     key: ${CLAUDE_API_KEY}
+ *     model: claude-sonnet-4-6
+ *     max-tokens: 8192
+ *     connect-timeout-seconds: 10
+ *     read-timeout-seconds: 120
+ * }</pre>
+ */
+@ConfigurationProperties(prefix = "claude.api")
+public class ClaudeApiProperties {
+
+    /** Claude API 엔드포인트 URL */
+    private String url;
+
+    /** API 인증 키. 반드시 환경변수(CLAUDE_API_KEY)로 주입 */
+    private String key;
+
+    /** 사용할 Claude 모델 ID */
+    private String model;
+
+    /** 응답 최대 토큰 수 */
+    private int maxTokens;
+
+    /** 연결 타임아웃 (초). Claude API 호출은 기본 RestTemplate과 별도 설정 */
+    private int connectTimeoutSeconds;
+
+    /** 읽기 타임아웃 (초). 코드 생성 요청은 수십 초 소요 가능 */
+    private int readTimeoutSeconds;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
+    }
+
+    public int getMaxTokens() {
+        return maxTokens;
+    }
+
+    public void setMaxTokens(int maxTokens) {
+        this.maxTokens = maxTokens;
+    }
+
+    public int getConnectTimeoutSeconds() {
+        return connectTimeoutSeconds;
+    }
+
+    public void setConnectTimeoutSeconds(int connectTimeoutSeconds) {
+        this.connectTimeoutSeconds = connectTimeoutSeconds;
+    }
+
+    public int getReadTimeoutSeconds() {
+        return readTimeoutSeconds;
+    }
+
+    public void setReadTimeoutSeconds(int readTimeoutSeconds) {
+        this.readTimeoutSeconds = readTimeoutSeconds;
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/ai/prompt/PromptBuilder.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/ai/prompt/PromptBuilder.java
@@ -1,0 +1,78 @@
+package com.example.admin_demo.domain.reactgenerate.ai.prompt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Claude API에 전달할 system prompt와 user prompt를 조립하는 컴포넌트.
+ *
+ * <p>PromptLoader에서 읽은 각 마크다운 섹션을 구분자(---)와 헤더로 연결하여
+ * Claude가 컨텍스트를 명확히 구분할 수 있는 단일 문자열로 반환한다.
+ *
+ * <p>섹션 조립 순서: 역할 정의 → CLAUDE.md → component-types → design-tokens → component-map
+ */
+@Component
+@RequiredArgsConstructor
+public class PromptBuilder {
+
+    private final PromptLoader promptLoader;
+
+    /**
+     * Claude API의 system 필드에 전달할 프롬프트를 생성한다.
+     *
+     * <p>비어있는 섹션은 건너뛰므로, prompts/ 파일 일부가 없어도 동작한다.
+     *
+     * @return 섹션이 조합된 system prompt 문자열
+     */
+    public String buildSystemPrompt() {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("당신은 Figma 디자인을 React 컴포넌트로 변환하는 전문가입니다.\n");
+        sb.append("반드시 아래에 제공된 컴포넌트 라이브러리만 사용하여 코드를 생성하세요.\n");
+        sb.append("목록에 없는 컴포넌트를 임의로 만들거나 외부 라이브러리를 추가하지 마세요.\n");
+
+        appendSection(sb, "CLAUDE.md (컴포넌트 라이브러리 가이드)", promptLoader.loadClaudeMd());
+        appendSection(sb, "Component Library (사용 가능한 컴포넌트 인터페이스)", promptLoader.loadComponentTypes());
+        appendSection(sb, "Design Tokens (CSS 변수 레퍼런스 — 하드코딩 금지)", promptLoader.loadDesignTokens());
+        appendSection(sb, "Component Map (Figma → React 매핑 전략)", promptLoader.loadComponentMap());
+
+        return sb.toString();
+    }
+
+    /**
+     * Claude API의 messages[0].content 필드에 전달할 user prompt를 생성한다.
+     *
+     * @param figmaUrl     생성 기준이 되는 Figma 화면 URL
+     * @param requirements 추가 요구사항 (빈 문자열 허용)
+     * @return user prompt 문자열
+     */
+    public String buildUserPrompt(String figmaUrl, String requirements) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("Generate a React component from the following Figma design.\n\n");
+        sb.append("Figma URL: ").append(figmaUrl).append("\n\n");
+
+        if (requirements != null && !requirements.isBlank()) {
+            sb.append("Requirements:\n").append(requirements).append("\n\n");
+        }
+
+        sb.append("Rules:\n");
+        sb.append("- 반드시 위 컴포넌트 라이브러리의 컴포넌트만 사용할 것\n");
+        sb.append("- 디자인 토큰(CSS 변수)을 활용하고 하드코딩 금지\n");
+        sb.append("- TypeScript로 작성하고 props interface를 포함할 것\n");
+        sb.append("- 접근성(aria 속성)을 고려할 것\n");
+        sb.append("- 응답은 ```tsx ... ``` 코드 블록 하나로만 작성할 것\n");
+
+        return sb.toString();
+    }
+
+    /**
+     * 섹션 내용이 있을 때만 헤더와 구분자를 붙여 StringBuilder에 추가한다.
+     * 빈 섹션은 system prompt에 불필요한 헤더가 노출되지 않도록 건너뜀.
+     */
+    private void appendSection(StringBuilder sb, String header, String content) {
+        if (content == null || content.isBlank()) return;
+        sb.append("\n\n--- ").append(header).append(" ---\n\n");
+        sb.append(content);
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/ai/prompt/PromptBuilder.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/ai/prompt/PromptBuilder.java
@@ -1,5 +1,8 @@
 package com.example.admin_demo.domain.reactgenerate.ai.prompt;
 
+import com.example.admin_demo.domain.reactgenerate.figma.FigmaDesignContext;
+import com.example.admin_demo.domain.reactgenerate.figma.FigmaNodeSummary;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -10,6 +13,9 @@ import org.springframework.stereotype.Component;
  * Claude가 컨텍스트를 명확히 구분할 수 있는 단일 문자열로 반환한다.
  *
  * <p>섹션 조립 순서: 역할 정의 → CLAUDE.md → component-types → design-tokens → component-map
+ *
+ * <p>user prompt에는 Figma URL 텍스트 대신 {@link FigmaDesignContext}에서 추출한
+ * 구조화된 레이아웃·색상·텍스트 정보를 포함한다.
  */
 @Component
 @RequiredArgsConstructor
@@ -42,28 +48,193 @@ public class PromptBuilder {
     /**
      * Claude API의 messages[0].content 필드에 전달할 user prompt를 생성한다.
      *
-     * @param figmaUrl     생성 기준이 되는 Figma 화면 URL
+     * <p>Figma URL 텍스트 대신 {@link FigmaDesignContext}의 구조화된 정보(크기, 레이아웃,
+     * 색상, 텍스트)를 ASCII 트리 형태로 포함하여 Claude의 코드 생성 정확도를 높인다.
+     *
+     * @param context      Figma API에서 추출한 디자인 컨텍스트
      * @param requirements 추가 요구사항 (빈 문자열 허용)
      * @return user prompt 문자열
      */
-    public String buildUserPrompt(String figmaUrl, String requirements) {
+    public String buildUserPrompt(FigmaDesignContext context, String requirements) {
         StringBuilder sb = new StringBuilder();
 
         sb.append("Generate a React component from the following Figma design.\n\n");
-        sb.append("Figma URL: ").append(figmaUrl).append("\n\n");
 
-        if (requirements != null && !requirements.isBlank()) {
-            sb.append("Requirements:\n").append(requirements).append("\n\n");
+        // Figma 디자인 컨텍스트 섹션
+        sb.append("## Figma Design Context\n");
+        sb.append("Component: ")
+                .append(context.getComponentName())
+                .append(" (")
+                .append(context.getComponentType())
+                .append(")\n");
+        sb.append("Canvas Size: ")
+                .append(context.getWidth())
+                .append(" × ")
+                .append(context.getHeight())
+                .append(" px\n");
+        sb.append("Layout: ")
+                .append(describeLayoutMode(context.getLayoutMode()))
+                .append("\n");
+        sb.append("Figma URL: ").append(context.getFigmaUrl()).append("\n");
+
+        // 하위 노드 트리 섹션
+        if (context.getChildren() != null && !context.getChildren().isEmpty()) {
+            sb.append("\n## Element Tree\n");
+            sb.append(formatNodeLine(
+                            context.getComponentName(),
+                            context.getComponentType(),
+                            context.getWidth(),
+                            context.getHeight(),
+                            context.getLayoutMode(),
+                            null,
+                            null,
+                            null))
+                    .append("\n");
+            formatNodes(sb, context.getChildren(), "");
         }
 
-        sb.append("Rules:\n");
+        // 추가 요구사항 섹션
+        if (requirements != null && !requirements.isBlank()) {
+            sb.append("\n## Additional Requirements\n").append(requirements).append("\n");
+        }
+
+        sb.append("\n## Rules\n");
         sb.append("- 반드시 위 컴포넌트 라이브러리의 컴포넌트만 사용할 것\n");
-        sb.append("- 디자인 토큰(CSS 변수)을 활용하고 하드코딩 금지\n");
+        sb.append("- 디자인 토큰(CSS 변수)을 활용하고 색상·크기 하드코딩 금지\n");
         sb.append("- TypeScript로 작성하고 props interface를 포함할 것\n");
         sb.append("- 접근성(aria 속성)을 고려할 것\n");
         sb.append("- 응답은 ```tsx ... ``` 코드 블록 하나로만 작성할 것\n");
 
         return sb.toString();
+    }
+
+    /**
+     * 하위 노드 목록을 ASCII 트리 형태로 재귀 출력한다.
+     *
+     * @param sb      결과를 추가할 StringBuilder
+     * @param nodes   출력할 노드 목록
+     * @param indent  현재 들여쓰기 문자열 (│ 또는 공백)
+     */
+    private void formatNodes(StringBuilder sb, List<FigmaNodeSummary> nodes, String indent) {
+        if (nodes == null || nodes.isEmpty()) return;
+
+        for (int i = 0; i < nodes.size(); i++) {
+            boolean last = i == nodes.size() - 1;
+            FigmaNodeSummary node = nodes.get(i);
+
+            // 마지막 노드는 └─, 그 외는 ├─ 사용
+            String connector = last ? "└─ " : "├─ ";
+            // 자식 들여쓰기: 마지막이면 공백, 아니면 │로 연결
+            String childIndent = indent + (last ? "   " : "│  ");
+
+            sb.append(indent)
+                    .append(connector)
+                    .append(formatNodeLine(
+                            node.getName(),
+                            node.getType(),
+                            node.getWidth(),
+                            node.getHeight(),
+                            node.getLayoutMode(),
+                            node.getFillColor(),
+                            node.getText(),
+                            hasPadding(node) ? formatPadding(node) : null))
+                    .append("\n");
+
+            formatNodes(sb, node.getChildren(), childIndent);
+        }
+    }
+
+    /**
+     * 단일 노드를 한 줄 문자열로 표현한다.
+     *
+     * <p>출력 예시: {@code [FRAME] Card (360×120px, VERTICAL, gap:8px, padding:16/16/16/16) | fill: #FFFFFF}
+     */
+    private String formatNodeLine(
+            String name,
+            String type,
+            int width,
+            int height,
+            String layoutMode,
+            String fillColor,
+            String text,
+            String padding) {
+        StringBuilder line = new StringBuilder();
+        line.append("[").append(type).append("] ").append(name);
+
+        // 크기 정보
+        if (width > 0 || height > 0) {
+            line.append(" (").append(width).append("×").append(height).append("px");
+
+            // Auto Layout 정보
+            if (layoutMode != null && !"NONE".equals(layoutMode)) {
+                line.append(", ").append(layoutMode);
+            }
+
+            // 패딩·간격 정보 (있는 경우만)
+            if (padding != null) {
+                line.append(", ").append(padding);
+            }
+
+            line.append(")");
+        }
+
+        // 채우기 색상
+        if (fillColor != null) {
+            line.append(" | fill: ").append(fillColor);
+        }
+
+        // 텍스트 내용 (50자 초과 시 말줄임)
+        if (text != null && !text.isBlank()) {
+            String truncated = text.length() > 50 ? text.substring(0, 50) + "…" : text;
+            line.append(" | text: \"").append(truncated).append("\"");
+        }
+
+        return line.toString();
+    }
+
+    /** 노드에 패딩 값이 하나라도 있는지 확인한다. */
+    private boolean hasPadding(FigmaNodeSummary node) {
+        return node.getPaddingTop() > 0
+                || node.getPaddingRight() > 0
+                || node.getPaddingBottom() > 0
+                || node.getPaddingLeft() > 0
+                || node.getGap() > 0;
+    }
+
+    /** 패딩·간격 정보를 {@code padding:top/right/bottom/left, gap:Npx} 형식으로 반환한다. */
+    private String formatPadding(FigmaNodeSummary node) {
+        StringBuilder sb = new StringBuilder();
+        if (node.getPaddingTop() > 0
+                || node.getPaddingRight() > 0
+                || node.getPaddingBottom() > 0
+                || node.getPaddingLeft() > 0) {
+            sb.append("padding:")
+                    .append(node.getPaddingTop())
+                    .append("/")
+                    .append(node.getPaddingRight())
+                    .append("/")
+                    .append(node.getPaddingBottom())
+                    .append("/")
+                    .append(node.getPaddingLeft());
+        }
+        if (node.getGap() > 0) {
+            if (sb.length() > 0) sb.append(", ");
+            sb.append("gap:").append(node.getGap()).append("px");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Figma layoutMode 값을 사람이 읽기 쉬운 설명으로 변환한다.
+     *
+     * @param layoutMode Figma API의 layoutMode 값 (NONE, HORIZONTAL, VERTICAL 또는 null)
+     * @return 설명 문자열
+     */
+    private String describeLayoutMode(String layoutMode) {
+        if (layoutMode == null || "NONE".equals(layoutMode)) return "NONE (고정 레이아웃)";
+        if ("HORIZONTAL".equals(layoutMode)) return "HORIZONTAL (Flex Row)";
+        if ("VERTICAL".equals(layoutMode)) return "VERTICAL (Flex Column)";
+        return layoutMode;
     }
 
     /**

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/ai/prompt/PromptLoader.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/ai/prompt/PromptLoader.java
@@ -1,0 +1,86 @@
+package com.example.admin_demo.domain.reactgenerate.ai.prompt;
+
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StreamUtils;
+
+/**
+ * Claude API system prompt에 포함할 마크다운 파일을 로드하는 컴포넌트.
+ *
+ * <p>파일은 classpath:prompts/ 디렉토리에서 읽으며, 애플리케이션 시작 시 한 번만 로드하여
+ * 메모리에 캐싱한다. 파일이 없을 경우 빈 문자열을 반환하여 누락 파일로 인한 기동 실패를 방지한다.
+ *
+ * <p>파일 배치 경로: src/main/resources/prompts/
+ * <ul>
+ *   <li>CLAUDE.md — reactive-springware 컴포넌트 라이브러리 가이드</li>
+ *   <li>component-types.md — 컴포넌트 TypeScript 인터페이스 레퍼런스</li>
+ *   <li>design-tokens.md — CSS 변수 토큰 레퍼런스</li>
+ *   <li>component-map.md — Figma → React 매핑 전략</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+public class PromptLoader {
+
+    private String claudeMd = "";
+    private String componentTypes = "";
+    private String designTokens = "";
+    private String componentMap = "";
+
+    /**
+     * 애플리케이션 시작 시 prompts/ 디렉토리의 모든 파일을 메모리에 로드한다.
+     * 파일이 없으면 경고 로그만 남기고 빈 문자열로 처리(graceful degradation).
+     */
+    @PostConstruct
+    public void load() {
+        claudeMd = readOrEmpty("prompts/CLAUDE.md");
+        componentTypes = readOrEmpty("prompts/component-types.md");
+        designTokens = readOrEmpty("prompts/design-tokens.md");
+        componentMap = readOrEmpty("prompts/component-map.md");
+
+        log.info(
+                "PromptLoader 초기화 완료 — CLAUDE.md={}자, component-types={}자, design-tokens={}자, component-map={}자",
+                claudeMd.length(),
+                componentTypes.length(),
+                designTokens.length(),
+                componentMap.length());
+    }
+
+    public String loadClaudeMd() {
+        return claudeMd;
+    }
+
+    public String loadComponentTypes() {
+        return componentTypes;
+    }
+
+    public String loadDesignTokens() {
+        return designTokens;
+    }
+
+    public String loadComponentMap() {
+        return componentMap;
+    }
+
+    /**
+     * classpath 리소스를 UTF-8 문자열로 읽는다.
+     * 파일이 존재하지 않거나 읽기 실패 시 빈 문자열을 반환한다.
+     */
+    private String readOrEmpty(String path) {
+        ClassPathResource resource = new ClassPathResource(path);
+        if (!resource.exists()) {
+            log.warn("프롬프트 파일 없음 (건너뜀): {}", path);
+            return "";
+        }
+        try {
+            return StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            log.error("프롬프트 파일 읽기 실패: {}", path, e);
+            return "";
+        }
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/controller/ReactGenerateController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/controller/ReactGenerateController.java
@@ -1,0 +1,44 @@
+package com.example.admin_demo.domain.reactgenerate.controller;
+
+import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateApprovalResponse;
+import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateRequest;
+import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateResponse;
+import com.example.admin_demo.domain.reactgenerate.service.ReactGenerateService;
+import com.example.admin_demo.global.dto.ApiResponse;
+import com.example.admin_demo.global.util.SecurityUtil;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/react-generate")
+@RequiredArgsConstructor
+@PreAuthorize("hasAuthority('REACT_GENERATE:R')")
+public class ReactGenerateController {
+
+    private final ReactGenerateService reactGenerateService;
+
+    @PostMapping("/generate")
+    @PreAuthorize("hasAuthority('REACT_GENERATE:W')")
+    public ResponseEntity<ApiResponse<ReactGenerateResponse>> generate(
+            @Valid @RequestBody ReactGenerateRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(reactGenerateService.generate(request)));
+    }
+
+    @PostMapping("/{id}/request-approval")
+    @PreAuthorize("hasAuthority('REACT_GENERATE:W')")
+    public ResponseEntity<ApiResponse<ReactGenerateApprovalResponse>> requestApproval(@PathVariable String id) {
+        return ResponseEntity.ok(ApiResponse.success(reactGenerateService.requestApproval(id)));
+    }
+
+    @PostMapping("/{id}/approve")
+    @PreAuthorize("hasAuthority('REACT_GENERATE:W')")
+    public ResponseEntity<ApiResponse<ReactGenerateApprovalResponse>> approve(@PathVariable String id) {
+        String currentUserId = SecurityUtil.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(reactGenerateService.approve(id, currentUserId)));
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/controller/ReactGenerateController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/controller/ReactGenerateController.java
@@ -26,7 +26,8 @@ public class ReactGenerateController {
     @PreAuthorize("hasAuthority('REACT_GENERATE:W')")
     public ResponseEntity<ApiResponse<ReactGenerateResponse>> generate(
             @Valid @RequestBody ReactGenerateRequest request) {
-        return ResponseEntity.ok(ApiResponse.success(reactGenerateService.generate(request)));
+        String currentUserId = SecurityUtil.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(reactGenerateService.generate(request, currentUserId)));
     }
 
     @PostMapping("/{id}/request-approval")

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactGenerateApprovalResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactGenerateApprovalResponse.java
@@ -1,0 +1,18 @@
+package com.example.admin_demo.domain.reactgenerate.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReactGenerateApprovalResponse {
+
+    private String id;
+    private String status;
+    private String approvedBy;
+    private String approvedAt;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactGenerateRequest.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactGenerateRequest.java
@@ -1,0 +1,17 @@
+package com.example.admin_demo.domain.reactgenerate.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReactGenerateRequest {
+
+    @NotBlank(message = "Figma URL을 입력해주세요.")
+    private String figmaUrl;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactGenerateRequest.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactGenerateRequest.java
@@ -14,4 +14,7 @@ public class ReactGenerateRequest {
 
     @NotBlank(message = "Figma URL을 입력해주세요.")
     private String figmaUrl;
+
+    /** 추가 요구사항. 생략 가능하며 미입력 시 기본 규칙만 적용. */
+    private String requirements;
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactGenerateResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactGenerateResponse.java
@@ -1,0 +1,20 @@
+package com.example.admin_demo.domain.reactgenerate.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReactGenerateResponse {
+
+    private String id;
+    private String figmaUrl;
+    private String reactCode;
+    private String previewHtml;
+    private String status;
+    private String createdAt;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/enums/ReactGenerateStatus.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/enums/ReactGenerateStatus.java
@@ -1,0 +1,7 @@
+package com.example.admin_demo.domain.reactgenerate.enums;
+
+public enum ReactGenerateStatus {
+    GENERATED,
+    PENDING_APPROVAL,
+    APPROVED
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/enums/ReactGenerateStatus.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/enums/ReactGenerateStatus.java
@@ -1,7 +1,8 @@
 package com.example.admin_demo.domain.reactgenerate.enums;
 
 public enum ReactGenerateStatus {
-    GENERATED,
-    PENDING_APPROVAL,
-    APPROVED
+    GENERATED, // 코드 생성 완료, 아직 승인 요청 전
+    PENDING_APPROVAL, // 승인 요청됨, 관리자 검토 대기
+    APPROVED, // 승인 완료
+    REJECTED // 반려
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/figma/FigmaApiClient.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/figma/FigmaApiClient.java
@@ -1,0 +1,101 @@
+package com.example.admin_demo.domain.reactgenerate.figma;
+
+import com.example.admin_demo.global.exception.InternalException;
+import com.example.admin_demo.global.exception.NotFoundException;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Figma REST API를 호출하여 노드 디자인 정보를 가져오는 클라이언트.
+ *
+ * <p>호출 엔드포인트: {@code GET /v1/files/{fileKey}/nodes?ids={nodeId}}
+ *
+ * <p>인증은 {@code X-Figma-Token} 헤더로 Personal Access Token을 전달한다.
+ * 토큰은 {@link FigmaApiProperties}를 통해 환경변수({@code FIGMA_ACCESS_TOKEN})에서 주입된다.
+ *
+ * <p>HTTP 오류 처리:
+ * <ul>
+ *   <li>401/403: 인증 실패 → {@link InternalException}</li>
+ *   <li>404: 파일·노드 없음 또는 접근 권한 없음 → {@link NotFoundException}</li>
+ *   <li>기타: {@link InternalException}</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+@EnableConfigurationProperties(FigmaApiProperties.class)
+public class FigmaApiClient {
+
+    /** Figma 노드 조회 URL 경로 템플릿. props.getUrl()과 연결하여 사용한다.
+     * base URL을 URI 템플릿 변수로 전달하면 RestTemplate이 URL-인코딩하여 무효한 URL이 생성되므로,
+     * 문자열 연결로 처리하고 path/query 변수만 URI 템플릿으로 사용한다. */
+    private static final String NODES_PATH = "/v1/files/{fileKey}/nodes?ids={nodeId}";
+
+    private final RestTemplate restTemplate;
+    private final FigmaApiProperties props;
+
+    public FigmaApiClient(RestTemplateBuilder builder, FigmaApiProperties props) {
+        this.props = props;
+        // Figma API 전용 타임아웃 설정 (전역 RestTemplate과 독립적으로 구성)
+        this.restTemplate = builder.connectTimeout(Duration.ofSeconds(props.getConnectTimeoutSeconds()))
+                .readTimeout(Duration.ofSeconds(props.getReadTimeoutSeconds()))
+                .build();
+    }
+
+    /**
+     * 지정한 fileKey와 nodeId에 해당하는 Figma 노드 데이터를 조회한다.
+     *
+     * @param fileKey Figma 파일 식별자 (URL 경로 세그먼트)
+     * @param nodeId  조회할 노드 ID (Figma API 형식: {@code pageId:nodeId})
+     * @return Figma API 응답 (노드 트리 포함)
+     * @throws NotFoundException  파일 또는 노드를 찾을 수 없거나 접근 권한이 없을 때
+     * @throws InternalException  인증 실패 또는 네트워크 오류 등 내부 오류 시
+     */
+    public FigmaNodeResponse getNode(String fileKey, String nodeId) {
+        log.info("Figma API 호출 — fileKey: {}, nodeId: {}", fileKey, nodeId);
+
+        // base URL을 URI 템플릿 변수로 넘기면 RestTemplate이 URL-인코딩하므로 문자열 연결로 처리
+        String url = props.getUrl() + NODES_PATH;
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-Figma-Token", props.getToken());
+
+        try {
+            ResponseEntity<FigmaNodeResponse> response = restTemplate.exchange(
+                    url, HttpMethod.GET, new HttpEntity<>(headers), FigmaNodeResponse.class, fileKey, nodeId);
+
+            FigmaNodeResponse body = response.getBody();
+            log.info(
+                    "Figma API 응답 수신 — 노드 수: {}",
+                    body != null && body.getNodes() != null ? body.getNodes().size() : 0);
+            return body;
+
+        } catch (HttpClientErrorException e) {
+            int status = e.getStatusCode().value();
+            if (status == 401 || status == 403) {
+                log.error("Figma API 인증 실패 — status: {}", status);
+                throw new InternalException("Figma API 인증에 실패했습니다. FIGMA_ACCESS_TOKEN을 확인하세요.");
+            }
+            if (status == 404) {
+                log.warn("Figma 파일·노드 없음 — fileKey: {}, nodeId: {}", fileKey, nodeId);
+                // 404는 파일이 없거나 토큰 권한이 해당 파일에 없을 때도 발생
+                throw new NotFoundException("Figma 파일 또는 노드를 찾을 수 없습니다. URL과 접근 권한을 확인하세요. (fileKey=" + fileKey + ")");
+            }
+            log.error("Figma API 오류 — status: {}", status, e);
+            throw new InternalException("Figma API 호출 중 오류가 발생했습니다. (HTTP " + status + ")");
+
+        } catch (RestClientException e) {
+            log.error("Figma API 네트워크 오류", e);
+            throw new InternalException("Figma API에 연결할 수 없습니다. 네트워크 상태를 확인하세요.");
+        }
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/figma/FigmaApiProperties.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/figma/FigmaApiProperties.java
@@ -1,0 +1,63 @@
+package com.example.admin_demo.domain.reactgenerate.figma;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * application.yml의 figma.api.* 설정을 바인딩하는 프로퍼티 클래스.
+ *
+ * <pre>{@code
+ * figma:
+ *   api:
+ *     url: https://api.figma.com
+ *     token: ${FIGMA_ACCESS_TOKEN}
+ *     connect-timeout-seconds: 10
+ *     read-timeout-seconds: 30
+ * }</pre>
+ */
+@ConfigurationProperties(prefix = "figma.api")
+public class FigmaApiProperties {
+
+    /** Figma REST API 베이스 URL */
+    private String url;
+
+    /** Personal Access Token. 반드시 환경변수(FIGMA_ACCESS_TOKEN)로 주입 */
+    private String token;
+
+    /** 연결 타임아웃 (초) */
+    private int connectTimeoutSeconds;
+
+    /** 읽기 타임아웃 (초) */
+    private int readTimeoutSeconds;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public int getConnectTimeoutSeconds() {
+        return connectTimeoutSeconds;
+    }
+
+    public void setConnectTimeoutSeconds(int connectTimeoutSeconds) {
+        this.connectTimeoutSeconds = connectTimeoutSeconds;
+    }
+
+    public int getReadTimeoutSeconds() {
+        return readTimeoutSeconds;
+    }
+
+    public void setReadTimeoutSeconds(int readTimeoutSeconds) {
+        this.readTimeoutSeconds = readTimeoutSeconds;
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/figma/FigmaDesignContext.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/figma/FigmaDesignContext.java
@@ -1,0 +1,41 @@
+package com.example.admin_demo.domain.reactgenerate.figma;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Figma 노드에서 추출한 디자인 컨텍스트.
+ *
+ * <p>Claude API user prompt 구성 시 Figma URL 텍스트 대신 이 클래스의 구조화된 정보를 사용한다.
+ * {@link FigmaDesignExtractor}가 {@link FigmaNodeResponse}를 이 클래스로 변환한다.
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FigmaDesignContext {
+
+    /** 원본 Figma URL (참조용) */
+    private String figmaUrl;
+
+    /** 루트 노드의 Figma 레이어 이름 */
+    private String componentName;
+
+    /** 루트 노드 타입 (FRAME, COMPONENT 등) */
+    private String componentType;
+
+    /** 루트 노드 너비 (px) */
+    private int width;
+
+    /** 루트 노드 높이 (px) */
+    private int height;
+
+    /** 루트 노드의 Auto Layout 방향: NONE, HORIZONTAL, VERTICAL */
+    private String layoutMode;
+
+    /** 하위 노드 요약 목록 (깊이 제한 적용) */
+    private List<FigmaNodeSummary> children;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/figma/FigmaDesignExtractor.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/figma/FigmaDesignExtractor.java
@@ -1,0 +1,167 @@
+package com.example.admin_demo.domain.reactgenerate.figma;
+
+import com.example.admin_demo.global.exception.NotFoundException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Figma API 원시 응답({@link FigmaNodeResponse})을 Claude 프롬프트용 컨텍스트({@link FigmaDesignContext})로 변환하는 컴포넌트.
+ *
+ * <p>변환 시 다음을 수행한다:
+ * <ul>
+ *   <li>루트 노드의 크기·타입·레이아웃 정보 추출</li>
+ *   <li>하위 노드를 {@code MAX_DEPTH}까지 재귀 탐색하여 {@link FigmaNodeSummary} 생성</li>
+ *   <li>SOLID 채우기 색상을 HEX 문자열로 변환 (Figma RGBA 0.0~1.0 → #RRGGBB)</li>
+ *   <li>TEXT 노드의 텍스트 내용 추출</li>
+ * </ul>
+ *
+ * <p>깊이 제한은 토큰 비용을 줄이고 Claude에게 핵심 구조만 전달하기 위해 적용한다.
+ */
+@Slf4j
+@Component
+public class FigmaDesignExtractor {
+
+    /** 노드 트리 탐색 최대 깊이. 루트는 0, 직계 자식은 1 */
+    private static final int MAX_DEPTH = 4;
+
+    /**
+     * Figma API 응답에서 디자인 컨텍스트를 추출한다.
+     *
+     * @param response Figma API {@code /v1/files/{fileKey}/nodes} 응답
+     * @param nodeId   요청한 노드 ID (API 형식: {@code pageId:nodeId})
+     * @param figmaUrl 원본 Figma URL (참조용으로 컨텍스트에 포함)
+     * @return Claude 프롬프트 생성에 사용할 디자인 컨텍스트
+     * @throws NotFoundException 응답에서 해당 노드를 찾을 수 없을 때
+     */
+    public FigmaDesignContext extract(FigmaNodeResponse response, String nodeId, String figmaUrl) {
+        FigmaNode root = findRootNode(response, nodeId);
+
+        log.debug(
+                "Figma 노드 추출 — name: {}, type: {}, children: {}개",
+                root.getName(),
+                root.getType(),
+                root.getChildren() == null ? 0 : root.getChildren().size());
+
+        return FigmaDesignContext.builder()
+                .figmaUrl(figmaUrl)
+                .componentName(root.getName())
+                .componentType(root.getType())
+                .width(toInt(
+                        root.getAbsoluteBoundingBox() != null
+                                ? root.getAbsoluteBoundingBox().getWidth()
+                                : 0))
+                .height(toInt(
+                        root.getAbsoluteBoundingBox() != null
+                                ? root.getAbsoluteBoundingBox().getHeight()
+                                : 0))
+                .layoutMode(root.getLayoutMode())
+                .children(extractChildren(root.getChildren(), 1))
+                .build();
+    }
+
+    /**
+     * 응답의 nodes 맵에서 루트 노드를 찾는다.
+     *
+     * <p>요청한 nodeId로 직접 조회를 시도하고, 없으면 맵의 첫 번째 값을 폴백으로 사용한다.
+     * API를 단일 nodeId로 요청했으므로 폴백 시에도 원하는 노드를 가져온다.
+     */
+    private FigmaNode findRootNode(FigmaNodeResponse response, String nodeId) {
+        if (response.getNodes() == null || response.getNodes().isEmpty()) {
+            throw new NotFoundException("Figma API 응답에 노드 데이터가 없습니다.");
+        }
+
+        FigmaNodeResponse.NodeWrapper wrapper = response.getNodes().get(nodeId);
+        if (wrapper == null) {
+            // 키 형식 불일치 대비 폴백: 단일 nodeId 요청이므로 첫 번째 값이 대상 노드
+            wrapper = response.getNodes().values().stream()
+                    .findFirst()
+                    .orElseThrow(() -> new NotFoundException("Figma API 응답에서 노드를 찾을 수 없습니다: nodeId=" + nodeId));
+            log.warn("nodeId 직접 조회 실패({}), 첫 번째 노드로 폴백합니다.", nodeId);
+        }
+
+        if (wrapper.getDocument() == null) {
+            throw new NotFoundException("Figma 노드 document가 비어있습니다: nodeId=" + nodeId);
+        }
+
+        return wrapper.getDocument();
+    }
+
+    /**
+     * 하위 노드 목록을 재귀적으로 탐색하여 {@link FigmaNodeSummary} 목록으로 변환한다.
+     *
+     * @param nodes 변환할 노드 목록
+     * @param depth 현재 탐색 깊이 (MAX_DEPTH 초과 시 빈 목록 반환)
+     */
+    private List<FigmaNodeSummary> extractChildren(List<FigmaNode> nodes, int depth) {
+        if (nodes == null || nodes.isEmpty() || depth > MAX_DEPTH) {
+            return Collections.emptyList();
+        }
+        return nodes.stream().map(node -> toSummary(node, depth)).collect(Collectors.toList());
+    }
+
+    /** 단일 {@link FigmaNode}를 {@link FigmaNodeSummary}로 변환한다. */
+    private FigmaNodeSummary toSummary(FigmaNode node, int depth) {
+        return FigmaNodeSummary.builder()
+                .name(node.getName())
+                .type(node.getType())
+                .text(node.getCharacters())
+                .fillColor(extractFillColor(node.getFills()))
+                .width(toInt(
+                        node.getAbsoluteBoundingBox() != null
+                                ? node.getAbsoluteBoundingBox().getWidth()
+                                : 0))
+                .height(toInt(
+                        node.getAbsoluteBoundingBox() != null
+                                ? node.getAbsoluteBoundingBox().getHeight()
+                                : 0))
+                .layoutMode(node.getLayoutMode())
+                .paddingTop(toInt(node.getPaddingTop()))
+                .paddingRight(toInt(node.getPaddingRight()))
+                .paddingBottom(toInt(node.getPaddingBottom()))
+                .paddingLeft(toInt(node.getPaddingLeft()))
+                .gap(toInt(node.getItemSpacing()))
+                .children(extractChildren(node.getChildren(), depth + 1))
+                .build();
+    }
+
+    /**
+     * 채우기 목록에서 첫 번째 SOLID 타입의 색상을 HEX 문자열로 반환한다.
+     *
+     * @param fills Figma 채우기 목록
+     * @return HEX 색상 문자열 (예: {@code #1A2B3C}), SOLID 채우기가 없으면 null
+     */
+    private String extractFillColor(List<FigmaNode.Fill> fills) {
+        if (fills == null || fills.isEmpty()) return null;
+        return fills.stream()
+                .filter(f -> "SOLID".equals(f.getType()) && f.getColor() != null)
+                .findFirst()
+                .map(f -> toHex(f.getColor()))
+                .orElse(null);
+    }
+
+    /**
+     * Figma RGBA 색상(각 채널 0.0~1.0)을 HEX 문자열(#RRGGBB)로 변환한다.
+     *
+     * @param color Figma Color 객체
+     * @return HEX 색상 문자열 (예: {@code #FF5733})
+     */
+    private String toHex(FigmaNode.Color color) {
+        int r = Math.min(255, (int) Math.round(color.getR() * 255));
+        int g = Math.min(255, (int) Math.round(color.getG() * 255));
+        int b = Math.min(255, (int) Math.round(color.getB() * 255));
+        return String.format("#%02X%02X%02X", r, g, b);
+    }
+
+    /** Double 값을 int로 변환한다. null이면 0을 반환한다. */
+    private int toInt(Double value) {
+        return value == null ? 0 : (int) Math.round(value);
+    }
+
+    /** double 값을 int로 변환한다. */
+    private int toInt(double value) {
+        return (int) Math.round(value);
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/figma/FigmaNode.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/figma/FigmaNode.java
@@ -1,0 +1,103 @@
+package com.example.admin_demo.domain.reactgenerate.figma;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Figma REST API 응답의 노드(Node) 구조를 매핑하는 클래스.
+ *
+ * <p>Figma 노드는 재귀적 트리 구조를 가지며, children 필드를 통해 하위 노드를 포함한다.
+ * 알 수 없는 필드는 무시하여 API 응답 변경에 유연하게 대응한다.
+ *
+ * <p>주요 타입: FRAME, GROUP, COMPONENT, INSTANCE, TEXT, RECTANGLE, ELLIPSE, VECTOR
+ */
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FigmaNode {
+
+    /** 노드 고유 식별자 (예: "1:25") */
+    private String id;
+
+    /** Figma 레이어 패널에 표시되는 이름 */
+    private String name;
+
+    /** 노드 타입 (FRAME, TEXT, RECTANGLE, COMPONENT, INSTANCE 등) */
+    private String type;
+
+    /** 하위 노드 목록 (재귀 트리 구조) */
+    private List<FigmaNode> children;
+
+    /** 캔버스 기준 절대 좌표 및 크기 */
+    private BoundingBox absoluteBoundingBox;
+
+    /** 배경·채우기 스타일 목록 */
+    private List<Fill> fills;
+
+    /** Auto Layout 방향: NONE, HORIZONTAL, VERTICAL */
+    private String layoutMode;
+
+    /** Auto Layout 왼쪽 패딩 (px) */
+    private Double paddingLeft;
+
+    /** Auto Layout 오른쪽 패딩 (px) */
+    private Double paddingRight;
+
+    /** Auto Layout 위쪽 패딩 (px) */
+    private Double paddingTop;
+
+    /** Auto Layout 아래쪽 패딩 (px) */
+    private Double paddingBottom;
+
+    /** Auto Layout 자식 요소 간격 (gap, px) */
+    private Double itemSpacing;
+
+    /** 주축(Main Axis) 정렬: MIN, CENTER, MAX, SPACE_BETWEEN */
+    private String primaryAxisAlignItems;
+
+    /** 교차축(Cross Axis) 정렬: MIN, CENTER, MAX */
+    private String counterAxisAlignItems;
+
+    /** TEXT 노드의 실제 텍스트 내용 */
+    private String characters;
+
+    /** 노드의 절대 좌표 및 크기를 담는 중첩 클래스 */
+    @Getter
+    @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class BoundingBox {
+        private double x;
+        private double y;
+        private double width;
+        private double height;
+    }
+
+    /** 노드의 채우기(Fill) 스타일을 담는 중첩 클래스 */
+    @Getter
+    @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Fill {
+
+        /** 채우기 타입: SOLID, GRADIENT_LINEAR, GRADIENT_RADIAL, IMAGE 등 */
+        private String type;
+
+        /** SOLID 타입일 때의 RGBA 색상 (각 채널 0.0~1.0) */
+        private Color color;
+
+        /** 채우기 불투명도 (0.0~1.0, 없으면 1.0으로 간주) */
+        private Double opacity;
+    }
+
+    /** RGBA 색상 값을 담는 중첩 클래스 (각 채널 0.0~1.0) */
+    @Getter
+    @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Color {
+        private double r;
+        private double g;
+        private double b;
+        private double a;
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/figma/FigmaNodeResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/figma/FigmaNodeResponse.java
@@ -1,0 +1,45 @@
+package com.example.admin_demo.domain.reactgenerate.figma;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Figma REST API {@code GET /v1/files/{fileKey}/nodes} 응답을 매핑하는 클래스.
+ *
+ * <p>응답 최상위 구조:
+ * <pre>
+ * {
+ *   "name": "파일명",
+ *   "nodes": {
+ *     "{nodeId}": {
+ *       "document": { ... }
+ *     }
+ *   }
+ * }
+ * </pre>
+ *
+ * <p>{@code nodes} 맵의 키는 요청한 nodeId와 동일한 형식({@code pageId:nodeId})을 사용한다.
+ */
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FigmaNodeResponse {
+
+    /** 요청한 노드 ID → 노드 데이터 매핑 */
+    private Map<String, NodeWrapper> nodes;
+
+    /**
+     * 단일 노드에 대한 래퍼 객체.
+     * Figma API는 각 노드를 {@code document} 필드로 감싸서 반환한다.
+     */
+    @Getter
+    @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class NodeWrapper {
+
+        /** 실제 노드 데이터 (재귀 트리 구조) */
+        private FigmaNode document;
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/figma/FigmaNodeSummary.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/figma/FigmaNodeSummary.java
@@ -1,0 +1,60 @@
+package com.example.admin_demo.domain.reactgenerate.figma;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Figma 노드에서 Claude 프롬프트 생성에 필요한 정보만 추출한 요약 클래스.
+ *
+ * <p>{@link FigmaDesignExtractor}가 원시 {@link FigmaNode}를 이 클래스로 변환한다.
+ * 깊이 제한({@code MAX_DEPTH}) 이하의 노드만 포함하며,
+ * 채우기 색상은 HEX 문자열로 변환하여 담는다.
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FigmaNodeSummary {
+
+    /** Figma 레이어 이름 */
+    private String name;
+
+    /** 노드 타입 (FRAME, TEXT, RECTANGLE, INSTANCE 등) */
+    private String type;
+
+    /** TEXT 노드의 텍스트 내용. 비(非) TEXT 노드는 null */
+    private String text;
+
+    /** SOLID 채우기의 HEX 색상 (예: {@code #1A1A1A}). 없으면 null */
+    private String fillColor;
+
+    /** 노드 너비 (px) */
+    private int width;
+
+    /** 노드 높이 (px) */
+    private int height;
+
+    /** Auto Layout 방향: NONE, HORIZONTAL, VERTICAL. null이면 고정 레이아웃 */
+    private String layoutMode;
+
+    /** 위쪽 패딩 (px) */
+    private int paddingTop;
+
+    /** 오른쪽 패딩 (px) */
+    private int paddingRight;
+
+    /** 아래쪽 패딩 (px) */
+    private int paddingBottom;
+
+    /** 왼쪽 패딩 (px) */
+    private int paddingLeft;
+
+    /** 자식 요소 간격 (gap, px) */
+    private int gap;
+
+    /** 하위 노드 요약 목록 (깊이 제한 적용) */
+    private List<FigmaNodeSummary> children;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/figma/FigmaUrlParser.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/figma/FigmaUrlParser.java
@@ -1,0 +1,120 @@
+package com.example.admin_demo.domain.reactgenerate.figma;
+
+import com.example.admin_demo.global.exception.InvalidInputException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Figma URL에서 fileKey와 nodeId를 추출하는 파서.
+ *
+ * <p>지원 URL 형식:
+ * <ul>
+ *   <li>{@code https://www.figma.com/file/{fileKey}/{title}?node-id={nodeId}}</li>
+ *   <li>{@code https://www.figma.com/design/{fileKey}/{title}?node-id={nodeId}}</li>
+ *   <li>{@code https://www.figma.com/proto/{fileKey}/{title}?node-id={nodeId}}</li>
+ * </ul>
+ *
+ * <p>nodeId는 URL 형식에 따라 아래 두 가지로 인코딩될 수 있으며, 모두 API 형식({@code 1:2})으로 정규화한다:
+ * <ul>
+ *   <li>퍼센트 인코딩: {@code node-id=1%3A2} → {@code 1:2}</li>
+ *   <li>대시 구분자: {@code node-id=1-2} → {@code 1:2}</li>
+ * </ul>
+ */
+public final class FigmaUrlParser {
+
+    /** /file/, /design/, /proto/ 다음 경로 세그먼트를 fileKey로 추출 */
+    private static final Pattern FILE_KEY_PATTERN = Pattern.compile("/(?:file|design|proto)/([^/?#]+)");
+
+    private FigmaUrlParser() {}
+
+    /**
+     * Figma URL을 파싱하여 fileKey와 nodeId를 추출한다.
+     *
+     * @param figmaUrl 파싱할 Figma URL
+     * @return fileKey와 nodeId를 담은 파싱 결과
+     * @throws InvalidInputException URL이 유효하지 않거나 nodeId가 없을 경우
+     */
+    public static ParsedFigmaUrl parse(String figmaUrl) {
+        if (figmaUrl == null || figmaUrl.isBlank()) {
+            throw new InvalidInputException("Figma URL이 비어있습니다.");
+        }
+
+        Matcher matcher = FILE_KEY_PATTERN.matcher(figmaUrl);
+        if (!matcher.find()) {
+            throw new InvalidInputException("유효하지 않은 Figma URL입니다. /file/ 또는 /design/ 경로를 포함해야 합니다: " + figmaUrl);
+        }
+        String fileKey = matcher.group(1);
+
+        String rawNodeId = extractQueryParam(figmaUrl, "node-id");
+        if (rawNodeId == null || rawNodeId.isBlank()) {
+            throw new InvalidInputException("Figma URL에 node-id가 없습니다. 특정 프레임·컴포넌트를 선택한 공유 URL을 사용하세요.");
+        }
+
+        String nodeId = normalizeNodeId(rawNodeId);
+        return new ParsedFigmaUrl(fileKey, nodeId);
+    }
+
+    /**
+     * URL의 쿼리스트링에서 특정 파라미터 값을 추출한다.
+     *
+     * @param url   전체 URL 문자열
+     * @param param 추출할 파라미터 이름
+     * @return 파라미터 값, 없으면 null
+     */
+    private static String extractQueryParam(String url, String param) {
+        int queryStart = url.indexOf('?');
+        if (queryStart < 0) return null;
+
+        String query = url.substring(queryStart + 1);
+        // 프래그먼트(#) 이후 제거
+        int fragmentStart = query.indexOf('#');
+        if (fragmentStart >= 0) {
+            query = query.substring(0, fragmentStart);
+        }
+
+        for (String kv : query.split("&")) {
+            String[] parts = kv.split("=", 2);
+            if (parts.length == 2 && param.equals(parts[0])) {
+                return parts[1];
+            }
+        }
+        return null;
+    }
+
+    /**
+     * node-id 쿼리 파라미터 값을 Figma API 형식({@code 1:2})으로 정규화한다.
+     *
+     * <p>Figma 브라우저 URL은 nodeId 구분자로 '-'를 사용하지만,
+     * Figma REST API는 ':'를 사용한다. 퍼센트 인코딩된 경우도 처리한다.
+     *
+     * @param raw URL에서 추출한 raw node-id 값
+     * @return Figma API 호출에 사용할 nodeId (콜론 구분 형식)
+     */
+    private static String normalizeNodeId(String raw) {
+        // %3A → ':' 변환 (URL 퍼센트 인코딩 해제)
+        String decoded = URLDecoder.decode(raw, StandardCharsets.UTF_8);
+        // 이미 콜론 구분 형식이면 그대로 사용
+        if (decoded.contains(":")) {
+            return decoded;
+        }
+        // 브라우저 URL의 대시 구분 형식을 API 콜론 형식으로 변환
+        // nodeId는 항상 {정수}:{정수} 형태이므로 대시를 콜론으로 치환해도 안전
+        return decoded.replace("-", ":");
+    }
+
+    /** Figma URL 파싱 결과를 담는 값 객체 */
+    @Getter
+    @AllArgsConstructor
+    public static class ParsedFigmaUrl {
+
+        /** Figma 파일 식별자 (URL 경로의 fileKey 세그먼트) */
+        private final String fileKey;
+
+        /** Figma 노드 식별자 (API 형식: {@code pageId:nodeId}) */
+        private final String nodeId;
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/mapper/ReactGenerateMapper.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/mapper/ReactGenerateMapper.java
@@ -1,0 +1,36 @@
+package com.example.admin_demo.domain.reactgenerate.mapper;
+
+import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateResponse;
+import org.apache.ibatis.annotations.Param;
+
+/**
+ * REACT_GENERATE_HIS 테이블 Mapper.
+ * React 코드 생성 이력의 저장·조회·상태 변경을 담당한다.
+ *
+ * <p>Oracle {@code @MapperScan}("domain.**.mapper") 스캔 대상으로 등록되어
+ * Oracle datasource를 통해 REACT_GENERATE_HIS 테이블에 접근한다.
+ */
+public interface ReactGenerateMapper {
+
+    /** 생성된 React 코드 이력을 신규 저장한다. */
+    void insert(
+            @Param("id") String id,
+            @Param("figmaUrl") String figmaUrl,
+            @Param("requirements") String requirements,
+            @Param("systemPrompt") String systemPrompt,
+            @Param("userPrompt") String userPrompt,
+            @Param("reactCode") String reactCode,
+            @Param("previewHtml") String previewHtml,
+            @Param("createdBy") String createdBy,
+            @Param("createdAt") String createdAt);
+
+    /** ID로 생성 이력을 단건 조회한다. 존재하지 않으면 null 반환. */
+    ReactGenerateResponse selectById(@Param("id") String id);
+
+    /** 승인 상태를 변경한다. 승인·반려 시 approvedBy/approvedAt 함께 기록. */
+    void updateStatus(
+            @Param("id") String id,
+            @Param("status") String status,
+            @Param("approvedBy") String approvedBy,
+            @Param("approvedAt") String approvedAt);
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactGenerateService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactGenerateService.java
@@ -1,0 +1,128 @@
+package com.example.admin_demo.domain.reactgenerate.service;
+
+import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateApprovalResponse;
+import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateRequest;
+import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateResponse;
+import com.example.admin_demo.domain.reactgenerate.enums.ReactGenerateStatus;
+import com.example.admin_demo.global.exception.NotFoundException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReactGenerateService {
+
+    // TODO: DB 테이블 생성 후 Mapper로 교체
+    private final Map<String, ReactGenerateResponse> store = new ConcurrentHashMap<>();
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    public ReactGenerateResponse generate(ReactGenerateRequest request) {
+        log.info("React 코드 생성 요청 - figmaUrl: {}", request.getFigmaUrl());
+
+        String id = UUID.randomUUID().toString();
+        String now = LocalDateTime.now().format(FORMATTER);
+
+        // TODO: Figma API 연동 및 Claude API를 통한 실제 코드 생성 구현
+        String reactCode = buildPlaceholderCode(request.getFigmaUrl());
+        String previewHtml = buildPreviewHtml(request.getFigmaUrl());
+
+        ReactGenerateResponse response = ReactGenerateResponse.builder()
+                .id(id)
+                .figmaUrl(request.getFigmaUrl())
+                .reactCode(reactCode)
+                .previewHtml(previewHtml)
+                .status(ReactGenerateStatus.GENERATED.name())
+                .createdAt(now)
+                .build();
+
+        store.put(id, response);
+        return response;
+    }
+
+    public ReactGenerateApprovalResponse requestApproval(String id) {
+        ReactGenerateResponse item = findById(id);
+        item.setStatus(ReactGenerateStatus.PENDING_APPROVAL.name());
+        store.put(id, item);
+
+        log.info("승인 요청 - id: {}", id);
+        return ReactGenerateApprovalResponse.builder()
+                .id(id)
+                .status(ReactGenerateStatus.PENDING_APPROVAL.name())
+                .build();
+    }
+
+    public ReactGenerateApprovalResponse approve(String id, String approvedBy) {
+        ReactGenerateResponse item = findById(id);
+        item.setStatus(ReactGenerateStatus.APPROVED.name());
+        store.put(id, item);
+
+        String now = LocalDateTime.now().format(FORMATTER);
+        log.info("승인 완료 - id: {}, approvedBy: {}", id, approvedBy);
+
+        return ReactGenerateApprovalResponse.builder()
+                .id(id)
+                .status(ReactGenerateStatus.APPROVED.name())
+                .approvedBy(approvedBy)
+                .approvedAt(now)
+                .build();
+    }
+
+    private ReactGenerateResponse findById(String id) {
+        ReactGenerateResponse item = store.get(id);
+        if (item == null) {
+            throw new NotFoundException("생성 결과를 찾을 수 없습니다. id=" + id);
+        }
+        return item;
+    }
+
+    private String buildPlaceholderCode(String figmaUrl) {
+        return """
+                import React from 'react';
+
+                // TODO: Figma URL에서 생성된 컴포넌트
+                // Source: %s
+                const GeneratedComponent = () => {
+                  return (
+                    <div className="generated-component">
+                      <h2>Generated Component</h2>
+                      <p>Figma 디자인 기반으로 생성된 컴포넌트입니다.</p>
+                    </div>
+                  );
+                };
+
+                export default GeneratedComponent;
+                """
+                .formatted(figmaUrl);
+    }
+
+    private String buildPreviewHtml(String figmaUrl) {
+        return """
+                <!DOCTYPE html>
+                <html>
+                <head>
+                  <meta charset="UTF-8">
+                  <style>
+                    body { font-family: sans-serif; padding: 20px; }
+                    .generated-component { border: 1px dashed #ccc; padding: 20px; border-radius: 8px; }
+                  </style>
+                </head>
+                <body>
+                  <div class="generated-component">
+                    <h2>Generated Component</h2>
+                    <p>Figma 디자인 기반으로 생성된 컴포넌트입니다.</p>
+                    <small style="color:#999">Source: %s</small>
+                  </div>
+                </body>
+                </html>
+                """
+                .formatted(figmaUrl);
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactGenerateService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactGenerateService.java
@@ -6,6 +6,11 @@ import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateApprovalResp
 import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateRequest;
 import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateResponse;
 import com.example.admin_demo.domain.reactgenerate.enums.ReactGenerateStatus;
+import com.example.admin_demo.domain.reactgenerate.figma.FigmaApiClient;
+import com.example.admin_demo.domain.reactgenerate.figma.FigmaDesignContext;
+import com.example.admin_demo.domain.reactgenerate.figma.FigmaDesignExtractor;
+import com.example.admin_demo.domain.reactgenerate.figma.FigmaNodeResponse;
+import com.example.admin_demo.domain.reactgenerate.figma.FigmaUrlParser;
 import com.example.admin_demo.domain.reactgenerate.mapper.ReactGenerateMapper;
 import com.example.admin_demo.global.exception.NotFoundException;
 import java.time.LocalDateTime;
@@ -23,6 +28,8 @@ public class ReactGenerateService {
     private final ReactGenerateMapper reactGenerateMapper;
     private final PromptBuilder promptBuilder;
     private final ClaudeApiClient claudeApiClient;
+    private final FigmaApiClient figmaApiClient;
+    private final FigmaDesignExtractor figmaDesignExtractor;
 
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
 
@@ -36,30 +43,178 @@ public class ReactGenerateService {
     public ReactGenerateResponse generate(ReactGenerateRequest request, String createdBy) {
         log.info("React 코드 생성 요청 — figmaUrl: {}, userId: {}", request.getFigmaUrl(), createdBy);
 
-        // 1. system / user prompt 조립
+        // 1. Figma URL에서 fileKey, nodeId 파싱
+        FigmaUrlParser.ParsedFigmaUrl parsed = FigmaUrlParser.parse(request.getFigmaUrl());
+        log.info("Figma URL 파싱 완료 — fileKey: {}, nodeId: {}", parsed.getFileKey(), parsed.getNodeId());
+
+        // 2. Figma API 호출로 디자인 노드 데이터 수신
+        FigmaNodeResponse figmaNodeResponse = figmaApiClient.getNode(parsed.getFileKey(), parsed.getNodeId());
+
+        // 3. 원시 Figma 응답에서 Claude 프롬프트용 디자인 컨텍스트 추출
+        FigmaDesignContext designContext =
+                figmaDesignExtractor.extract(figmaNodeResponse, parsed.getNodeId(), request.getFigmaUrl());
+        log.info(
+                "Figma 디자인 추출 완료 — component: {} ({}), size: {}×{}",
+                designContext.getComponentName(),
+                designContext.getComponentType(),
+                designContext.getWidth(),
+                designContext.getHeight());
+
+        // 4. system / user prompt 조립 (Figma 디자인 컨텍스트 포함)
         String systemPrompt = promptBuilder.buildSystemPrompt();
-        String userPrompt = promptBuilder.buildUserPrompt(request.getFigmaUrl(), request.getRequirements());
+        String userPrompt = promptBuilder.buildUserPrompt(designContext, request.getRequirements());
 
-        // 2. Claude API 호출하여 React 코드 생성
-        String reactCode = claudeApiClient.generate(systemPrompt, userPrompt);
+        // 5. Claude API 호출하여 React 코드 생성
+        // TODO : 현재 Claude API 는 코드만 구현한 상태 (Claude API 확정 후, 위의 주석 제거 후 테스트 필요)
+//        String reactCode = claudeApiClient.generate(systemPrompt, userPrompt);
+        String reactCode = """
+                import React from "react";
+                import { Eye, EyeOff, KeyRound, Fingerprint, QrCode } from "lucide-react";
+                
+                import { BlankPageLayout } from "@cl/layout/BlankPageLayout";
+                import { AppBrandHeader } from "@cl/layout/AppBrandHeader";
+                import { Stack } from "@cl/layout/Stack";
+                import { Inline } from "@cl/layout/Inline";
+                import { Typography } from "@cl/core/Typography";
+                import { Input } from "@cl/core/Input";
+                import { Button } from "@cl/core/Button";
+                import { DividerWithLabel } from "@cl/modules/common/DividerWithLabel";
+                import { QuickMenuGrid } from "@cl/biz/common/QuickMenuGrid";
+                import type { LoginPageProps } from "./types";
+                
+                export type { LoginPageProps } from "./types";
+                
+                export function LoginPage({
+                  hasError = false,
+                  showPassword = false,
+                  onTogglePassword,
+                  onLogin,
+                }: LoginPageProps) {
+                  const ALT_LOGIN_ITEMS = [
+                    {
+                      id: "pin",
+                      icon: <KeyRound size={20} />,
+                      label: "간편 비밀번호",
+                      onClick: () => {},
+                    },
+                    {
+                      id: "bio",
+                      icon: <Fingerprint size={20} />,
+                      label: "생체인증",
+                      onClick: () => {},
+                    },
+                    {
+                      id: "qr",
+                      icon: <QrCode size={20} />,
+                      label: "QR 로그인",
+                      onClick: () => {},
+                    },
+                  ];
+                
+                  return (
+                    <BlankPageLayout>
+                      <AppBrandHeader brandInitial="H" brandName="하나카드" />
+                
+                      <Stack gap="md" className="px-standard pt-xl pb-md">
+                        <Stack gap="xs" className="pb-md">
+                          <Typography
+                            as="h1"
+                            variant="heading"
+                            color="heading"
+                            className="text-3xl"
+                          >
+                            로그인
+                          </Typography>
+                          <Typography variant="body" color="muted">
+                            하나카드에 오신 것을 환영합니다
+                          </Typography>
+                        </Stack>
+                
+                        <Stack gap="lg">
+                          <Input
+                            label="아이디"
+                            type="text"
+                            placeholder="아이디를 입력하세요"
+                            defaultValue="hanabank_user"
+                            fullWidth
+                          />
+                          <Input
+                            label="비밀번호"
+                            type={showPassword ? "text" : "password"}
+                            placeholder="비밀번호를 입력하세요"
+                            defaultValue="password123"
+                            fullWidth
+                            validationState={hasError ? "error" : "default"}
+                            helperText={
+                              hasError ? "아이디 또는 비밀번호가 틀렸습니다" : undefined
+                            }
+                            rightElement={
+                              <button
+                                type="button"
+                                onClick={onTogglePassword}
+                                aria-label={showPassword ? "비밀번호 숨김" : "비밀번호 표시"}
+                                className="text-text-muted"
+                              >
+                                {showPassword ? <Eye size={20} /> : <EyeOff size={20} />}
+                              </button>
+                            }
+                          />
+                        </Stack>
+                
+                        <Inline justify="center" gap="sm" className="py-sm">
+                          <Button variant="ghost" size="sm" onClick={() => {}}>
+                            아이디 찾기
+                          </Button>
+                          <div
+                            className="w-px h-3 bg-border-subtle self-center"
+                            aria-hidden="true"
+                          />
+                          <Button variant="ghost" size="sm" onClick={() => {}}>
+                            비밀번호 변경
+                          </Button>
+                          <div
+                            className="w-px h-3 bg-border-subtle self-center"
+                            aria-hidden="true"
+                          />
+                          <Button variant="ghost" size="sm" onClick={() => {}}>
+                            회원가입
+                          </Button>
+                        </Inline>
+                
+                        <div className="pt-md">
+                          <Button variant="primary" size="lg" fullWidth onClick={onLogin}>
+                            로그인
+                          </Button>
+                        </div>
+                      </Stack>
+                
+                      <Stack gap="xl" className="px-standard pb-2xl">
+                        <DividerWithLabel label="다른 로그인 방식" />
+                        <QuickMenuGrid cols={3} items={ALT_LOGIN_ITEMS} />
+                      </Stack>
+                    </BlankPageLayout>
+                  );
+                }
+                """;
 
-        // 3. 코드 기반 preview HTML 생성
+                // 6. 코드 기반 preview HTML 생성
         String previewHtml = buildPreviewHtml(reactCode, request.getFigmaUrl());
 
-        // 4. DB 저장 (초기 상태: GENERATED)
+        // 7. DB 저장 (초기 상태: GENERATED)
         String id = UUID.randomUUID().toString();
         String now = LocalDateTime.now().format(FORMATTER);
 
-        reactGenerateMapper.insert(
-                id,
-                request.getFigmaUrl(),
-                request.getRequirements(),
-                systemPrompt,
-                userPrompt,
-                reactCode,
-                previewHtml,
-                createdBy,
-                now);
+        // TODO : 현재 DB 설계 확정 전이므로, 수정 필요
+//        reactGenerateMapper.insert(
+//                id,
+//                request.getFigmaUrl(),
+//                request.getRequirements(),
+//                systemPrompt,
+//                userPrompt,
+//                reactCode,
+//                previewHtml,
+//                createdBy,
+//                now);
 
         log.info("React 코드 생성 완료 — id: {}", id);
 

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactGenerateService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactGenerateService.java
@@ -1,15 +1,16 @@
 package com.example.admin_demo.domain.reactgenerate.service;
 
+import com.example.admin_demo.domain.reactgenerate.ai.ClaudeApiClient;
+import com.example.admin_demo.domain.reactgenerate.ai.prompt.PromptBuilder;
 import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateApprovalResponse;
 import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateRequest;
 import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateResponse;
 import com.example.admin_demo.domain.reactgenerate.enums.ReactGenerateStatus;
+import com.example.admin_demo.domain.reactgenerate.mapper.ReactGenerateMapper;
 import com.example.admin_demo.global.exception.NotFoundException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,22 +20,50 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ReactGenerateService {
 
-    // TODO: DB 테이블 생성 후 Mapper로 교체
-    private final Map<String, ReactGenerateResponse> store = new ConcurrentHashMap<>();
+    private final ReactGenerateMapper reactGenerateMapper;
+    private final PromptBuilder promptBuilder;
+    private final ClaudeApiClient claudeApiClient;
 
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
 
-    public ReactGenerateResponse generate(ReactGenerateRequest request) {
-        log.info("React 코드 생성 요청 - figmaUrl: {}", request.getFigmaUrl());
+    /**
+     * Figma URL과 요구사항을 받아 Claude API로 React 코드를 생성하고 DB에 저장한다.
+     *
+     * @param request figmaUrl, requirements
+     * @param createdBy 생성 요청자 ID (로그인 사용자)
+     * @return 생성된 코드와 메타 정보
+     */
+    public ReactGenerateResponse generate(ReactGenerateRequest request, String createdBy) {
+        log.info("React 코드 생성 요청 — figmaUrl: {}, userId: {}", request.getFigmaUrl(), createdBy);
 
+        // 1. system / user prompt 조립
+        String systemPrompt = promptBuilder.buildSystemPrompt();
+        String userPrompt = promptBuilder.buildUserPrompt(request.getFigmaUrl(), request.getRequirements());
+
+        // 2. Claude API 호출하여 React 코드 생성
+        String reactCode = claudeApiClient.generate(systemPrompt, userPrompt);
+
+        // 3. 코드 기반 preview HTML 생성
+        String previewHtml = buildPreviewHtml(reactCode, request.getFigmaUrl());
+
+        // 4. DB 저장 (초기 상태: GENERATED)
         String id = UUID.randomUUID().toString();
         String now = LocalDateTime.now().format(FORMATTER);
 
-        // TODO: Figma API 연동 및 Claude API를 통한 실제 코드 생성 구현
-        String reactCode = buildPlaceholderCode(request.getFigmaUrl());
-        String previewHtml = buildPreviewHtml(request.getFigmaUrl());
+        reactGenerateMapper.insert(
+                id,
+                request.getFigmaUrl(),
+                request.getRequirements(),
+                systemPrompt,
+                userPrompt,
+                reactCode,
+                previewHtml,
+                createdBy,
+                now);
 
-        ReactGenerateResponse response = ReactGenerateResponse.builder()
+        log.info("React 코드 생성 완료 — id: {}", id);
+
+        return ReactGenerateResponse.builder()
                 .id(id)
                 .figmaUrl(request.getFigmaUrl())
                 .reactCode(reactCode)
@@ -42,30 +71,32 @@ public class ReactGenerateService {
                 .status(ReactGenerateStatus.GENERATED.name())
                 .createdAt(now)
                 .build();
-
-        store.put(id, response);
-        return response;
     }
 
+    /**
+     * 생성된 코드를 관리자 승인 요청 상태로 변경한다.
+     */
     public ReactGenerateApprovalResponse requestApproval(String id) {
-        ReactGenerateResponse item = findById(id);
-        item.setStatus(ReactGenerateStatus.PENDING_APPROVAL.name());
-        store.put(id, item);
+        requireExists(id);
 
-        log.info("승인 요청 - id: {}", id);
+        reactGenerateMapper.updateStatus(id, ReactGenerateStatus.PENDING_APPROVAL.name(), null, null);
+        log.info("승인 요청 — id: {}", id);
+
         return ReactGenerateApprovalResponse.builder()
                 .id(id)
                 .status(ReactGenerateStatus.PENDING_APPROVAL.name())
                 .build();
     }
 
+    /**
+     * 관리자가 생성 코드를 승인한다.
+     */
     public ReactGenerateApprovalResponse approve(String id, String approvedBy) {
-        ReactGenerateResponse item = findById(id);
-        item.setStatus(ReactGenerateStatus.APPROVED.name());
-        store.put(id, item);
+        requireExists(id);
 
         String now = LocalDateTime.now().format(FORMATTER);
-        log.info("승인 완료 - id: {}, approvedBy: {}", id, approvedBy);
+        reactGenerateMapper.updateStatus(id, ReactGenerateStatus.APPROVED.name(), approvedBy, now);
+        log.info("승인 완료 — id: {}, approvedBy: {}", id, approvedBy);
 
         return ReactGenerateApprovalResponse.builder()
                 .id(id)
@@ -75,54 +106,35 @@ public class ReactGenerateService {
                 .build();
     }
 
-    private ReactGenerateResponse findById(String id) {
-        ReactGenerateResponse item = store.get(id);
-        if (item == null) {
+    /** ID로 이력을 조회하고, 없으면 NotFoundException을 던진다. */
+    private void requireExists(String id) {
+        if (reactGenerateMapper.selectById(id) == null) {
             throw new NotFoundException("생성 결과를 찾을 수 없습니다. id=" + id);
         }
-        return item;
     }
 
-    private String buildPlaceholderCode(String figmaUrl) {
-        return """
-                import React from 'react';
-
-                // TODO: Figma URL에서 생성된 컴포넌트
-                // Source: %s
-                const GeneratedComponent = () => {
-                  return (
-                    <div className="generated-component">
-                      <h2>Generated Component</h2>
-                      <p>Figma 디자인 기반으로 생성된 컴포넌트입니다.</p>
-                    </div>
-                  );
-                };
-
-                export default GeneratedComponent;
-                """
-                .formatted(figmaUrl);
-    }
-
-    private String buildPreviewHtml(String figmaUrl) {
+    /**
+     * 생성된 React 코드를 iframe에서 미리볼 수 있는 HTML을 생성한다.
+     * React 코드는 직접 실행이 불가하므로 코드를 code 태그로 감싸 표시한다.
+     */
+    private String buildPreviewHtml(String reactCode, String figmaUrl) {
         return """
                 <!DOCTYPE html>
                 <html>
                 <head>
                   <meta charset="UTF-8">
                   <style>
-                    body { font-family: sans-serif; padding: 20px; }
-                    .generated-component { border: 1px dashed #ccc; padding: 20px; border-radius: 8px; }
+                    body { font-family: monospace; padding: 16px; background: #1e1e1e; color: #d4d4d4; }
+                    pre { white-space: pre-wrap; word-break: break-all; font-size: 13px; }
+                    .source { font-size: 11px; color: #666; margin-bottom: 8px; }
                   </style>
                 </head>
                 <body>
-                  <div class="generated-component">
-                    <h2>Generated Component</h2>
-                    <p>Figma 디자인 기반으로 생성된 컴포넌트입니다.</p>
-                    <small style="color:#999">Source: %s</small>
-                  </div>
+                  <div class="source">Source: %s</div>
+                  <pre>%s</pre>
                 </body>
                 </html>
                 """
-                .formatted(figmaUrl);
+                .formatted(figmaUrl, reactCode.replace("<", "&lt;").replace(">", "&gt;"));
     }
 }

--- a/admin/src/main/java/com/example/admin_demo/global/page/controller/PageController.java
+++ b/admin/src/main/java/com/example/admin_demo/global/page/controller/PageController.java
@@ -320,6 +320,13 @@ public class PageController {
         return resolveView(request, "pages/message-parsing-json/message-parsing-json :: content", model);
     }
 
+    // ── React 플랫폼 ── react_generate
+
+    @GetMapping("/react-generate")
+    public String reactGenerate(HttpServletRequest request, Model model) {
+        return resolveView(request, "pages/react-generate/react-generate :: content", model);
+    }
+
     // ── 서비스 관리 ── v3_neb_service_base_info, v3_neb_biz_component, v3_validator_component,
     //                    v3_biz_app, v3_sql_query_manage, v3_sql_dataSource_manage
 

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -87,6 +87,14 @@ menu:
   hidden-menu-ids:
     - acl_manage  # Framework 관리메뉴 (asis 메뉴)
 
+# Figma API Configuration (React Generate 메뉴 — 디자인 노드 조회)
+figma:
+  api:
+    url: https://api.figma.com
+    token: ${FIGMA_ACCESS_TOKEN}
+    connect-timeout-seconds: 10
+    read-timeout-seconds: 30
+
 # Claude API Configuration (React Generate 메뉴)
 claude:
   api:

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -87,6 +87,17 @@ menu:
   hidden-menu-ids:
     - acl_manage  # Framework 관리메뉴 (asis 메뉴)
 
+# Claude API Configuration (React Generate 메뉴)
+claude:
+  api:
+    url: https://api.anthropic.com/v1/messages
+    key: ${CLAUDE_API_KEY}
+    model: claude-sonnet-4-6      # 코드 생성 품질과 비용 균형 고려
+    max-tokens: 8192
+    # Claude 응답은 수십 초 소요될 수 있으므로 기본 RestTemplate 타임아웃과 별도 설정
+    connect-timeout-seconds: 10
+    read-timeout-seconds: 120
+
 # Scheduling Configuration (배치 이력 정리 스케줄러)
 scheduling:
   batch-his-cleanup:

--- a/admin/src/main/resources/mapper/oracle/reactgenerate/ReactGenerateMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/reactgenerate/ReactGenerateMapper.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!--
+    ReactGenerate Mapper (REACT_GENERATE_HIS)
+    - React 코드 생성 이력 INSERT / SELECT / UPDATE
+-->
+<mapper namespace="com.example.admin_demo.domain.reactgenerate.mapper.ReactGenerateMapper">
+
+    <!-- ==================== INSERT ==================== -->
+
+    <insert id="insert">
+        INSERT INTO REACT_GENERATE_HIS (
+            ID,
+            FIGMA_URL,
+            REQUIREMENTS,
+            SYSTEM_PROMPT,
+            USER_PROMPT,
+            REACT_CODE,
+            PREVIEW_HTML,
+            STATUS,
+            CREATED_BY,
+            CREATED_AT
+        ) VALUES (
+            #{id,jdbcType=VARCHAR},
+            #{figmaUrl,jdbcType=VARCHAR},
+            #{requirements,jdbcType=CLOB},
+            #{systemPrompt,jdbcType=CLOB},
+            #{userPrompt,jdbcType=CLOB},
+            #{reactCode,jdbcType=CLOB},
+            #{previewHtml,jdbcType=CLOB},
+            'GENERATED',
+            #{createdBy,jdbcType=VARCHAR},
+            #{createdAt,jdbcType=VARCHAR}
+        )
+    </insert>
+
+    <!-- ==================== SELECT ==================== -->
+
+    <sql id="selectColumns">
+        ID          AS id,
+        FIGMA_URL   AS figmaUrl,
+        REACT_CODE  AS reactCode,
+        PREVIEW_HTML AS previewHtml,
+        STATUS      AS status,
+        CREATED_AT  AS createdAt
+    </sql>
+
+    <select id="selectById" resultType="com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateResponse">
+        SELECT
+            <include refid="selectColumns"/>
+        FROM REACT_GENERATE_HIS
+        WHERE ID = #{id,jdbcType=VARCHAR}
+    </select>
+
+    <!-- ==================== UPDATE ==================== -->
+
+    <update id="updateStatus">
+        UPDATE REACT_GENERATE_HIS
+        SET
+            STATUS      = #{status,jdbcType=VARCHAR},
+            APPROVED_BY = #{approvedBy,jdbcType=VARCHAR},
+            APPROVED_AT = #{approvedAt,jdbcType=VARCHAR}
+        WHERE ID = #{id,jdbcType=VARCHAR}
+    </update>
+
+</mapper>

--- a/admin/src/main/resources/menu-resource-permissions.yml
+++ b/admin/src/main/resources/menu-resource-permissions.yml
@@ -144,3 +144,6 @@ menu-resource:
     v3_sql_dataSource_manage:
       R: DATASOURCE:R
       W: DATASOURCE:W
+    react_generate:
+      R: REACT_GENERATE:R
+      W: REACT_GENERATE:W

--- a/admin/src/main/resources/menu-resource-permissions.yml
+++ b/admin/src/main/resources/menu-resource-permissions.yml
@@ -147,6 +147,6 @@ menu-resource:
     v3_sql_dataSource_manage:
       R: DATASOURCE:R
       W: DATASOURCE:W
-    react_generate:
+    v3_react_generate:
       R: REACT_GENERATE:R
       W: REACT_GENERATE:W

--- a/admin/src/main/resources/prompts/CLAUDE.md
+++ b/admin/src/main/resources/prompts/CLAUDE.md
@@ -1,0 +1,447 @@
+# Reactive-Springware Claude Code 지침_dev version
+
+## 코드 작성 규칙
+
+### 주석
+
+이 프로젝트의 실사용자는 프로젝트 내부 구조를 전혀 모르는 외부 개발자다.
+코드만 봐도 의도를 파악할 수 있도록 주석을 충분히 작성한다.
+
+**파일 상단 JSDoc**
+
+- 새 파일을 생성할 때는 반드시 파일 상단에 JSDoc 주석을 작성한다.
+- 주석에는 다음 내용을 포함한다:
+  - 파일명 (`@file`)
+  - 파일/함수의 역할 설명 (`@description`)
+  - 주요 파라미터 (`@param`)
+  - 반환값 (`@returns`)
+  - 필요한 경우 사용 예시 (`@example`)
+
+**인라인 주석**
+
+- 다음 경우에는 반드시 인라인 주석을 추가한다:
+  - 왜 이 값을 선택했는지 이유가 필요한 상수·기본값 (e.g. 기본 listStyle이 'card'인 이유)
+  - 외부 개발자가 처음 봤을 때 의도를 오해할 수 있는 로직
+  - 타입 단언(`as`)이나 예외 처리 등 방어 코드
+  - 여러 분기 중 특정 분기가 존재하는 이유가 명확하지 않은 경우
+
+---
+
+# 🧪 Development Phase Rules
+
+This project is currently in **development phase**.
+
+During development phase, the following rules MUST be followed:
+
+### Component Usage Rules
+
+- Pages MUST be generated using components from `component-library/`
+- Direct HTML elements are NOT allowed
+- New UI must use existing component-library components
+
+If additional components are required:
+
+- Create reusable common components
+- Add them to `component-library/`
+- Generate Storybook file together
+
+#### Mandatory When Creating New Components
+
+When creating new components in `component-library/`:
+
+Claude MUST also generate:
+
+- Component file
+- Types file (if needed)
+- Storybook file
+
+Example:
+
+```
+component-library/
+  Button/
+    index.tsx
+    types.ts
+    Button.stories.tsx
+```
+
+---
+
+### File Generation Location Rules
+
+All generated pages and files MUST be created under:
+
+```
+demo/react-demo-app/
+```
+
+Claude MUST NOT create files outside this directory.
+
+---
+
+### Folder Scope Restriction
+
+Claude MUST only modify files inside:
+
+```
+figma-react-generator/
+```
+
+Rules:
+
+- Only modify files inside `figma-react-generator/`
+- Do NOT reference parent folders
+- Do NOT modify upper-level directories
+- Do NOT follow existing structure outside this folder
+
+---
+
+### Generation Scope Summary
+
+Claude MUST:
+
+✔ Follow rule files first
+✔ Follow all rules inside rules/ folder
+✔ Use component-library components only
+✔ Create reusable components when needed
+✔ Generate Storybook with new components
+✔ Generate files under demo/react-demo-app
+✔ Only modify figma-react-generator folder
+
+Claude MUST NOT:
+
+❌ Follow existing project structure blindly
+❌ Ignore rules folder
+❌ Modify parent folders
+❌ Generate files outside defined directories
+❌ Use raw HTML instead of component-library
+
+---
+
+### Final Rule
+
+Rules defined in this document override:
+
+- Existing project structure
+- Existing folder layout
+- Existing code patterns
+
+Claude MUST strictly follow these rules during code generation.
+
+---
+
+# 🎯 목적
+
+이 프로젝트는 Figma 디자인을 기반으로 React 코드를 자동 생성하는 플랫폼이다.
+Claude가 생성하는 모든 코드는 **일관성**, **재사용성**, **유지보수성**을 최우선으로 한다.
+
+---
+
+# 🧠 기본 원칙
+
+### 1. component-library가 유일한 UI 소스다
+
+모든 UI는 반드시 `component-library`에서 가져온다.
+직접 HTML 태그(`div`, `button` 등)를 사용하거나 외부 UI 라이브러리를 추가하지 않는다.
+이 원칙을 지켜야 디자인 시스템과 코드가 항상 동기화된다.
+
+### 2. 디자인 토큰이 유일한 스타일 소스다
+
+색상·간격·폰트 크기는 반드시 `design-tokens`에서 가져온다.
+임의 값(`#333`, `16px`)을 하드코딩하면 Figma 디자인 변경 시 코드를 일일이 수정해야 하는 기술 부채가 생긴다.
+
+### 3. Figma 매핑 기준을 벗어나지 않는다
+
+`docs/component-map.md`에 정의된 컴포넌트만 생성한다.
+정의되지 않은 컴포넌트를 임의로 만들면 디자이너의 의도와 다른 UI가 생성된다.
+
+### 4. 관심사를 명확히 분리한다
+
+- **HTTP 호출·데이터 가공·모델 변환·에러 처리**는 `{entity}Repository.ts`에서만 한다.
+- **데이터 패칭 로직**은 `use{Entity}.ts`에서만 한다.
+- **컴포넌트**는 데이터를 표시하는 역할만 한다.
+
+Repository 패턴을 사용하는 이유: API 응답 구조가 바뀌어도 Repository만 수정하면 되고, Hook과 Page는 변경하지 않아도 된다. 유지보수 비용이 크게 줄어든다.
+
+### 5. 데이터 상태를 반드시 처리한다
+
+모든 데이터 화면은 `loading`, `error`, `empty` 세 가지 상태를 빠짐없이 처리해야 한다.
+처리하지 않으면 로딩 중 깨진 화면, 에러 시 빈 화면, 데이터 없을 때 의미 없는 빈 테이블이 사용자에게 노출된다.
+반드시 이 순서로 처리한다: `isLoading` → `isError` → empty check → 정상 렌더링.
+
+### 6. 타입 안전성을 유지한다
+
+`any` 타입은 TypeScript를 사용하는 의미를 없앤다.
+모든 props와 API 응답에는 명시적 타입을 정의한다.
+
+---
+
+# 🚫 하지 말아야 하는 이유
+
+| 금지 항목                           | 하지 말아야 하는 이유                            |
+| ----------------------------------- | ------------------------------------------------ |
+| HTML 태그 직접 사용                 | 디자인 시스템 일관성 붕괴                        |
+| Inline style                        | Figma 변경 시 코드 일괄 추적 불가                |
+| 임의 색상·크기 하드코딩             | 테마 변경 시 전체 수정 필요                      |
+| Hook·Component에서 직접 HTTP 호출   | Repository 계층 우회, API 변경 시 전체 수정 필요 |
+| `any` 타입                          | 런타임 오류를 컴파일 타임에 잡지 못함            |
+| 정의되지 않은 컴포넌트 생성         | Figma 디자인 의도 이탈                           |
+| loading/error/empty 처리 생략       | 로딩 중·에러·빈 데이터 상황에서 UI 깨짐          |
+| Page에서 `useState` 직접 사용       | 비즈니스 로직이 Page에 쌓여 재사용·테스트 불가   |
+| Component에서 이벤트 로직 직접 처리 | 컴포넌트 재사용성 소멸, 라우팅·API 호출 분산     |
+
+---
+
+### 컴포넌트 조합 규칙
+
+컴포넌트 계층은 Page → Layout → Section → Component 순서를 반드시 지킨다.
+이 계층을 건너뛰거나 역방향으로 중첩하면 레이아웃 일관성이 무너진다.
+특히 Component 내부에 Page를 다시 만드는 구조는 절대 허용하지 않는다.
+
+### 네이밍 규칙
+
+일관된 네이밍이 없으면 같은 역할의 파일이 다른 이름으로 생성되어 구조 파악이 어려워진다.
+
+| 대상                | 규칙                     | 예시                           |
+| ------------------- | ------------------------ | ------------------------------ |
+| Page (목록)         | `{Entity}ListPage`       | `UserListPage`                 |
+| Page (상세)         | `{Entity}DetailPage`     | `UserDetailPage`               |
+| Page (등록)         | `{Entity}CreatePage`     | `UserCreatePage`               |
+| Page (수정)         | `{Entity}EditPage`       | `UserEditPage`                 |
+| Component (테이블)  | `{Entity}Table`          | `UserTable`                    |
+| Component (폼)      | `{Entity}Form`           | `UserForm`                     |
+| Component (모달)    | `{Entity}{Action}Modal`  | `UserDeleteModal`              |
+| Hook (목록)         | `use{Entity}List`        | `useUserList`                  |
+| Hook (폼)           | `use{Entity}Form`        | `useUserForm`                  |
+| Repository          | camelCase + `Repository` | `userRepository.ts`            |
+| Type                | camelCase + `Types`      | `userTypes.ts`                 |
+| 이벤트 (Hook 정의)  | `handle{Action}`         | `handleDelete`, `handleSearch` |
+| 이벤트 (props 전달) | `on{Action}`             | `onDelete`, `onSearch`         |
+
+### Props 설계 규칙
+
+Props는 최소한으로 설계한다. 불필요하게 많은 props는 컴포넌트의 역할이 불분명하다는 신호다.
+`variant`, `size` 같은 열거형 props를 사용하고, boolean을 나열하는 방식은 피한다.
+boolean props는 이름만으로 의미가 명확해야 한다. (`disabled`, `loading` 등)
+
+### 상태관리 방향
+
+상태의 출처(서버 vs 클라이언트)에 따라 관리 도구를 다르게 사용한다.
+서버 데이터에 `useState`를 사용하면 캐싱·동기화·에러 처리를 직접 구현해야 해서 코드가 복잡해진다.
+**Page에서 상태를 직접 생성하지 않는다.** 상태는 반드시 Hook을 통해 가져온다. Page에서 `useState`를 직접 쓰면 로직이 Page에 쌓이고 테스트와 재사용이 불가능해진다.
+전역 상태는 정말 전역이 필요한 경우(인증, 테마)에만 사용한다. 과도한 전역 상태는 데이터 흐름을 추적하기 어렵게 만든다.
+
+### 이벤트 처리 규칙
+
+이벤트 핸들러는 **Hook에서 정의**하고, Page는 Hook에서 받은 핸들러를 Component에 전달만 한다. Component는 callback props로만 받는다.
+Component 내부에서 직접 이벤트를 처리하면 같은 컴포넌트를 다른 동작으로 재사용할 수 없다.
+핸들러 네이밍: Hook에서 정의할 때는 `handle~`, props로 전달할 때는 `on~` prefix를 사용한다.
+
+### 컴포넌트 크기 규칙
+
+컴포넌트는 200줄을 넘지 않도록 한다.
+200줄을 초과한다면 역할이 두 개 이상이라는 신호다. 분리를 검토한다.
+
+---
+
+# 🙋 개발자 확인 원칙
+
+판단할 수 없는 상황에서는 **절대 임의로 가정하고 진행하지 않는다.**
+불확실한 내용을 추측하여 생성하면 잘못된 코드를 수정하는 비용이 처음부터 확인하는 비용보다 크다.
+
+다음 상황에서는 반드시 개발자에게 확인 후 진행한다.
+
+- 고객사 브랜드가 명시되지 않은 경우 (지원 브랜드: 하나은행·신한은행·KB국민은행·IBK기업은행·NH농협은행·우리은행 등)
+- Figma 컴포넌트가 `docs/component-map.md`에 없는 경우
+- 엔티티명을 Figma 디자인에서 판단할 수 없는 경우
+- API 엔드포인트, 응답 구조, pagination 방식이 불명확한 경우
+- Table vs Card vs Form 등 화면 타입이 애매한 경우
+- Form의 create/update 용도, validation 방식이 불명확한 경우
+- 생성하려는 파일이 이미 존재하거나 라우터 URL이 충돌하는 경우
+- 비즈니스 로직이나 권한 처리 방식을 추론할 수 없는 경우
+
+확인 질문은 한 번에 모아서 한다. 항목마다 개별로 질문하지 않는다.
+
+---
+
+# 🎯 라이브러리 최종 목표
+
+Claude가 생성한 코드는 **Figma 디자인과 동일한 UI**를 보여주면서,
+외부 개발자가 처음 보더라도 구조와 의도를 바로 이해할 수 있어야 한다.
+
+---
+
+# 🎨 디자인 토큰 규칙
+
+## globals.css는 자동 생성 파일이다
+
+`design-tokens/globals.css`는 **직접 수정하지 않는다.**
+이 파일은 Figma Variables → Token Studio export → Claude 변환 과정을 통해서만 업데이트된다.
+
+## temp.json을 받으면 반드시 아래 절차를 수행한다
+
+누군가 `temp.json` 파일을 전달하거나 "globals.css 업데이트해줘"라고 요청하면,
+아래 절차를 순서대로 수행한다. 절대 globals.css를 직접 수정하는 것으로 시작하지 않는다.
+
+```
+1. temp.json 파싱
+   └─ 최상위 키(primitives / semantic / brand.hana 등 / domain.*)를 기준으로 분류
+
+2. figma-tokens/*.json 업데이트 (카테고리별 분배)
+   ├─ primitives.json  — spacing, radius, text, font, shadow, transition, breakpoint, nav, z
+   ├─ semantic.json    — color.* (brand·domain 참조 포함)
+   ├─ brand.{키}.json  — brand.* 토큰 (하나은행·신한은행 등 브랜드별)
+   └─ domain.{키}.json — domain.* 토큰 (banking·card·giro·insurance)
+
+3. figma-tokens/*.json → globals.css 변환
+   ├─ [data-brand="hana"] 등 브랜드 블록 — brand.*.json에서 생성
+   ├─ [data-domain="card"] 등 도메인 블록 — domain.*.json에서 생성
+   ├─ @theme 블록 — semantic.json에서 생성
+   └─ @layer base 블록 — 전역 기본 스타일 유지
+
+4. temp.json 삭제 안내
+   └─ "temp.json은 삭제해도 됩니다" 메시지 출력
+```
+
+## 토큰 파일 구조 규칙
+
+변환 시 아래 파일 구조와 경로를 반드시 유지한다.
+
+```
+design-tokens/
+├── globals.css              ← 자동 생성 (직접 수정 금지)
+└── figma-tokens/
+    ├── primitives.json      ← spacing / radius / text / font / shadow 등 고정값
+    ├── semantic.json        ← color.* 시맨틱 토큰 (brand·domain 토큰 참조)
+    ├── brand.hana.json      ← 하나은행
+    ├── brand.ibk.json       ← IBK기업은행
+    ├── brand.kb.json        ← KB국민은행
+    ├── brand.nh.json        ← NH농협은행
+    ├── brand.shinhan.json   ← 신한은행
+    ├── brand.woori.json     ← 우리은행
+    ├── domain.banking.json  ← 뱅킹 도메인
+    ├── domain.card.json     ← 카드 도메인
+    ├── domain.giro.json     ← 지로 도메인
+    └── domain.insurance.json← 보험 도메인
+```
+
+신규 브랜드·도메인이 temp.json에 포함되어 있으면 대응하는 파일을 새로 생성한다.
+기존에 없는 키가 추가된 경우 개발자에게 확인 후 적절한 파일에 배치한다.
+
+## figma-plugin/src/tokens.ts와의 관계
+
+`tokens.ts`는 **Figma 플러그인 전용** 파일이다.
+globals.css와 완전히 동기화할 필요 없으며, 아래 토큰만 관리한다.
+
+- Figma 컴포넌트 생성 시 사용하는 **변수 경로 상수** (Figma Variables 바인딩용 경로) 와 **값 상수**(Figma Plugin API용 런타임 값) 조합으로 이루어져있다.
+- 브랜드별·도메인별 색상은 tokens.ts에 포함하지 않는다.
+- Figma 컴포넌트를 생성할 때 필요한 변수 경로 상수가 tokens.ts에 없는 경우, 임의로 추가하지 않고 **반드시 개발자에게 확인** 후 진행한다.
+- temp.json 업데이트 작업에서 tokens.ts는 수정하지 않는다.
+- tokens.ts 수정이 필요한 경우 개발자에게 별도로 확인한다.
+
+---
+
+# 🔌 Figma 플러그인 컴포넌트 생성 규칙
+
+`figma-plugin/src/components/` 하위에 컴포넌트 생성 파일을 작성할 때 반드시 아래 규칙을 따른다.
+
+## 변수 바인딩 원칙
+
+모든 속성은 **Figma Variables가 존재하면 바인딩하고, 없으면 fallback 값으로 폴백**한다.
+속성 종류에 따라 사용하는 헬퍼가 다르다.
+
+### 색상 속성 → `COLOR_VAR + setFillWithVar / addTextWithVar`
+
+```ts
+// fill 색상 바인딩
+await setFillWithVar(node, COLOR_VAR.surface, COLOR.surface);
+
+// 텍스트 생성 + 색상 바인딩 (동시에 처리)
+await addTextWithVar(parent, '텍스트', FONT_SIZE.base, COLOR_VAR.textHeading, COLOR.textHeading, bold);
+```
+
+### 수치 속성(spacing, radius, fontSize) → `SIZE_VAR + setFloatVar`
+
+`setAutoLayout`, `setPadding`, `node.cornerRadius =` 등으로 fallback 값을 먼저 설정한 뒤,
+반드시 곧바로 `setFloatVar`로 동일 필드를 Variable에 바인딩한다.
+
+```ts
+// itemSpacing
+setAutoLayout(node, 'VERTICAL', SPACING.md);
+await setFloatVar(node, 'itemSpacing', SIZE_VAR.spacingMd, SPACING.md);
+
+// padding (setPadding으로 fallback 설정 후 각 필드를 개별 바인딩)
+setPadding(node, SPACING.xl, SPACING.xl);
+await setFloatVar(node, 'paddingTop',    SIZE_VAR.spacingXl, SPACING.xl);
+await setFloatVar(node, 'paddingRight',  SIZE_VAR.spacingXl, SPACING.xl);
+await setFloatVar(node, 'paddingBottom', SIZE_VAR.spacingXl, SPACING.xl);
+await setFloatVar(node, 'paddingLeft',   SIZE_VAR.spacingXl, SPACING.xl);
+
+// cornerRadius
+await setFloatVar(node, 'cornerRadius', SIZE_VAR.radiusFull, RADIUS.full);
+
+// 상단만 radius 적용하는 경우 (예: BottomSheet rounded-t-2xl)
+await setFloatVar(node, 'topLeftRadius',  SIZE_VAR.radiusLg, RADIUS.lg);
+await setFloatVar(node, 'topRightRadius', SIZE_VAR.radiusLg, RADIUS.lg);
+node.bottomLeftRadius  = 0;
+node.bottomRightRadius = 0;
+
+// fontSize — addTextWithVar의 7번째 인자로 전달
+await addTextWithVar(parent, '텍스트', FONT_SIZE.sm, COLOR_VAR.textBase, COLOR.textBase, bold, SIZE_VAR.fontSizeSm);
+```
+
+값이 `0`인 padding도 `SIZE_VAR.spacing0`가 tokens.ts에 존재하므로 동일하게 바인딩한다.
+
+```ts
+// 예: paddingTop/Bottom = 0인 경우
+setPadding(node, 0, SPACING.md);
+await setFloatVar(node, 'paddingTop',    SIZE_VAR.spacing0,  SPACING['0']);
+await setFloatVar(node, 'paddingBottom', SIZE_VAR.spacing0,  SPACING['0']);
+await setFloatVar(node, 'paddingRight',  SIZE_VAR.spacingMd, SPACING.md);
+await setFloatVar(node, 'paddingLeft',   SIZE_VAR.spacingMd, SPACING.md);
+```
+
+### stroke 속성 → `COLOR_VAR + setStrokeWithVar`
+
+```ts
+// stroke에 COLOR 변수 바인딩 (setStroke는 RGB만 받으므로 반드시 이 헬퍼 사용)
+await setStrokeWithVar(node, COLOR_VAR.border, COLOR.border);
+await setStrokeWithVar(node, COLOR_VAR.brandPrimary, BRAND.primary, 2); // weight 지정 가능
+```
+
+### lineHeight 속성 → `SIZE_VAR + setLineHeightVar`
+
+```ts
+// lineHeight는 { value, unit } 객체 구조라 setFloatVar로 처리 불가 — 전용 헬퍼 사용
+const text = await addTextWithVar(parent, '텍스트', FONT_SIZE.base, COLOR_VAR.textHeading, COLOR.textHeading, bold, SIZE_VAR.fontSizeBase);
+await setLineHeightVar(text, SIZE_VAR.lineHeightBase, LINE_HEIGHT.base);
+```
+
+## `layoutSizingHorizontal = 'FILL'` / `layoutGrow = 1` 설정 순서
+
+반드시 `parent.appendChild(child)` **이후에** 설정한다. 이전에 설정하면 Figma가 조용히 무시한다.
+
+```ts
+// ❌ 잘못된 예 — Figma가 무시함
+node.layoutSizingHorizontal = 'FILL';
+parent.appendChild(node);
+
+// ✅ 올바른 예 — appendChild 이후에 설정
+parent.appendChild(node);
+node.layoutSizingHorizontal = 'FILL';
+```
+
+## 헬퍼 함수 (`figma-plugin/src/helpers.ts`)
+
+| 함수 | 용도 |
+|------|------|
+| `setFillWithVar(node, colorVar, fallback)` | fill에 COLOR 변수 바인딩 |
+| `setStrokeWithVar(node, colorVar, fallback, weight?)` | stroke에 COLOR 변수 바인딩 (setStroke 대체) |
+| `setFloatVar(node, field, sizeVar, fallback)` | 수치 필드(padding/radius/itemSpacing 등)에 FLOAT 변수 바인딩 |
+| `setLineHeightVar(node, sizeVar, fallback)` | TextNode lineHeight에 FLOAT 변수 바인딩 (setFloatVar 대체) |
+| `addTextWithVar(parent, text, fontSize, colorVar, fallback, bold?, fontSizeVar?)` | 텍스트 생성 + 색상·fontSize 변수 바인딩 |
+| `setAutoLayout(node, direction, gap, align?)` | Auto Layout 설정 (gap은 fallback용 — 이후 setFloatVar로 바인딩) |
+| `setPadding(node, top, right, bottom?, left?)` | padding 설정 (fallback용 — 이후 setFloatVar로 바인딩) |
+| `combineVariants(components, name, cols?)` | variant 배열을 그리드 배치 후 ComponentSet으로 묶음 |
+
+---

--- a/admin/src/main/resources/prompts/component-map.md
+++ b/admin/src/main/resources/prompts/component-map.md
@@ -1,3 +1,5 @@
+<!-- 이 파일은 scripts/extract-component-map.ts로 자동 생성됩니다. 직접 수정하지 마세요. -->
+<!-- 원본: docs/component-map.md -->
 # Component Map — Figma → React 매핑 전략
 
 > **대상 Figma 파일**: Hana Bank App (`eRnV2DPVtHbGn5HSISS65O`)

--- a/admin/src/main/resources/prompts/component-types.md
+++ b/admin/src/main/resources/prompts/component-types.md
@@ -1,0 +1,2207 @@
+# Component Types
+
+> 이 파일은 `scripts/extract-components.ts`로 자동 생성됩니다. 직접 수정하지 마세요.
+> Claude API system prompt에 포함되어 컴포넌트 API 레퍼런스로 사용됩니다.
+
+## 사용 규칙
+
+- 아래 컴포넌트만 사용할 것. 목록에 없는 컴포넌트는 존재하지 않음
+- import 경로: `@neobnsrnd-team/reactive-springware`
+- TypeScript로 작성하고 props interface를 포함할 것
+
+## Core (원자 컴포넌트 — Button, Input, Badge 등 단일 HTML 요소 수준)
+
+### Badge
+
+```typescript
+import React from 'react';
+
+/** primary: 시스템 공통 파란색 | brand: 현재 은행 브랜드색 */
+export type BadgeVariant = 'primary' | 'brand' | 'success' | 'danger' | 'warning' | 'neutral';
+
+export interface BadgeProps {
+  /** 배지 색상 변형. 기본: 'neutral' */
+  variant?:   BadgeVariant;
+  /** dot 모드일 때는 children 없이도 사용 가능 */
+  children?:  React.ReactNode;
+  /** true이면 텍스트 없이 점(dot)만 표시 */
+  dot?:       boolean;
+  className?: string;
+}
+```
+
+### Button
+
+```typescript
+import React from 'react';
+
+export type ButtonVariant = 'primary' | 'outline' | 'ghost' | 'danger';
+export type ButtonSize    = 'sm' | 'md' | 'lg';
+/**
+ * 버튼 내부 콘텐츠 정렬 방향.
+ * - `center` (기본): 텍스트+아이콘을 가운데 정렬
+ * - `between`: 아코디언 트리거 등에서 좌우 분리
+ */
+export type ButtonJustify = 'center' | 'between';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** 버튼 외형 변형. 기본: 'primary' */
+  variant?:   ButtonVariant;
+  /** 버튼 크기. 기본: 'md' */
+  size?:      ButtonSize;
+  /** true이면 로딩 스피너 표시 및 aria-busy 처리 */
+  loading?:   boolean;
+  /** true이면 정방형 아이콘 전용 버튼 (텍스트 숨김) */
+  iconOnly?:  boolean;
+  leftIcon?:  React.ReactNode;
+  rightIcon?: React.ReactNode;
+  /** true이면 w-full 적용 */
+  fullWidth?: boolean;
+  /** 내부 정렬. 기본: 'center' */
+  justify?:   ButtonJustify;
+}
+
+export interface ButtonGroupProps {
+  children:   React.ReactNode;
+  className?: string;
+}
+```
+
+### Input
+
+```typescript
+import React from 'react';
+
+export type InputSize            = 'md' | 'lg';
+export type InputValidationState = 'default' | 'error' | 'success';
+
+export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  /** 입력 필드 레이블 */
+  label?:           string;
+  /** 안내 문구 또는 에러 메시지. validationState='error' 시 빨간색으로 표시 */
+  helperText?:      string;
+  /** 유효성 상태. 기본: 'default' */
+  validationState?: InputValidationState;
+  /**
+   * 입력 필드 높이. 기본: 'md'.
+   * HTMLInputElement의 size(number)와 충돌하므로 Omit 후 재정의.
+   */
+  size?:            InputSize;
+  leftIcon?:        React.ReactNode;
+  /** 우측 버튼/단위 슬롯 (인증번호 전송, 단위 텍스트 등) */
+  rightElement?:    React.ReactNode;
+  /** true이면 w-full 적용 */
+  fullWidth?:       boolean;
+  /**
+   * 입력값 포맷 패턴. `#`은 숫자 한 자리, 그 외 문자는 구분자로 그대로 삽입된다.
+   * 숫자만 입력받고, 최대 자릿수는 패턴의 `#` 개수로 자동 제한된다.
+   *
+   * @example
+   * '###-######-#####'  // 하나은행  → 012-345678-90123
+   * '######-##-######'  // KB국민은행 → 012345-67-890123
+   */
+  formatPattern?:   string;
+  /**
+   * 한국 휴대폰번호 포맷 적용 여부.
+   * 자릿수에 따라 포맷이 동적으로 전환된다.
+   * - 10자리: 010-XXX-XXXX  (3-3-4)
+   * - 11자리: 010-XXXX-XXXX (3-4-4)
+   * `formatPattern`과 함께 사용하면 `phoneFormat`이 우선 적용된다.
+   */
+  phoneFormat?:     boolean;
+}
+```
+
+### Select
+
+```typescript
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+export interface SelectProps {
+  /** 드롭다운 선택지 목록 */
+  options:    SelectOption[];
+  /** 현재 선택된 값 */
+  value:      string;
+  /** 선택 변경 핸들러 */
+  onChange:   (value: string) => void;
+  /** 접근성 레이블 (aria-label) */
+  'aria-label'?: string;
+  className?: string;
+}
+```
+
+### Typography
+
+```typescript
+import React from 'react';
+
+export type TypographyVariant = 'heading' | 'subheading' | 'body-lg' | 'body' | 'body-sm' | 'caption';
+export type TypographyWeight  = 'normal' | 'medium' | 'bold';
+export type TypographyColor   = 'heading' | 'base' | 'label' | 'secondary' | 'muted' | 'brand' | 'danger' | 'success';
+
+export interface TypographyProps {
+  /** 텍스트 크기 변형. 기본: 'body' */
+  variant?:   TypographyVariant;
+  /** 폰트 굵기. 기본: variant별 기본값 적용 */
+  weight?:    TypographyWeight;
+  /** 텍스트 색상. 기본: 'base' */
+  color?:     TypographyColor;
+  /** true이면 font-numeric(Manrope) 적용 — 금액·숫자 표시용 */
+  numeric?:   boolean;
+  /** 렌더링할 HTML 태그. 기본: 'p' */
+  as?:        React.ElementType;
+  children:   React.ReactNode;
+  className?: string;
+}
+
+/* 하위 호환성 — 기존 TextProps 참조가 있는 고객 코드를 위해 alias 유지 */
+export type TextProps    = TypographyProps;
+export type TextVariant  = TypographyVariant;
+export type TextWeight   = TypographyWeight;
+export type TextColor    = TypographyColor;
+```
+
+## Layout (페이지 구조 컴포넌트 — PageLayout, Stack, Grid, Inline 등)
+
+### AppBrandHeader
+
+```typescript
+export interface AppBrandHeaderProps {
+  /**
+   * 브랜드 이니셜 — 원형 배지 내부에 표시.
+   * 예: 'H' (하나은행), 'K' (국민은행), 'S' (신한은행)
+   */
+  brandInitial: string;
+  /**
+   * 브랜드명 — 이니셜 배지 오른쪽에 표시.
+   * 예: '하나은행'
+   */
+  brandName: string;
+  className?: string;
+}
+```
+
+### BlankPageLayout
+
+```typescript
+import React from 'react';
+
+export interface BlankPageLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * 콘텐츠 세로 정렬 방식.
+   * - 'top': 상단 정렬 (기본값 — 온보딩 스크롤 화면)
+   * - 'center': 수직 중앙 정렬 (로그인 폼 등 단일 블록 화면)
+   */
+  align?: 'top' | 'center';
+  className?: string;
+}
+```
+
+### BottomNav
+
+```typescript
+import React from 'react';
+
+export interface BottomNavItem {
+  /** 항목 고유 식별자 (activeId 비교에 사용) */
+  id:          string;
+  /** 비활성 상태 아이콘 */
+  icon:        React.ReactNode;
+  /** 활성 상태 아이콘. 미전달 시 icon 재사용 */
+  activeIcon?: React.ReactNode;
+  /** 탭 레이블 텍스트 */
+  label:       string;
+  /** 탭 클릭 핸들러 */
+  onClick:     () => void;
+}
+
+export interface BottomNavProps {
+  /** 탭 항목 목록 */
+  items:      BottomNavItem[];
+  /** 현재 활성 탭 id */
+  activeId:   string;
+  className?: string;
+}
+```
+
+### Grid
+
+```typescript
+import React from 'react';
+
+import type { StackGap } from '../Stack/types';
+
+export interface GridProps {
+  children:      React.ReactNode;
+  /**
+   * 모바일 기준 열 수. 기본: 2.
+   */
+  cols?:         1 | 2 | 3 | 4;
+  /**
+   * 태블릿(md 이상) 기준 열 수. 미전달 시 cols 값 유지.
+   */
+  tabletCols?:   2 | 3 | 4;
+  /** 셀 간격. 기본: 'sm' */
+  gap?:          StackGap;
+  className?:    string;
+}
+```
+
+### HomePageLayout
+
+```typescript
+import React from 'react';
+
+export interface HomePageLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** 헤더 타이틀 (앱 이름 또는 서비스명, 예: '하나은행') */
+  title: string;
+  /**
+   * 타이틀 좌측에 표시할 로고 아이콘 슬롯.
+   * 미전달 시 로고 영역 렌더링 안 함
+   */
+  logo?: React.ReactNode;
+  /**
+   * 헤더 우측 슬롯.
+   * 미전달 시 기본 프로필·벨·메뉴 3개 아이콘 버튼 표시
+   */
+  rightAction?: React.ReactNode;
+  /**
+   * 알림 뱃지 표시 여부.
+   * rightAction을 직접 전달한 경우 무시됨.
+   * 기본: false
+   */
+  hasNotification?: boolean;
+  /** 하단 글로벌 탭바 영역 여백 자동 추가 여부. 기본: true */
+  withBottomNav?: boolean;
+  className?: string;
+}
+```
+
+### Inline
+
+```typescript
+import React from 'react';
+
+import type { StackGap } from '../Stack/types';
+
+export type InlineAlign   = 'start' | 'center' | 'end' | 'baseline' | 'stretch';
+export type InlineJustify = 'start' | 'center' | 'end' | 'between' | 'around' | 'evenly';
+
+export interface InlineProps {
+  children:   React.ReactNode;
+  /** 요소 간 간격. 기본: 'sm' */
+  gap?:       StackGap;
+  /** 교차축(세로) 정렬. 기본: 'center' */
+  align?:     InlineAlign;
+  /** 주축(가로) 정렬. 기본: 'start' */
+  justify?:   InlineJustify;
+  /** true이면 flex-wrap 적용 */
+  wrap?:      boolean;
+  /** 렌더링할 HTML 태그. 기본: 'div' */
+  as?:        React.ElementType;
+  className?: string;
+}
+```
+
+### ModalSlideOver
+
+```typescript
+import type { ReactNode } from 'react';
+
+export interface ModalSlideOverProps {
+  /** 모달 내부에 렌더링할 콘텐츠 */
+  children: ReactNode;
+  /** 백드롭 클릭 시 호출. 미전달 시 백드롭 클릭으로 닫기 비활성 */
+  onClose?: () => void;
+  /** 슬라이드 방향 (기본: 'right') */
+  direction?: 'right' | 'bottom';
+  /** z-index 레벨 (기본: 50) */
+  zIndex?: number;
+}
+```
+
+### PageLayout
+
+```typescript
+import React from 'react';
+
+export interface PageLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** 상단 헤더 타이틀 */
+  title:         string;
+  /** 전달 시 헤더 좌측에 뒤로가기(<) 버튼 표시 */
+  onBack?:       () => void;
+  /** 헤더 우측 슬롯 (알림·설정·닫기 버튼 등) */
+  rightAction?:  React.ReactNode;
+  /**
+   * 화면 하단 고정 액션 바 슬롯 (iOS 스타일 하단 버튼 영역).
+   * 전달 시 화면 하단에 blur 배경 고정 바가 렌더링되며,
+   * 본문 스크롤 영역에 동일한 높이의 spacer가 추가되어
+   * 마지막 콘텐츠가 고정 바에 가려지지 않는다.
+   */
+  bottomBar?:    React.ReactNode;
+  className?:    string;
+}
+```
+
+### Section
+
+```typescript
+import React from 'react';
+
+export interface SectionProps {
+  /** 섹션 제목. 전달 시 SectionHeader 노출, 미전달 시 제목 없이 콘텐츠만 렌더링 */
+  title?: string;
+  /** 제목 옆 숫자 배지 (항목 수 등) */
+  badge?: number;
+  /** 우측 액션 레이블 (예: '전체보기') */
+  actionLabel?: string;
+  /** 액션 클릭 핸들러 */
+  onAction?: () => void;
+  /** 섹션 내부 콘텐츠 */
+  children: React.ReactNode;
+  /** SectionHeader와 children 사이, 그리고 children 내부 항목 간격. 기본: 'md' */
+  gap?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+  className?: string;
+}
+```
+
+### Stack
+
+```typescript
+import React from 'react';
+
+export type StackGap   = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+export type StackAlign = 'start' | 'center' | 'end' | 'stretch';
+
+export interface StackProps {
+  children:   React.ReactNode;
+  /** 자식 요소 간 간격. 기본: 'md' */
+  gap?:       StackGap;
+  /** 교차축(가로) 정렬. 기본: 'stretch' */
+  align?:     StackAlign;
+  /** 렌더링할 HTML 태그. 기본: 'div' */
+  as?:        React.ElementType;
+  className?: string;
+}
+```
+
+## Modules (분자 컴포넌트 — 2개 이상 Core 조합, 도메인 무관)
+
+### AccountSelectItem
+
+```typescript
+import React from 'react';
+
+export interface AccountSelectItemProps {
+  /**
+   * 아이콘 슬롯.
+   * lucide-react 아이콘 컴포넌트를 전달한다.
+   * 선택 상태에 따라 컨테이너 배경·색상이 자동 전환된다.
+   */
+  icon?: React.ReactNode;
+  /** 계좌 명칭 (예: \"하나 주거래 통장\") */
+  accountName: string;
+  /** 계좌번호 (예: \"123-456-789012\") */
+  accountNumber: string;
+  /**
+   * 잔액 표시 문자열 (예: \"3,000,000원\").
+   * 포맷 처리는 호출자에서 완료 후 전달한다.
+   */
+  balance: string;
+  /**
+   * 선택 상태. 기본값: false
+   * - true : 브랜드 배경(bg-brand-5) + 브랜드 아이콘 원 + 우측 체크 아이콘
+   * - false: 기본 배경 + 중립 아이콘 원
+   */
+  selected?: boolean;
+  /** 클릭 핸들러 */
+  onClick?: () => void;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### ActionLinkItem
+
+```typescript
+import React from 'react';
+
+export interface ActionLinkItemProps {
+  /**
+   * 아이콘 슬롯.
+   * lucide-react Icon 컴포넌트 또는 이미지 요소를 전달한다.
+   * @example <Share2 className="size-5" />
+   */
+  icon: React.ReactNode;
+  /**
+   * 아이콘 배경 원의 추가 className.
+   * 브랜드별 아이콘 배경색을 지정할 때 사용한다.
+   * 기본값: 'bg-brand-10 text-brand-text' (브랜드 청록색 반투명)
+   * @example "bg-[#fee500]" — 카카오톡 노란색 배경
+   */
+  iconBgClassName?: string;
+  /** 링크 레이블 텍스트 */
+  label: string;
+  /**
+   * 상하 패딩 크기. 기본값: 'md'.
+   * - 'md': py-standard (16px) — 카드형 단독 액션 버튼
+   * - 'sm': py-sm (8px)       — 목록 내 행처럼 촘촘하게 나열할 때
+   */
+  size?: 'sm' | 'md';
+  /**
+   * 카드 테두리 표시 여부. 기본값: true.
+   * false로 설정하면 border·shadow가 제거되어 목록 내 행(row) 형태로 사용 가능.
+   * @example showBorder={false} — 전체 메뉴 화면의 메뉴 목록 행
+   */
+  showBorder?: boolean;
+  /** 클릭 이벤트 핸들러 */
+  onClick?: () => void;
+  /** 추가 CSS className */
+  className?: string;
+}
+```
+
+### AlertBanner
+
+```typescript
+import React from 'react';
+
+/**
+ * 배너의 의미·색상 조합을 결정하는 intent.
+ * - 'warning' : 주의·경고 (amber/노란색)
+ * - 'danger'  : 오류·위험 (red)
+ * - 'success' : 완료·성공 (green)
+ * - 'info'    : 안내·정보 (blue)
+ */
+export type AlertBannerIntent = 'warning' | 'danger' | 'success' | 'info';
+
+export interface AlertBannerProps {
+  /**
+   * 배너 의미·색상 조합. 기본값: 'warning'
+   * Figma 이체 확인 화면의 주의 배너는 'warning'을 사용한다.
+   */
+  intent?: AlertBannerIntent;
+  /**
+   * 배너 텍스트 콘텐츠.
+   * 문자열 또는 ReactNode(강조 span 포함) 모두 허용한다.
+   */
+  children: React.ReactNode;
+  /**
+   * 좌측 아이콘 슬롯 override.
+   * 미전달 시 intent별 기본 아이콘이 자동 사용된다.
+   * @example icon={<Lock className="size-4" />}
+   */
+  icon?: React.ReactNode;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### AmountInput
+
+```typescript
+export interface AmountInputProps {
+  /** 원화 단위 숫자 값. 부모에서 관리하는 controlled 값 */
+  value:       number | null;
+  /** 값 변경 시 호출. 유효한 숫자 또는 null 전달 */
+  onChange:    (value: number | null) => void;
+  /** 입력 필드 레이블. 기본: '금액' */
+  label?:      string;
+  /** 도움말 또는 에러 메시지 */
+  helperText?: string;
+  /** 에러 상태 여부 */
+  hasError?:   boolean;
+  /** 빠른 금액 선택 버튼 목록 (단위: 원). 예: [10000, 50000, 100000] */
+  quickAmounts?: number[];
+  /** 최대 입력 가능 금액 (원). 초과 시 hasError로 처리 */
+  maxAmount?:  number;
+  /**
+   * 이체 한도 안내 텍스트. 금액 입력 행 우측에 표시된다.
+   * 예: '1회 5,000,000원 / 1일 10,000,000원'
+   */
+  transferLimitText?: string;
+  disabled?:   boolean;
+  /** 플레이스홀더. 기본: '금액을 입력하세요' */
+  placeholder?: string;
+  className?:  string;
+}
+```
+
+### BalanceToggle
+
+```typescript
+export interface BalanceToggleProps {
+  /** true = 잔액 숨김 상태, false = 잔액 표시 상태 */
+  hidden: boolean
+  /** 토글 클릭 시 호출되는 핸들러 */
+  onToggle: () => void
+  className?: string
+}
+```
+
+### BankSelectGrid
+
+```typescript
+/** 은행 목록 단일 항목 */
+export interface BankItem {
+  /** 은행 식별 코드. 예: 'hana', 'kb', 'shinhan' */
+  code: string;
+  /** 화면에 표시할 은행명. 예: '하나은행' */
+  name: string;
+  /** 은행 로고/아이콘 (ReactNode). 미전달 시 기본 아이콘 표시 */
+  icon?: React.ReactNode;
+}
+
+export interface BankSelectGridProps {
+  /** 선택 가능한 은행 목록 */
+  banks: BankItem[];
+  /** 현재 선택된 은행 코드 */
+  selectedCode?: string;
+  /** 은행 선택 핸들러 */
+  onSelect: (code: string) => void;
+  /** 한 행에 표시할 열 수 (기본: 4) */
+  columns?: 3 | 4;
+}
+```
+
+### BottomSheet
+
+```typescript
+import React from 'react';
+
+/**
+ * 시트 최대 높이 프리셋.
+ * - 'auto': 콘텐츠 높이에 맞춤 (최대 90dvh)
+ * - 'half': 화면 절반(50dvh)
+ * - 'full': 전체 화면(90dvh)
+ */
+export type BottomSheetSnap = 'auto' | 'half' | 'full';
+
+export interface BottomSheetProps {
+  /** 시트 열림 여부 */
+  open: boolean;
+  /** 시트 닫기 핸들러 (백드롭 클릭, ESC 키, 닫기 버튼 공통) */
+  onClose: () => void;
+  /** 시트 상단 타이틀. 미전달 시 타이틀 영역 렌더링 안 함 */
+  title?: string;
+  /** 본문 슬롯 */
+  children?: React.ReactNode;
+  /** 하단 고정 버튼 영역 슬롯 */
+  footer?: React.ReactNode;
+  /**
+   * 시트 최대 높이 프리셋. 기본: 'auto'
+   * 콘텐츠가 프리셋 높이를 초과하면 본문 영역이 내부 스크롤로 전환
+   */
+  snap?: BottomSheetSnap;
+  /**
+   * 백드롭 클릭으로 닫기 비활성화 여부.
+   * 필수 액션이 있는 시트(예: 약관 동의)에서 true로 설정.
+   * 기본: false
+   */
+  disableBackdropClose?: boolean;
+  /**
+   * 헤더 우측 X(닫기) 버튼 숨김 여부. 기본: false
+   * Footer 버튼으로만 닫기를 처리하는 시트(예: 이체 확인)에서 true로 설정한다.
+   * true로 설정해도 ESC 키·백드롭 클릭 닫기는 유지된다.
+   */
+  hideCloseButton?: boolean;
+  className?: string;
+}
+```
+
+### Card
+
+```typescript
+import React from 'react';
+
+export interface CardProps {
+  children:     React.ReactNode;
+  /** true이면 hover/active 인터랙션 스타일 활성화 */
+  interactive?: boolean;
+  /** 전달 시 <button> 태그로 렌더링 */
+  onClick?:     () => void;
+  /**
+   * true이면 카드 내부 padding을 제거한다.
+   * CardHighlight 등 카드 전체 너비를 차지하는 섹션을 구성할 때 사용한다.
+   * 이 경우 내부 콘텐츠에서 직접 padding을 지정해야 한다.
+   */
+  noPadding?:   boolean;
+  className?:   string;
+}
+
+export interface CardHeaderProps {
+  title:      string;
+  subtitle?:  string;
+  /** 헤더 우측 버튼/링크 슬롯 */
+  action?:    React.ReactNode;
+  /** 헤더 좌측 아이콘 슬롯 */
+  icon?:      React.ReactNode;
+}
+
+export interface CardRowProps {
+  label:            string;
+  value:            string;
+  /** 금액 강조 등 값 텍스트 스타일 override */
+  valueClassName?:  string;
+}
+
+/**
+ * 우측에 임의 ReactNode를 배치하는 카드 행 컴포넌트.
+ * value가 단순 문자열이 아닌 경우(편집 아이콘, 액션 버튼 포함 행 등)에 사용한다.
+ * 예) 메모 편집 행, 상대계좌 + 이체하기 버튼 행
+ */
+export interface CardActionRowProps {
+  /** 행 좌측 레이블 */
+  label:      string;
+  /** 행 우측에 자유롭게 배치할 ReactNode */
+  children:   React.ReactNode;
+  className?: string;
+}
+
+/**
+ * 카드 하단의 강조 섹션 컴포넌트.
+ * 이체 후 잔액 등 핵심 수치를 브랜드 색상 배경으로 강조 표시할 때 사용한다.
+ * Card의 noPadding prop과 함께 사용하면 카드 전체 너비를 채울 수 있다.
+ */
+export interface CardHighlightProps {
+  /** 좌측 레이블 텍스트 (예: "이체 후 잔액") */
+  label:            string;
+  /** 우측 값 텍스트 (예: "2,900,000원") */
+  value:            string;
+  /** 값 텍스트 스타일 override */
+  valueClassName?:  string;
+}
+```
+
+### Checkbox
+
+```typescript
+import React from 'react';
+
+export interface CheckboxProps {
+  /** 체크 상태 */
+  checked: boolean;
+  /** 상태 변경 핸들러 */
+  onChange: (checked: boolean) => void;
+  /** 우측 레이블 텍스트 또는 ReactNode */
+  label?: React.ReactNode;
+  /**
+   * label prop이 없을 때 스크린리더용 접근성 이름.
+   * label이 없으면 반드시 전달해야 WCAG 접근성 기준을 충족한다.
+   */
+  ariaLabel?: string;
+  /**
+   * 체크박스 모양. 기본: 'square'
+   * - 'square' : 둥근 모서리 사각형 (기본값, 일반 체크박스)
+   * - 'circle' : 원형 (라디오 버튼 느낌의 단독 선택 등에 사용)
+   */
+  shape?: 'square' | 'circle';
+  /** 비활성화 여부 */
+  disabled?: boolean;
+  /**
+   * 체크박스 input의 id.
+   * 전달 시 label htmlFor와 연결되어 레이블 클릭으로도 체크 상태 변경 가능.
+   */
+  id?: string;
+  className?: string;
+}
+```
+
+### CollapsibleSection
+
+```typescript
+import type React from 'react';
+
+export interface CollapsibleSectionProps {
+  /**
+   * 항상 노출되는 헤더 영역.
+   * 클릭 시 콘텐츠 표시/숨김이 토글된다.
+   */
+  header: React.ReactNode;
+  /** 펼침 상태에서만 표시되는 콘텐츠 */
+  children: React.ReactNode;
+  /**
+   * 초기 펼침 여부.
+   * @default true — 기본적으로 펼쳐진 상태로 렌더링
+   */
+  defaultExpanded?: boolean;
+  /**
+   * 헤더 텍스트 영역 정렬.
+   * - 'left'  : 텍스트를 왼쪽 정렬 (화살표는 항상 우측 끝 고정)
+   * - 'center': 텍스트를 가운데 정렬
+   * @default 'center'
+   */
+  headerAlign?: 'left' | 'center';
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### DatePicker
+
+```typescript
+import type React from 'react';
+
+export type DatePickerMode = 'single' | 'range';
+
+export interface DatePickerProps {
+  /** 선택 모드. 기본: 'single' */
+  mode?:          DatePickerMode;
+  /** single 모드에서 사용하는 선택된 날짜 */
+  value?:         Date | null;
+  /** range 모드에서 사용하는 시작·종료 날짜 */
+  rangeValue?:    [Date | null, Date | null];
+  onChange?:      (date: Date | null) => void;
+  onRangeChange?: (range: [Date | null, Date | null]) => void;
+  minDate?:       Date;
+  maxDate?:       Date;
+  placeholder?:   string;
+  label?:         string;
+  disabled?:      boolean;
+  className?:     string;
+  /**
+   * 외부에서 달력 열림 상태를 제어할 때 사용 (제어 모드).
+   * 이 prop이 제공되면 내장 트리거 버튼을 렌더링하지 않는다.
+   */
+  open?:          boolean;
+  /** 달력 열림 상태 변경 콜백 (제어 모드 전용) */
+  onOpenChange?:  (open: boolean) => void;
+  /**
+   * 달력 패널 위치 계산의 기준이 되는 외부 트리거 요소 (제어 모드 전용).
+   * 미제공 시 내장 triggerRef를 사용한다.
+   */
+  anchorRef?:     React.RefObject<HTMLElement | null>;
+}
+```
+
+### DividerWithLabel
+
+```typescript
+export interface DividerWithLabelProps {
+  /** 구분선 중앙에 표시할 텍스트 (예: '다른 로그인 방식') */
+  label: string;
+  className?: string;
+}
+```
+
+### DropdownMenu
+
+```typescript
+import React from 'react';
+
+/** 드롭다운 메뉴 단일 항목 */
+export interface DropdownMenuItem {
+  /** 표시 레이블 */
+  label: string;
+  /** 좌측 아이콘 (선택) */
+  icon?: React.ReactNode;
+  /** 항목 클릭 핸들러 */
+  onClick: () => void;
+  /**
+   * 항목 스타일 변형. 기본: 'default'
+   * - 'default' : 일반 텍스트 색상
+   * - 'danger'  : 위험 액션(예: 로그아웃·삭제)에 사용, semantic-danger 색상 적용
+   */
+  variant?: 'default' | 'danger';
+}
+
+export interface DropdownMenuProps {
+  /** 드롭다운을 열고 닫는 트리거 요소 */
+  children: React.ReactNode;
+  /** 드롭다운에 표시할 항목 목록 */
+  items: DropdownMenuItem[];
+  /**
+   * 패널 정렬 방향. 기본: 'right'
+   * - 'right' : 트리거 우측 기준 좌측으로 패널 정렬 (우측 끝 버튼에 적합)
+   * - 'left'  : 트리거 좌측 기준 우측으로 패널 정렬
+   */
+  align?: 'left' | 'right';
+  className?: string;
+}
+```
+
+### EmptyState
+
+```typescript
+import React from 'react';
+
+export interface EmptyStateProps {
+  /** SVG 또는 img 요소. 도메인별 일러스트를 외부에서 주입 */
+  illustration?: React.ReactNode;
+  title:         string;
+  description?:  string;
+  /** CTA 버튼 등 액션 슬롯 */
+  action?:       React.ReactNode;
+  className?:    string;
+}
+```
+
+### ErrorState
+
+```typescript
+export interface ErrorStateProps {
+  /** 사용자에게 표시할 에러 메시지 */
+  title?: string;
+  /** 상세 설명 (선택) */
+  description?: string;
+  /** 재시도 버튼 클릭 핸들러. 전달 시 재시도 버튼 노출 */
+  onRetry?: () => void;
+  /** 재시도 버튼 레이블. 기본: '다시 시도' */
+  retryLabel?: string;
+  className?: string;
+}
+```
+
+### InfoRow
+
+```typescript
+export interface InfoRowProps {
+  /** 행 좌측 레이블 텍스트 (예: "출금계좌") */
+  label: string;
+  /** 행 우측 값 텍스트 (예: "하나 123-456-789012") */
+  value: string;
+  /**
+   * 값 텍스트에 추가할 Tailwind 클래스.
+   * 수수료 0원처럼 특정 행 값에 브랜드·강조 색상을 적용할 때 사용한다.
+   * @example valueClassName="text-brand-text"
+   * @example valueClassName="text-base"  — 금액처럼 한 단계 큰 텍스트
+   */
+  valueClassName?: string;
+  /**
+   * 하단 구분선 표시 여부. 기본값: true
+   * 목록 마지막 행이나 구분선이 불필요한 경우 false로 설정한다.
+   */
+  showBorder?: boolean;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### LabelValueRow
+
+```typescript
+import type React from 'react';
+
+export interface LabelValueRowProps {
+  /** 좌측 레이블 텍스트 (caption 크기, muted 색상) */
+  label: string;
+  /**
+   * 우측 값 영역.
+   * 문자열 또는 스타일이 필요한 경우 ReactNode를 전달한다.
+   * (예: 금액에 numeric 폰트·색상 적용 시 <span> 전달)
+   */
+  value: React.ReactNode;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### Modal
+
+```typescript
+import React from 'react';
+
+export type ModalSize      = 'sm' | 'md' | 'lg' | 'fullscreen';
+/**
+ * 모달 헤더 타이틀 정렬 방향.
+ * - 'left'  (기본): 타이틀 좌측 정렬, X 버튼 우측 배치 (일반 확인 모달)
+ * - 'center': 타이틀 중앙 정렬, X 버튼 절대 배치 우측 (경고/안내 모달)
+ */
+export type ModalTitleAlign = 'left' | 'center';
+
+export interface ModalProps {
+  /** 모달 표시 여부 */
+  open:              boolean;
+  /** 닫기 요청 핸들러 (ESC 키, 배경 클릭 포함) */
+  onClose:           () => void;
+  /** 헤더 제목. 생략 시 닫기 버튼만 표시 */
+  title?:            string;
+  /** 본문 영역. 내용이 길면 내부 스크롤 */
+  children:          React.ReactNode;
+  /** 하단 버튼 영역. Button 조합 권장 */
+  footer?:           React.ReactNode;
+  /**
+   * 데스크톱 기준 모달 최대 너비.
+   * 모바일에서는 항상 전체 너비 Bottom Sheet.
+   * @default 'md'
+   */
+  size?:             ModalSize;
+  /** true이면 배경 클릭으로 닫기 비활성화 */
+  disableBackdropClose?: boolean;
+  /**
+   * 헤더 타이틀 정렬.
+   * - 'left'  (기본): 타이틀 좌측, X 버튼 우측 (일반 확인 모달)
+   * - 'center': 타이틀 중앙, X 버튼 절대 우측 (경고·안내 모달)
+   * @default 'left'
+   */
+  titleAlign?:       ModalTitleAlign;
+  className?:        string;
+}
+```
+
+### NoticeItem
+
+```typescript
+import React from 'react';
+
+export interface NoticeItemProps {
+  /**
+   * 아이콘 슬롯.
+   * lucide-react Icon 요소를 전달한다.
+   */
+  icon:             React.ReactNode;
+  /**
+   * 아이콘 배경 원의 추가 className.
+   * 기본값: 'bg-brand-5 text-brand-text'
+   * @example "bg-[#ecfdf5] text-success-text" — 초록색 배경
+   */
+  iconBgClassName?: string;
+  /** 공지 제목 */
+  title:            string;
+  /** 공지 부제목 (미전달 시 미노출) */
+  description?:     string;
+  /** 항목 클릭 핸들러 */
+  onClick?:         () => void;
+  /**
+   * 하단 구분선 표시 여부.
+   * 목록의 마지막 항목에는 false를 전달한다.
+   * 기본값: true
+   */
+  showDivider?:     boolean;
+  className?:       string;
+}
+```
+
+### NumberKeypad
+
+```typescript
+export interface NumberKeypadProps {
+  /**
+   * 키패드에 표시할 숫자 배열 (0~9, 셔플 상태).
+   * - digits[0..8]: 3×3 그리드 (행 우선 순서)
+   * - digits[9]: 하단 행 중앙 버튼
+   * 길이는 반드시 10이어야 한다.
+   */
+  digits: number[];
+  /**
+   * 숫자 버튼 클릭 시 호출.
+   * @param digit - 클릭된 숫자 (0~9)
+   */
+  onDigitPress: (digit: number) => void;
+  /** 지우기(⌫) 버튼 클릭 시 호출 */
+  onDelete: () => void;
+  /** 재배열 버튼 클릭 시 호출 — 고객이 digits를 다시 셔플해서 전달해야 한다 */
+  onShuffle: () => void;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### OtpInput
+
+```typescript
+/** OTP 자릿수. 기본 6자리, 필요 시 4자리 PIN 용도로도 사용 */
+export type OtpLength = 4 | 6;
+
+export interface OtpInputProps {
+  /** OTP 자릿수. 기본: 6 */
+  length?: OtpLength;
+  /** 입력 완료(length개 모두 입력) 시 호출. 완성된 OTP 문자열 전달 */
+  onComplete?: (otp: string) => void;
+  /** 각 자릿수 변경 시 호출 */
+  onChange?: (otp: string) => void;
+  /** 에러 상태 여부 (빨간 테두리 표시) */
+  error?: boolean;
+  /** 비활성화 여부 */
+  disabled?: boolean;
+  /** 숫자 마스킹 여부 (비밀번호 스타일). 기본: false */
+  masked?: boolean;
+  /** 추가 클래스 */
+  className?: string;
+}
+```
+
+### PinConfirmSheet
+
+```typescript
+export interface PinConfirmSheetProps {
+  /** 시트 열림 여부 */
+  open: boolean;
+  /** 닫기 핸들러 */
+  onClose: () => void;
+  /**
+   * PIN 입력 완료 핸들러.
+   * pinLength 자리가 모두 입력되면 자동 호출된다.
+   * @param pin - 입력된 PIN 문자열
+   */
+  onConfirm: (pin: string) => void;
+  /** 시트 상단 타이틀. 기본: '비밀번호 입력' */
+  title?: string;
+  /** PIN 자릿수. 기본: 4 */
+  pinLength?: number;
+}
+```
+
+### PinDotIndicator
+
+```typescript
+export interface PinDotIndicatorProps {
+  /**
+   * 전체 도트 수 (비밀번호 자릿수).
+   * 기본값: 4 — 계좌 비밀번호 4자리에 맞춤
+   */
+  length?: number;
+  /**
+   * 채워진(입력된) 도트 수.
+   * 0 ≤ filledCount ≤ length 범위여야 한다.
+   */
+  filledCount: number;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### RecentRecipientItem
+
+```typescript
+export interface RecentRecipientItemProps {
+  /** 수취인명. 예: '홍길동' */
+  name: string;
+  /** 은행명. 예: '하나은행' */
+  bankName: string;
+  /** 마스킹된 계좌번호. 예: '123-****-5678' */
+  maskedAccount: string;
+  /** 항목 클릭 핸들러 (해당 수취인 정보로 이체 폼 자동 입력) */
+  onClick: () => void;
+}
+```
+
+### SectionHeader
+
+```typescript
+export interface SectionHeaderProps {
+  /** 섹션 제목 텍스트 */
+  title: string;
+  /**
+   * 제목 우측에 표시할 계좌/항목 수 배지 (예: 2 → '2').
+   * 미전달 시 배지 미노출.
+   */
+  badge?: number;
+  /** 우측 액션 레이블 (예: '전체보기'). 미전달 시 액션 영역 미노출 */
+  actionLabel?: string;
+  /** 액션 클릭 핸들러. actionLabel과 함께 전달해야 동작 */
+  onAction?: () => void;
+  /** 추가 클래스 */
+  className?: string;
+}
+```
+
+### SelectableItem
+
+```typescript
+import React from 'react';
+
+export interface SelectableItemProps {
+  /**
+   * 아이콘 슬롯.
+   * lucide-react 아이콘 컴포넌트를 전달한다.
+   * 선택 상태에 따라 컨테이너 배경·아이콘 색상이 자동 전환된다.
+   */
+  icon: React.ReactNode;
+  /** 표시할 레이블 텍스트 (예: "하나은행", "KB국민은행") */
+  label: string;
+  /**
+   * 선택 상태. 기본값: false
+   * - true : 브랜드 배경(bg-brand-5) + 브랜드 아이콘 원 + 브랜드 텍스트
+   * - false: 중립 배경(bg-surface-subtle) + 회색 아이콘 원 + label 텍스트
+   */
+  selected?: boolean;
+  /** 클릭 핸들러 */
+  onClick?: () => void;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### SelectableListItem
+
+```typescript
+export interface SelectableListItemProps {
+  /** 표시 레이블 */
+  label: string;
+  /** 선택 여부 */
+  isSelected: boolean;
+  /** 클릭 핸들러 */
+  onClick: () => void;
+}
+```
+
+### SidebarNav
+
+```typescript
+/** 사이드바 네비게이션 개별 항목 */
+export interface SidebarNavItem {
+  /** 항목 고유 식별자 */
+  id: string;
+  /** 표시할 레이블 텍스트 */
+  label: string;
+}
+
+export interface SidebarNavProps {
+  /** 네비게이션 항목 목록 */
+  items: SidebarNavItem[];
+  /** 현재 활성화된 항목 id */
+  activeId: string;
+  /**
+   * 항목 클릭 시 호출되는 콜백.
+   * 선택된 항목의 id를 인자로 전달한다.
+   */
+  onItemChange: (id: string) => void;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### StepIndicator
+
+```typescript
+export interface StepIndicatorProps {
+  /** 전체 단계 수 */
+  total: number;
+  /** 현재 진행 중인 단계 (1-based) */
+  current: number;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### SuccessHero
+
+```typescript
+export interface SuccessHeroProps {
+  /**
+   * 받는 사람 이름 (예: "홍길동").
+   * 타이틀에 "{recipientName}님께" 형태로 삽입된다.
+   */
+  recipientName: string;
+  /**
+   * 이체 금액 문자열 (예: "50,000원").
+   * 타이틀에 "{amount} 이체 완료" 형태로 삽입된다.
+   */
+  amount: string;
+  /**
+   * 부제목 텍스트.
+   * 기본값: "성공적으로 이체되었습니다."
+   */
+  subtitle?: string;
+  /** 추가 CSS className */
+  className?: string;
+}
+```
+
+### TabNav
+
+```typescript
+export interface TabNavItem {
+  /** 탭 고유 식별자 */
+  id:    string;
+  /** 탭 레이블 텍스트 */
+  label: string;
+}
+
+/**
+ * 탭 스타일 변형.
+ * - 'underline': 활성 탭 하단 인디케이터 라인 (기본값). 상단 내비게이션 탭에 사용.
+ * - 'pill': 활성 탭에 둥근 배경 채움. 상품 카테고리·필터 탭에 사용.
+ */
+export type TabNavVariant = 'underline' | 'pill';
+
+export interface TabNavProps {
+  /** 탭 목록 */
+  items:        TabNavItem[];
+  /** 현재 활성 탭 id */
+  activeId:     string;
+  /**
+   * 탭 변경 핸들러.
+   * @param id - 클릭된 탭 id
+   */
+  onTabChange:  (id: string) => void;
+  /**
+   * 탭 스타일 변형.
+   * @default 'underline'
+   */
+  variant?:     TabNavVariant;
+  /**
+   * 탭 버튼이 컨테이너 전체 너비를 균등하게 채울지 여부.
+   * true: 각 탭이 flex-1로 균등 분할 (Figma의 "full width" 탭 패턴)
+   * false: 탭이 콘텐츠 너비만큼만 차지 (기본값)
+   * @default false
+   */
+  fullWidth?:   boolean;
+  className?:   string;
+}
+```
+
+### TransactionList
+
+```typescript
+/** API 응답 flat 배열의 단일 거래 항목 */
+export interface TransactionItem {
+  id:       string;
+  /** ISO 8601 형식. 예: '2026-03-26T14:30:00Z' */
+  date:     string;
+  title:    string;
+  amount:   number;
+  balance?: number;
+  type:     'deposit' | 'withdrawal' | 'transfer';
+}
+
+/** 날짜별로 그룹핑된 거래 내역 (프론트엔드 변환 후 구조) */
+export interface TransactionGroup {
+  /** 표시용 날짜 문자열 (dateHeaderFormat에 따라 형식이 결정됨) */
+  date:   string;
+  items:  TransactionItem[];
+}
+
+/**
+ * 날짜 그룹 헤더 표시 형식.
+ * - 'month-day'      : 'MM월 DD일'       (기본값, 연도 생략)
+ * - 'year-month-day' : 'YYYY년 MM월 DD일' (연도 포함)
+ */
+export type DateHeaderFormat = 'month-day' | 'year-month-day';
+
+export type TransactionType = 'deposit' | 'withdrawal' | 'transfer';
+
+export interface TransactionListItemProps {
+  type:      TransactionType;
+  title:     string;
+  /** 표시용 날짜 문자열 */
+  date:      string;
+  /** 원화 단위 숫자. 컴포넌트 내부에서 Intl.NumberFormat으로 포맷 */
+  amount:    number;
+  /** 거래 후 잔액 */
+  balance?:  number;
+  onClick?:  () => void;
+}
+
+export interface TransactionListProps {
+  /** API 응답 flat 배열. 컴포넌트 내부에서 날짜별로 그룹핑 */
+  items:      TransactionItem[];
+  /** 로딩 상태 */
+  loading?:   boolean;
+  /** 빈 목록 표시 메시지. 기본: '거래 내역이 없어요' */
+  emptyMessage?: string;
+  /**
+   * 거래 항목 클릭 핸들러.
+   * 전달 시 각 항목이 <button>으로 렌더링되며 hover/active 인터랙션이 활성화된다.
+   * 예: 항목 클릭 → 거래 상세 바텀시트 오픈
+   */
+  onItemClick?: (item: TransactionItem) => void;
+  /**
+   * 날짜 그룹 헤더 표시 형식.
+   * - 'month-day'      : 'MM월 DD일'       (기본값)
+   * - 'year-month-day' : 'YYYY년 MM월 DD일'
+   */
+  dateHeaderFormat?: DateHeaderFormat;
+  className?: string;
+}
+```
+
+### TransactionSearchFilter
+
+```typescript
+/**
+ * 퀵 기간 선택 옵션.
+ * 선택 시 오늘 기준으로 startDate·endDate를 자동 계산한다.
+ */
+export type QuickPeriod = '1m' | '3m' | '6m' | '12m';
+
+/**
+ * 거래 내역 정렬 순서.
+ * - recent: 최근순 (기본값)
+ * - old: 과거순
+ */
+export type SortOrder = 'recent' | 'old';
+
+/**
+ * 거래 유형 필터.
+ * - all: 전체 (기본값)
+ * - deposit: 입금만
+ * - withdrawal: 출금만
+ */
+export type TransactionType = 'all' | 'deposit' | 'withdrawal';
+
+/** 조회 버튼 클릭 시 상위로 전달되는 검색 파라미터 */
+export interface TransactionSearchParams {
+  /** ISO 날짜 형식 'YYYY-MM-DD' */
+  startDate: string;
+  /** ISO 날짜 형식 'YYYY-MM-DD' */
+  endDate: string;
+  sortOrder: SortOrder;
+  transactionType: TransactionType;
+}
+
+export interface TransactionSearchFilterProps {
+  /** 현재 적용된 검색 조건. 초기값 및 외부 동기화에 사용 */
+  value: TransactionSearchParams;
+  /**
+   * 조회 버튼 클릭 시 호출.
+   * 폼 내부 상태(localParams)를 기준으로 호출되므로
+   * 조회 전까지는 외부 value에 영향을 주지 않는다.
+   */
+  onSearch: (params: TransactionSearchParams) => void;
+  /** 초기 펼침 여부. 기본: false (접힌 상태) */
+  defaultExpanded?: boolean;
+  className?: string;
+}
+```
+
+### TransferForm
+
+```typescript
+export interface TransferFormData {
+  /** 받는 계좌번호 */
+  toAccount: string;
+  /** 이체 금액 (원) */
+  amount:    number;
+  /** 메모 (선택) */
+  memo:      string;
+}
+
+export interface TransferFormProps {
+  /** 이체 가능 최대 금액 (내 계좌 잔액) */
+  availableBalance?: number;
+  /** 폼 제출 핸들러. 최종 확인 전에 호출됨 */
+  onSubmit:          (data: TransferFormData) => void;
+  /** 폼 제출 처리 중 여부 (버튼 로딩 상태) */
+  submitting?:       boolean;
+  className?:        string;
+}
+```
+
+### TransferLimitInfo
+
+```typescript
+export interface TransferLimitInfoProps {
+  /** 1회 이체 한도 (원). 예: 1000000 */
+  perTransferLimit: number;
+  /** 1일 이체 한도 (원). 예: 5000000 */
+  dailyLimit: number;
+  /** 오늘 이미 이체한 누적 금액 (원). 전달 시 잔여 한도 함께 표시 */
+  usedAmount?: number;
+}
+```
+
+## Biz (도메인 특화 컴포넌트 — 금융 비즈니스 로직 포함)
+
+### biz/banking
+
+#### AccountSelectorCard
+
+```typescript
+import React from 'react';
+
+export interface AccountSelectorCardProps {
+  /** 계좌명. 예: '하나 주거래 통장' */
+  accountName: string;
+  /** 계좌번호. 예: '123-456-789012'. 마스킹 없이 그대로 표시 */
+  accountNumber: string;
+  /**
+   * 우측 원형 버튼 내 아이콘.
+   * 미전달 시 WalletMinimal 아이콘을 기본으로 사용한다.
+   */
+  icon?: React.ReactNode;
+  /**
+   * 계좌명 영역 클릭 시 콜백.
+   * 계좌 변경 드롭다운 혹은 BottomSheet를 열 때 사용한다.
+   */
+  onAccountChange?: () => void;
+  /** 우측 원형 아이콘 버튼 클릭 시 콜백. 예: 계좌 상세 이동 */
+  onIconClick?: () => void;
+  /**
+   * 우측 원형 아이콘 버튼의 aria-label.
+   * 미전달 시 기본값 '계좌 상세' 사용.
+   * 카드 상세·이체 등 다른 용도로 재사용 시 실제 기능에 맞게 전달한다.
+   */
+  iconAriaLabel?: string;
+  /**
+   * 출금가능금액 표시 문자열.
+   * 전달 시 계좌번호 아래에 브랜드 색상으로 렌더링된다.
+   * 예: '출금가능금액: 3,000,000원'
+   */
+  availableBalance?: string;
+  className?: string;
+}
+```
+
+#### AccountSummaryCard
+
+```typescript
+import React from 'react';
+
+/**
+ * 계좌 유형.
+ * - deposit:       예금(입출금) 계좌
+ * - savings:       적금·저축 계좌
+ * - loan:          대출 계좌 — 금액 danger 색상, 기본 레이블 '대출잔액'
+ * - foreignDeposit: 외화예금 계좌 — balanceDisplay로 외화 포맷 전달
+ * - retirement:    퇴직연금 계좌 — 기본 레이블 '적립금'
+ * - securities:    증권 계좌 — 기본 레이블 '평가금액'
+ */
+export type AccountType =
+  | 'deposit'
+  | 'savings'
+  | 'loan'
+  | 'foreignDeposit'
+  | 'retirement'
+  | 'securities';
+
+export interface AccountSummaryCardProps {
+  /** 계좌 유형. 유형별 금액 레이블·색상·배지 용도가 달라짐 */
+  type:           AccountType;
+  /** 예: '급여 통장', '청약저축' */
+  accountName:    string;
+  /** 예: '123-456-789012'. 화면에 마스킹 없이 그대로 표시 */
+  accountNumber:  string;
+  /** 원화 단위 숫자. 컴포넌트 내부에서 Intl.NumberFormat('ko-KR') 처리 */
+  balance:        number;
+  /**
+   * 화면 표시용 잔액 문자열.
+   * 전달 시 balance의 내부 포맷 변환을 건너뛰고 이 값을 그대로 표시.
+   * 다중 통화(USD·EUR 등) 또는 Repository에서 이미 포맷한 경우에 사용.
+   * (예: '$1,000.00', '총 $1,000.00 (약 1,350,000원)')
+   */
+  balanceDisplay?: string;
+  /**
+   * 금액 영역 레이블. 미전달 시 type별 기본값 사용.
+   * - deposit: '잔액'
+   * - savings: '납입금액'
+   * - loan: '대출잔액'
+   */
+  balanceLabel?:  string;
+  /**
+   * 배지 텍스트. 미전달 시 배지 영역 렌더링 안 함.
+   * - deposit: '주거래', '급여' 등
+   * - savings: 'D-30' (만기일) 등
+   * - loan: '변동금리', '고정금리' 등
+   */
+  badgeText?:     string;
+  /**
+   * 카드 우측 상단 더보기 버튼 종류.
+   * - 'chevron': 다음 화면으로 이동하는 > 아이콘
+   * - 'ellipsis': 추가 옵션 메뉴를 여는 ... 아이콘
+   * 미전달 시 더보기 버튼 미노출.
+   */
+  moreButton?:    'chevron' | 'ellipsis';
+  /** 더보기 버튼 클릭 핸들러. moreButton과 함께 전달해야 동작 */
+  onMoreClick?:   () => void;
+  onClick?:       () => void;
+  /** 이체·내역 버튼 슬롯. 각 버튼은 균등 너비로 확장됨 */
+  actions?:       React.ReactNode;
+  className?:     string;
+}
+```
+
+### biz/card
+
+#### AccountSelectCard
+
+```typescript
+export interface AccountSelectCardProps {
+  /** 은행명. 예: '하나은행' */
+  bankName: string;
+  /** 마스킹된 계좌번호. 예: '123-****-5678' */
+  maskedAccount: string;
+  /** 선택 여부 */
+  isSelected: boolean;
+  /** 클릭 핸들러 */
+  onClick: () => void;
+}
+```
+
+#### BillingPeriodLabel
+
+```typescript
+export interface BillingPeriodLabelProps {
+  /** 이용기간 시작일. 예: '2025.03.01' */
+  startDate:  string;
+  /** 이용기간 종료일. 예: '2025.03.31' */
+  endDate:    string;
+  className?: string;
+}
+```
+
+#### CardBenefitSummary
+
+```typescript
+/** 혜택 항목 단일 정보 */
+export interface BenefitItem {
+  /** 혜택 레이블. 예: '이번달 할인', '캐시백' */
+  label: string;
+  /** 혜택 금액 또는 포인트 (원 또는 P). 예: 12500 */
+  amount: number;
+  /** 단위 표시. 예: '원', 'P' (기본: '원') */
+  unit?: string;
+}
+
+export interface CardBenefitSummaryProps {
+  /** 보유 포인트 잔액 */
+  points: number;
+  /** 이번달 혜택 항목 목록 (할인·캐시백 등) */
+  benefits: BenefitItem[];
+  /** 포인트 상세 클릭 핸들러 */
+  onPointDetail?: () => void;
+  /** 혜택 상세 클릭 핸들러 */
+  onBenefitDetail?: () => void;
+}
+```
+
+#### CardChipItem
+
+```typescript
+export interface CardChipItemProps {
+  /** 카드명. 예: '하나 머니 체크카드' */
+  name: string;
+  /** 마스킹된 카드번호. 예: '1234-****-****-5678' */
+  maskedNumber: string;
+}
+```
+
+#### CardInfoPanel
+
+```typescript
+export interface CardInfoRow {
+  /** 좌측 레이블. 예: '결제 계좌', '결제일' */
+  label: string;
+  /**
+   * 우측 값. '\n' 포함 시 줄바꿈으로 표시.
+   * 예: '하나은행\n123456****1234'
+   */
+  value: string;
+}
+
+export interface CardInfoSection {
+  /** 섹션 제목. 예: '결제정보', '카드 이용기간' */
+  title: string;
+  rows: CardInfoRow[];
+}
+
+export interface CardInfoPanelProps {
+  sections: CardInfoSection[];
+  className?: string;
+}
+```
+
+#### CardLinkedBalance
+
+```typescript
+export interface CardLinkedBalanceProps {
+  /** 연결계좌 잔액 (원) */
+  balance:    number;
+  /** true: 금액 마스킹 표시 */
+  hidden:     boolean;
+  /** 보기/숨기기 버튼 클릭 */
+  onToggle:   () => void;
+  className?: string;
+}
+```
+
+#### CardManagementPanel
+
+```typescript
+/** 카드 관리 네비게이션 단일 행 데이터 */
+export interface CardManagementNavRow {
+  /** 행 레이블 */
+  label:    string;
+  /** 우측 보조 텍스트 (카드번호·계좌번호 등). 미전달 시 미노출 */
+  subText?: string;
+  /** 행 클릭 핸들러 */
+  onClick?: () => void;
+}
+
+export interface CardManagementPanelProps {
+  /** 네비게이션 행 목록. 순서대로 렌더링되며 개수 제한 없음 */
+  rows:       CardManagementNavRow[];
+  className?: string;
+}
+```
+
+#### CardPaymentActions
+
+```typescript
+export interface CardPaymentActionsProps {
+  /** 분할납부 버튼 클릭 핸들러 */
+  onInstallment?: () => void;
+  /** 즉시결제 버튼 클릭 핸들러 */
+  onImmediatePayment?: () => void;
+  /** 일부결제금액이월약정(리볼빙) 버튼 클릭 핸들러 */
+  onRevolving?: () => void;
+  className?: string;
+}
+```
+
+#### CardPaymentItem
+
+```typescript
+import React from 'react';
+
+export interface CardPaymentItemProps {
+  /** 가맹점·서비스 아이콘 (lucide-react 등 React 노드) */
+  icon:               React.ReactNode;
+  /**
+   * 아이콘 배경 Tailwind 클래스.
+   * 미전달 시 기본 bg-brand-10 사용.
+   * 예: 'bg-surface-subtle', 'bg-danger-surface'
+   */
+  iconBgClassName?:   string;
+  /** 카드 영문명. 예: 'HANA MONEY CHECK' */
+  cardEnName:         string;
+  /** 카드 한글명 또는 가맹점명. 예: '하나 머니 체크카드' */
+  cardName:           string;
+  /** 결제 금액 (원). 양수: 결제, 음수: 취소/환불 */
+  amount:             number;
+  /** "상세보기" 버튼 클릭 핸들러. 미전달 시 버튼 미노출 */
+  onDetailClick?:     () => void;
+  /** 행 전체 클릭 핸들러 */
+  onClick?:           () => void;
+  className?:         string;
+}
+```
+
+#### CardPaymentSummary
+
+```typescript
+export interface CardPaymentSummaryProps {
+  /** 출금예정일. 예: '2026.04.08' */
+  dateFull: string;
+  /** 청구 년월. 예: '26년 4월' */
+  dateYM: string;
+  /** 오늘날짜. 예: '04.08' */
+  dateMD: string;
+  /** 총 청구금액 (원) */
+  totalAmount: number;
+  /** 리볼빙 금액 (원). 0이면 표시하지 않음 */
+  revolving?: number;
+  /** 카드론 금액 (원). 0이면 표시하지 않음 */
+  cardLoan?: number;
+  /** 현금서비스 금액 (원). 0이면 표시하지 않음 */
+  cashAdvance?: number;
+  /** 리볼빙(일부결제금액이월약정) 버튼 클릭 핸들러. 미전달 시 버튼 비활성 */
+  onRevolving?: () => void;
+  /** 카드론(장기카드대출) 버튼 클릭 핸들러. 미전달 시 버튼 비활성 */
+  onCardLoan?: () => void;
+  /** 현금서비스(단기카드대출) 버튼 클릭 핸들러. 미전달 시 버튼 비활성 */
+  onCashAdvance?: () => void;
+  /** 날짜(년월) 영역 클릭 핸들러. 전달 시 날짜 선택 모달 등을 열 수 있음 */
+  onDateClick?: () => void;
+  className?: string;
+}
+```
+
+#### CardPerformanceBar
+
+```typescript
+export interface CardPerformanceBarProps {
+  /** 카드명. 예: '하나 머니 체크카드' */
+  cardName: string;
+  /** 이번달 이용금액 (원) */
+  currentAmount: number;
+  /** 혜택 달성을 위한 목표 실적 금액 (원) */
+  targetAmount: number;
+  /** 목표 달성 시 제공되는 혜택 설명. 예: '전월 실적 달성 시 캐시백 1%' */
+  benefitDescription?: string;
+  /** 실적 상세 클릭 핸들러 */
+  onDetail?: () => void;
+}
+```
+
+#### CardPillTab
+
+```typescript
+export interface CardPillTabProps {
+  /** 탭 레이블 (카드명 등) */
+  label: string;
+  /** 선택 여부 */
+  isSelected: boolean;
+  /** 클릭 핸들러 */
+  onClick: () => void;
+}
+```
+
+#### CardSummaryCard
+
+```typescript
+import React from 'react';
+
+/**
+ * 카드 유형.
+ * - credit: 신용카드 — 사용금액 + 한도 표시, warning/danger 색상 분기
+ * - check: 체크카드 — 연결 계좌 잔액 표시
+ * - prepaid: 선불카드 — 충전 잔액 표시
+ */
+export type CardType = 'credit' | 'check' | 'prepaid';
+
+export interface CardSummaryCardProps {
+  /** 카드 유형. 유형별 레이블·색상이 달라짐 */
+  type:             CardType;
+  /** 카드 상품명. 예: '하나 머니 체크카드', '1Q카드' */
+  cardName:         string;
+  /**
+   * 마스킹된 카드 번호. 예: '1234 **** **** 5678'
+   * 컴포넌트는 그대로 표시하며 마스킹 처리는 호출자 책임
+   */
+  cardNumber:       string;
+  /**
+   * 기준 금액.
+   * - credit: 당월 사용금액
+   * - check/prepaid: 잔액
+   */
+  amount:           number;
+  /**
+   * 한도 금액 (credit 타입 전용).
+   * 전달 시 "사용금액 / 한도" 형태로 표시하며 한도 대비 사용률 색상 분기.
+   */
+  limitAmount?:     number;
+  /**
+   * 배지 텍스트. 미전달 시 배지 미노출.
+   * - credit: '포인트 적립', '캐시백' 등 혜택 유형
+   * - check: '주거래' 등
+   * - prepaid: '잔액 부족' 경고 배지 등
+   */
+  badgeText?:       string;
+  onClick?:         () => void;
+  /** 결제내역·충전 버튼 슬롯 */
+  actions?:         React.ReactNode;
+  className?:       string;
+}
+```
+
+#### CardVisual
+
+```typescript
+import React from 'react';
+
+export type CardBrand = 'VISA' | 'Mastercard' | 'AMEX' | 'JCB' | 'UnionPay';
+
+export interface CardVisualProps {
+  /** 카드 이미지 슬롯 (img 또는 SVG 컴포넌트) */
+  cardImage:  React.ReactNode;
+  /** 카드 브랜드 */
+  brand:      CardBrand;
+  /** 카드명. 예: '하나 머니 체크카드' */
+  cardName:   string;
+  /**
+   * compact 모드.
+   * true: 스크롤로 카드 영역을 벗어났을 때 스티키 헤더용 — 브랜드+카드명 한 줄 말줄임.
+   * false(기본): 카드 이미지 + 브랜드 + 카드명 풀 레이아웃.
+   */
+  compact?:   boolean;
+  className?: string;
+}
+```
+
+#### LoanMenuBar
+
+```typescript
+import React from 'react'
+
+export interface LoanMenuBarItem {
+  id: string
+  /** 메뉴 아이콘 (lucide-react ReactNode) */
+  icon: React.ReactNode
+  /** 메뉴 레이블 텍스트 */
+  label: string
+  /** 메뉴 클릭 핸들러 */
+  onClick: () => void
+}
+
+export interface LoanMenuBarProps {
+  /** 메뉴 항목 목록. 보통 단기카드대출 / 장기카드대출 / 리볼빙 3종 */
+  items: LoanMenuBarItem[]
+  className?: string
+}
+```
+
+#### PaymentAccountCard
+
+```typescript
+import type React from 'react';
+
+export interface PaymentAccountCardProps {
+  /** 결제 계좌 명칭. 예: '하나은행 결제계좌' */
+  title: string;
+  /** 출금 가능 시간. 예: '365일 06:00~23:30' */
+  hours: string;
+  /** 당행/타행을 구분하는 아이콘 (lucide-react 컴포넌트) */
+  icon: React.ReactNode;
+}
+```
+
+#### QuickShortcutCard
+
+```typescript
+import React from 'react'
+
+export interface QuickShortcutCardProps {
+  /** 메인 타이틀 (e.g. "내 쿠폰", "카드 신청") */
+  title: string
+  /** 서브 텍스트 (e.g. "3장 사용가능", "맞춤형 추천") */
+  subtitle: string
+  /**
+   * 우측 아이콘 슬롯 (lucide-react ReactNode)
+   * 전달하지 않으면 아이콘 영역이 렌더링되지 않는다.
+   */
+  icon?: React.ReactNode
+  /** 카드 클릭 핸들러 */
+  onClick?: () => void
+  className?: string
+}
+```
+
+#### StatementHeroCard
+
+```typescript
+export interface StatementHeroCardProps {
+  /** 원화 명세서 금액 (정수, 자동 포맷) */
+  amount: number;
+  /**
+   * 결제일 표시 텍스트
+   * @example "12월 25일"
+   */
+  dueDate: string;
+  /**
+   * 카드 상단 설명 레이블
+   * @default "이번 달 명세서"
+   */
+  label?: string;
+  /** 상세 화살표 클릭 핸들러 (전달 시 화살표 아이콘 노출) */
+  onDetail?: () => void;
+  /** true이면 금액을 마스킹 처리하여 숨긴다 */
+  hidden?: boolean;
+  className?: string;
+}
+```
+
+#### StatementTotalCard
+
+```typescript
+export interface StatementTotalCardProps {
+  /** 총 결제금액 (원) */
+  amount: number;
+  /**
+   * 금액 상단 배지 텍스트.
+   * - '예정': 결제 예정 상태
+   * - 미전달: 배지 미노출
+   */
+  badge?: '예정';
+  /** 금액 우측 화살표 클릭 → 이용내역 화면 이동 */
+  onDetailClick?: () => void;
+  /** 분할납부 버튼 클릭 핸들러 */
+  onInstallment?: () => void;
+  /** 즉시결제 버튼 클릭 핸들러 */
+  onImmediatePayment?: () => void;
+  /** 일부결제금액이월약정(리볼빙) 버튼 클릭 핸들러 */
+  onRevolving?: () => void;
+  className?: string;
+}
+```
+
+#### SummaryCard
+
+```typescript
+import React from 'react';
+
+/**
+ * asset  — 총 자산 카드. 좌측 액센트 바 없음, 금액 강조 색상 브랜드
+ * spending — 이번 달 소비 카드. 좌측 도메인 액센트 바 적용, 금액 기본 색상
+ */
+export type SummaryCardVariant = 'asset' | 'spending';
+
+export interface SummaryCardAction {
+  /** 버튼 레이블 */
+  label: string;
+  /** 버튼 클릭 핸들러 */
+  onClick: () => void;
+  /**
+   * 활성 상태. true 시 도메인 액센트 배경(--domain-card-accent)으로 강조
+   * @default false
+   */
+  active?: boolean;
+}
+
+export interface SummaryCardProps {
+  /** 카드 유형 — 레이아웃과 색상에 영향 */
+  variant: SummaryCardVariant;
+  /** 한글 메인 제목 (e.g. "총 자산", "이번 달 소비") */
+  title: string;
+  /** 원화 금액 (정수, 자동 포맷) */
+  amount: number;
+  /** 우측 상단 아이콘 슬롯 */
+  icon?: React.ReactNode;
+  /** 하단 액션 버튼 목록 */
+  actions?: SummaryCardAction[];
+  /** 카드 전체 클릭 핸들러 */
+  onClick?: () => void;
+  /** true이면 금액을 마스킹 처리하여 숨긴다 */
+  hidden?: boolean;
+  className?: string;
+}
+```
+
+#### UsageHistoryFilterSheet
+
+```typescript
+export interface CardOption {
+  value: string;
+  label: string;
+}
+
+export type ApprovalType = 'approved' | 'confirmed';
+export type CardType     = 'all' | 'credit' | 'check';
+export type RegionType   = 'all' | 'domestic' | 'overseas';
+export type UsageType    = 'all' | 'lump' | 'installment' | 'cashAdvance' | 'cancel';
+export type PeriodType   = 'thisMonth' | '1month' | '3months' | 'custom';
+
+export interface SearchFilter {
+  approval:      ApprovalType;
+  cardType:      CardType;
+  /** 선택된 카드 value. 'all' 이면 전체 */
+  selectedCard:  string;
+  region:        RegionType;
+  usageType:     UsageType;
+  period:        PeriodType;
+  /** period === 'custom' 일 때 선택된 월. 예: '2026-03' */
+  customMonth?:  string;
+}
+
+export interface UsageHistoryFilterSheetProps {
+  open: boolean;
+  onClose: () => void;
+  cardOptions: CardOption[];
+  /** 필터 확정 시 호출. filter.customMonth에 선택 월이 담긴다. */
+  onApply: (filter: SearchFilter) => void;
+}
+```
+
+#### UsageTransactionItem
+
+```typescript
+/** 가맹점 상세 정보 — 상세 BottomSheet 아코디언에 표시 */
+export interface MerchantInfo {
+  address?:      string;
+  phone?:        string;
+  businessType?: string;
+}
+
+/** 이용내역 단건 */
+export interface Transaction {
+  id: string;
+  /** 사용처(가맹점명) */
+  merchant: string;
+  /** 결제 금액(원). 음수: 취소/환불 */
+  amount: number;
+  /** 거래일. 예: '2026.04.08' */
+  date: string;
+  /** 거래구분. 예: '일시불' | '할부(3개월)' | '단기카드대출' | '취소' */
+  type: string;
+  /** 승인번호 */
+  approvalNumber: string;
+  /** 거래상태. 예: '승인' | '결제확정' | '취소' */
+  status: string;
+  /** 이용카드명 */
+  cardName: string;
+  /** 가맹점 상세 정보 */
+  merchantInfo?: MerchantInfo;
+}
+
+export interface UsageTransactionItemProps {
+  tx: Transaction;
+  /**
+   * 전달 시 행이 버튼으로 렌더링되며 클릭 시 상세 BottomSheet를 노출한다.
+   * 미전달 시 행은 div로 렌더링되고 상세 BottomSheet를 노출하지 않는다.
+   */
+  onClick?: () => void;
+}
+```
+
+### biz/common
+
+#### BannerCarousel
+
+```typescript
+import React from 'react';
+
+export type BannerVariant = 'promo' | 'info' | 'warning';
+
+export interface BannerCarouselItem {
+  id:           string;
+  /** 배너 색상 변형. 기본: 'promo' */
+  variant?:     BannerVariant;
+  title:        string;
+  description?: string;
+  /** 우측 CTA 슬롯 */
+  action?:      React.ReactNode;
+  /** 전달 시 닫기(×) 버튼 표시 */
+  onClose?:     () => void;
+}
+
+export interface BannerCarouselProps {
+  items:               BannerCarouselItem[];
+  /**
+   * 자동 재생 간격(ms). 기본: 3000.
+   * items.length < 2이면 자동 재생 비활성화.
+   */
+  autoPlayInterval?:   number;
+  className?:          string;
+}
+```
+
+#### BrandBanner
+
+```typescript
+import React from 'react';
+
+export interface BrandBannerProps {
+  /**
+   * 배너 소제목 — 주요 타이틀 위에 표시되는 작은 텍스트.
+   * (예: '개인 맞춤 혜택')
+   */
+  subtitle?: string;
+  /**
+   * 배너 주요 타이틀.
+   * (예: '나만을 위한 특별한 한아멤버스')
+   */
+  title: string;
+  /**
+   * 우측 아이콘 슬롯 — 흰색 반투명 원형 컨테이너 내부에 렌더링됨.
+   * 미전달 시 아이콘 영역 미표시.
+   */
+  icon?: React.ReactNode;
+  /**
+   * 배너 클릭 핸들러.
+   * 전달 시 button 태그로 렌더링되어 클릭 가능 배너가 됨.
+   */
+  onClick?: () => void;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+#### QuickMenuGrid
+
+```typescript
+import React from 'react';
+
+export interface QuickMenuItem {
+  id:      string;
+  icon:    React.ReactNode;
+  label:   string;
+  onClick: () => void;
+  /** 알림 배지 숫자. 0 또는 미전달 시 배지 미노출 */
+  badge?:  number;
+  /**
+   * 아이콘 컨테이너 형태.
+   * - 'circle'  : 원형 (기본값)
+   * - 'rounded' : 각이 둥근 사각형
+   */
+  iconShape?: 'circle' | 'rounded';
+}
+
+export interface QuickMenuGridProps {
+  items:      QuickMenuItem[];
+  /**
+   * 열 수. 기본: 4.
+   * 아이템 수에 따라 4열(기본) 또는 3열 권장.
+   */
+  cols?:      2 | 3 | 4;
+  className?: string;
+}
+```
+
+#### UserProfile
+
+```typescript
+export interface UserProfileProps {
+  /** 표시할 사용자 이름 (예: '김하나님') */
+  name: string;
+  /**
+   * 최근 접속 일시 문자열 (예: '2023.11.01 10:30:15').
+   * 미전달 시 최근 접속 행 미표시.
+   */
+  lastLogin?: string;
+  /**
+   * 내 정보 관리 클릭 핸들러.
+   * onProfileManageClick 또는 onLogoutClick 중 하나라도 전달되면 설정 버튼이 표시된다.
+   */
+  onProfileManageClick?: () => void;
+  /**
+   * 로그아웃 클릭 핸들러.
+   * onProfileManageClick 또는 onLogoutClick 중 하나라도 전달되면 설정 버튼이 표시된다.
+   */
+  onLogoutClick?: () => void;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### biz/insurance
+
+#### InsuranceSummaryCard
+
+```typescript
+import React from 'react';
+
+/**
+ * 보험 유형.
+ * - life: 생명보험 — 사망·만기 보장
+ * - health: 건강보험 — 실손·암 보장
+ * - car: 자동차보험 — 차량 보장
+ */
+export type InsuranceType = 'life' | 'health' | 'car';
+
+/**
+ * 보험 계약 상태.
+ * - active: 정상 유지 중
+ * - pending: 납입 유예
+ * - expired: 만기 또는 해지
+ */
+export type InsuranceStatus = 'active' | 'pending' | 'expired';
+
+export interface InsuranceSummaryCardProps {
+  /** 보험 유형. 유형별 아이콘·레이블이 달라짐 */
+  type:              InsuranceType;
+  /** 보험 상품명. 예: '하나생명 통합종신보험', '하나손해 운전자보험' */
+  insuranceName:     string;
+  /**
+   * 계약 번호 또는 증권 번호.
+   * 예: '2024-001-123456'
+   */
+  contractNumber:    string;
+  /**
+   * 월 납입 보험료 (원화 단위 숫자).
+   * 내부에서 Intl.NumberFormat('ko-KR') 처리.
+   */
+  premium:           number;
+  /**
+   * 다음 납입일. 예: '2026.04.01'
+   * 표시용 문자열로 직접 전달 (포맷은 호출자 책임)
+   */
+  nextPaymentDate?:  string;
+  /** 계약 상태. 상태별 배지 색상이 달라짐 */
+  status:            InsuranceStatus;
+  /**
+   * 배지 텍스트 override. 미전달 시 status 기반 기본 텍스트 사용.
+   * - active: '정상'
+   * - pending: '유예'
+   * - expired: '만기'
+   */
+  badgeText?:        string;
+  onClick?:          () => void;
+  /** 보장 내역·청구 버튼 슬롯 */
+  actions?:          React.ReactNode;
+  className?:        string;
+}
+```

--- a/admin/src/main/resources/prompts/design-tokens.md
+++ b/admin/src/main/resources/prompts/design-tokens.md
@@ -1,0 +1,54 @@
+# Design Tokens
+
+> 이 파일은 `scripts/extract-design-tokens.ts`로 자동 생성됩니다. 직접 수정하지 마세요.
+> Claude API system prompt에 포함되어 하드코딩 방지용 레퍼런스로 사용됩니다.
+
+## 사용 규칙
+
+- 색상·간격·타이포는 반드시 CSS 변수(`var(--*)`) 또는 Tailwind 토큰 클래스를 사용할 것
+- `#FFFFFF`, `16px` 같은 하드코딩 금지
+- 브랜드 컬러(`--color-brand-*`)는 prop으로 노출하지 말고 토큰으로 고정할 것
+
+## Semantic Tokens (공통 고정값)
+
+모든 은행 브랜드에서 공통으로 사용되는 시맨틱 컬러. 컴포넌트 내부에 직접 적용.
+
+### color
+
+| CSS 변수 | 참조값 |
+|---------|--------|
+| `--color-brand` | `{brand.primary}` |
+| `--color-danger` | `#e11d48` |
+| `--color-text` | `#ffffff` |
+| `--color-border` | `#e2e8f0` |
+| `--color-surface` | `#ffffff` |
+| `--color-success` | `#16a34a` |
+| `--color-warning` | `#d97706` |
+| `--color-primary` | `#2563eb` |
+| `--color-info-surface` | `#eff6ff` |
+
+## Brand Tokens — hana (하나은행)
+
+브랜드별 가변 토큰. `data-brand="hana"` 속성으로 주입됨.
+컴포넌트 prop에 색상 값을 직접 전달하지 말 것.
+
+| CSS 변수 | 값 |
+|---------|-----|
+| `--brand-primary` | `#008485` |
+| `--brand-alt` | `#14b8a6` |
+| `--brand-fg` | `#ffffff` |
+| `--brand-text` | `#008485` |
+| `--brand-dark` | `#006e6f` |
+| `--brand-darker` | `#005859` |
+| `--brand-shadow` | `#00848540` |
+| `--brand-bg` | `#f5f8f8` |
+| `--brand-name` | `하나은행` |
+| `--brand-domain-card-accent` | `#caee5d` |
+| `--brand-domain-card-accentText` | `#546b00` |
+
+## Primitive Tokens (참고용 — 직접 사용 금지)
+
+Semantic/Brand 토큰이 참조하는 원시값. 컴포넌트에서 직접 사용하지 말 것.
+
+| CSS 변수 | 값 |
+|---------|-----|

--- a/admin/src/main/resources/templates/pages/react-generate/react-generate-script.html
+++ b/admin/src/main/resources/templates/pages/react-generate/react-generate-script.html
@@ -43,11 +43,13 @@
         $('#generatingIndicator').removeClass('d-none');
         $('#btnGenerate').prop('disabled', true);
 
+        const requirements = $('#requirementsInput').val().trim() || null;
+
         $.ajax({
             url: API_BASE_URL + '/react-generate/generate',
             method: 'POST',
             contentType: 'application/json',
-            data: JSON.stringify({ figmaUrl: figmaUrl }),
+            data: JSON.stringify({ figmaUrl: figmaUrl, requirements: requirements }),
             success: function (res) {
                 if (res.success && res.data) {
                     renderResult(res.data);

--- a/admin/src/main/resources/templates/pages/react-generate/react-generate-script.html
+++ b/admin/src/main/resources/templates/pages/react-generate/react-generate-script.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<th:block th:fragment="script">
+<script th:inline="javascript">
+    const HAS_REACT_WRITE = /*[[${userAuthorities != null && userAuthorities.contains('REACT_GENERATE:W')}]]*/ false;
+
+    let currentId = null;
+    let currentStatus = null;
+
+    const STATUS_LABEL = {
+        GENERATED:        { text: '생성 완료',  cls: 'bg-secondary' },
+        PENDING_APPROVAL: { text: '승인 대기',  cls: 'bg-warning text-dark' },
+        APPROVED:         { text: '승인 완료',  cls: 'bg-success' }
+    };
+
+    function updateStatusBadge(status) {
+        currentStatus = status;
+        const info = STATUS_LABEL[status] || { text: status, cls: 'bg-secondary' };
+        const badge = $('#statusBadge');
+        badge.text(info.text).removeClass().addClass('badge ' + info.cls);
+
+        // 버튼 상태 업데이트
+        $('#btnRequestApproval').prop('disabled', status !== 'GENERATED');
+        if ($('#btnApprove').length) {
+            $('#btnApprove').prop('disabled', status !== 'PENDING_APPROVAL');
+        }
+    }
+
+    // ─── 생성 ───────────────────────────────────────────────
+    $('#btnGenerate').on('click', function () {
+        const figmaUrl = $('#figmaUrlInput').val().trim();
+        if (!figmaUrl) {
+            Toast.warning('Figma URL을 입력해주세요.');
+            return;
+        }
+        if (!figmaUrl.startsWith('https://www.figma.com/')) {
+            Toast.warning('올바른 Figma URL 형식이 아닙니다.');
+            return;
+        }
+
+        $('#resultSection').addClass('d-none');
+        $('#generatingIndicator').removeClass('d-none');
+        $('#btnGenerate').prop('disabled', true);
+
+        $.ajax({
+            url: API_BASE_URL + '/react-generate/generate',
+            method: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({ figmaUrl: figmaUrl }),
+            success: function (res) {
+                if (res.success && res.data) {
+                    renderResult(res.data);
+                } else {
+                    Toast.error(res.message || '코드 생성에 실패했습니다.');
+                }
+            },
+            error: function (xhr) {
+                const msg = xhr.responseJSON?.message || '코드 생성 중 오류가 발생했습니다.';
+                Toast.error(msg);
+            },
+            complete: function () {
+                $('#generatingIndicator').addClass('d-none');
+                $('#btnGenerate').prop('disabled', false);
+            }
+        });
+    });
+
+    function renderResult(data) {
+        currentId = data.id;
+
+        // 메타 정보
+        $('#resultMeta').text('생성일시: ' + (data.createdAt || ''));
+
+        // 화면 미리보기 (iframe srcdoc)
+        const frame = document.getElementById('previewFrame');
+        frame.srcdoc = data.previewHtml || '';
+
+        // 코드 미리보기 (escape XSS)
+        const escaped = (data.reactCode || '').replace(/&/g, '&amp;')
+                                               .replace(/</g, '&lt;')
+                                               .replace(/>/g, '&gt;');
+        document.getElementById('codeDisplay').innerHTML = escaped;
+
+        updateStatusBadge(data.status);
+        $('#resultSection').removeClass('d-none');
+
+        // 첫 탭 활성화
+        const screenTab = new bootstrap.Tab(document.getElementById('tab-screen'));
+        screenTab.show();
+    }
+
+    // ─── 코드 복사 ───────────────────────────────────────────
+    $('#btnCopyCode').on('click', function () {
+        const code = document.getElementById('codeDisplay').textContent;
+        navigator.clipboard.writeText(code).then(function () {
+            Toast.success('코드가 클립보드에 복사되었습니다.');
+        }).catch(function () {
+            Toast.error('복사에 실패했습니다.');
+        });
+    });
+
+    // ─── 승인 요청 ───────────────────────────────────────────
+    $('#btnRequestApproval').on('click', function () {
+        if (!currentId) return;
+        if (!confirm('승인을 요청하시겠습니까?')) return;
+
+        $.ajax({
+            url: API_BASE_URL + '/react-generate/' + currentId + '/request-approval',
+            method: 'POST',
+            success: function (res) {
+                if (res.success && res.data) {
+                    updateStatusBadge(res.data.status);
+                    Toast.success('승인 요청이 완료되었습니다.');
+                } else {
+                    Toast.error(res.message || '승인 요청에 실패했습니다.');
+                }
+            },
+            error: function (xhr) {
+                Toast.error(xhr.responseJSON?.message || '승인 요청 중 오류가 발생했습니다.');
+            }
+        });
+    });
+
+    // ─── 승인 ────────────────────────────────────────────────
+    $('#btnApprove').on('click', function () {
+        if (!currentId) return;
+        if (!confirm('해당 코드를 승인하시겠습니까?')) return;
+
+        $.ajax({
+            url: API_BASE_URL + '/react-generate/' + currentId + '/approve',
+            method: 'POST',
+            success: function (res) {
+                if (res.success && res.data) {
+                    updateStatusBadge(res.data.status);
+                    Toast.success('승인이 완료되었습니다. (승인자: ' + (res.data.approvedBy || '') + ')');
+                } else {
+                    Toast.error(res.message || '승인에 실패했습니다.');
+                }
+            },
+            error: function (xhr) {
+                Toast.error(xhr.responseJSON?.message || '승인 처리 중 오류가 발생했습니다.');
+            }
+        });
+    });
+
+    // ─── Enter 키 지원 ──────────────────────────────────────
+    $('#figmaUrlInput').on('keydown', function (e) {
+        if (e.key === 'Enter') {
+            $('#btnGenerate').trigger('click');
+        }
+    });
+</script>
+</th:block>
+</body>
+</html>

--- a/admin/src/main/resources/templates/pages/react-generate/react-generate.html
+++ b/admin/src/main/resources/templates/pages/react-generate/react-generate.html
@@ -11,23 +11,30 @@
         </h4>
     </div>
 
-    <!-- Figma URL Input Card -->
+    <!-- Input Card -->
     <div class="card mb-3">
         <div class="card-body">
-            <div class="row g-2 align-items-end">
-                <div class="col">
-                    <label for="figmaUrlInput" class="form-label fw-semibold">Figma URL</label>
-                    <input type="url"
-                           id="figmaUrlInput"
-                           class="form-control"
-                           placeholder="https://www.figma.com/design/..."
-                           autocomplete="off">
-                </div>
-                <div class="col-auto">
-                    <button type="button" class="btn btn-primary" id="btnGenerate">
-                        <i class="bi bi-lightning-charge-fill me-1"></i>생성
-                    </button>
-                </div>
+            <div class="mb-2">
+                <label for="figmaUrlInput" class="form-label fw-semibold">Figma URL</label>
+                <input type="url"
+                       id="figmaUrlInput"
+                       class="form-control"
+                       placeholder="https://www.figma.com/design/..."
+                       autocomplete="off">
+            </div>
+            <div class="mb-3">
+                <label for="requirementsInput" class="form-label fw-semibold">
+                    요구사항 <span class="text-muted fw-normal small">(선택)</span>
+                </label>
+                <textarea id="requirementsInput"
+                          class="form-control"
+                          rows="3"
+                          placeholder="예: 이체 화면의 계좌 선택 카드를 생성해줘. primary 버튼만 사용할 것."></textarea>
+            </div>
+            <div class="d-flex justify-content-end">
+                <button type="button" class="btn btn-primary" id="btnGenerate">
+                    <i class="bi bi-lightning-charge-fill me-1"></i>생성
+                </button>
             </div>
         </div>
     </div>

--- a/admin/src/main/resources/templates/pages/react-generate/react-generate.html
+++ b/admin/src/main/resources/templates/pages/react-generate/react-generate.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<div th:fragment="content">
+
+    <!-- Page Header -->
+    <div class="page-header">
+        <h4 class="page-title">
+            <i class="bi bi-code-slash text-primary"></i>
+            React 코드 생성
+        </h4>
+    </div>
+
+    <!-- Figma URL Input Card -->
+    <div class="card mb-3">
+        <div class="card-body">
+            <div class="row g-2 align-items-end">
+                <div class="col">
+                    <label for="figmaUrlInput" class="form-label fw-semibold">Figma URL</label>
+                    <input type="url"
+                           id="figmaUrlInput"
+                           class="form-control"
+                           placeholder="https://www.figma.com/design/..."
+                           autocomplete="off">
+                </div>
+                <div class="col-auto">
+                    <button type="button" class="btn btn-primary" id="btnGenerate">
+                        <i class="bi bi-lightning-charge-fill me-1"></i>생성
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Generating Indicator -->
+    <div id="generatingIndicator" class="d-none text-center py-4">
+        <div class="spinner-border text-primary me-2" role="status" aria-hidden="true"></div>
+        <span class="text-muted">React 코드를 생성하는 중입니다...</span>
+    </div>
+
+    <!-- Result Section -->
+    <div id="resultSection" class="d-none">
+
+        <!-- Status Badge -->
+        <div class="d-flex align-items-center justify-content-between mb-2">
+            <span class="text-muted small" id="resultMeta"></span>
+            <span class="badge" id="statusBadge"></span>
+        </div>
+
+        <!-- Preview Tabs -->
+        <ul class="nav nav-tabs" id="previewTabs" role="tablist">
+            <li class="nav-item" role="presentation">
+                <button class="nav-link active"
+                        id="tab-screen"
+                        data-bs-toggle="tab"
+                        data-bs-target="#screenPreview"
+                        type="button"
+                        role="tab">
+                    <i class="bi bi-display me-1"></i>화면 미리보기
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link"
+                        id="tab-code"
+                        data-bs-toggle="tab"
+                        data-bs-target="#codePreview"
+                        type="button"
+                        role="tab">
+                    <i class="bi bi-file-code me-1"></i>코드 미리보기
+                </button>
+            </li>
+        </ul>
+
+        <div class="tab-content border border-top-0 rounded-bottom">
+            <!-- Screen Preview Tab -->
+            <div class="tab-pane fade show active p-0" id="screenPreview" role="tabpanel">
+                <iframe id="previewFrame"
+                        title="화면 미리보기"
+                        style="width:100%; height:500px; border:none; border-radius: 0 0 4px 4px;">
+                </iframe>
+            </div>
+
+            <!-- Code Preview Tab -->
+            <div class="tab-pane fade" id="codePreview" role="tabpanel">
+                <div class="position-relative">
+                    <button class="btn btn-sm btn-outline-secondary position-absolute top-0 end-0 m-2"
+                            id="btnCopyCode" title="코드 복사">
+                        <i class="bi bi-clipboard"></i>
+                    </button>
+                    <pre id="codeDisplay"
+                         class="bg-dark text-light p-4 m-0 rounded-bottom"
+                         style="overflow-x:auto; max-height:500px; font-size:0.85rem; white-space:pre-wrap;"></pre>
+                </div>
+            </div>
+        </div>
+
+        <!-- Action Buttons -->
+        <div class="d-flex gap-2 mt-3">
+            <button type="button" class="btn btn-outline-warning" id="btnRequestApproval">
+                <i class="bi bi-send me-1"></i>승인 요청
+            </button>
+            <button type="button"
+                    class="btn btn-success"
+                    id="btnApprove"
+                    th:if="${userAuthorities != null and userAuthorities.contains('REACT_GENERATE:W')}">
+                <i class="bi bi-check-circle me-1"></i>승인
+            </button>
+        </div>
+    </div>
+
+    <!-- Scripts -->
+    <th:block th:replace="~{pages/react-generate/react-generate-script :: script}" />
+</div>
+</body>
+</html>

--- a/reactive-springware/generated/component-map.md
+++ b/reactive-springware/generated/component-map.md
@@ -1,3 +1,5 @@
+<!-- 이 파일은 scripts/extract-component-map.ts로 자동 생성됩니다. 직접 수정하지 마세요. -->
+<!-- 원본: docs/component-map.md -->
 # Component Map — Figma → React 매핑 전략
 
 > **대상 Figma 파일**: Hana Bank App (`eRnV2DPVtHbGn5HSISS65O`)

--- a/reactive-springware/generated/component-types.md
+++ b/reactive-springware/generated/component-types.md
@@ -1,0 +1,2207 @@
+# Component Types
+
+> 이 파일은 `scripts/extract-components.ts`로 자동 생성됩니다. 직접 수정하지 마세요.
+> Claude API system prompt에 포함되어 컴포넌트 API 레퍼런스로 사용됩니다.
+
+## 사용 규칙
+
+- 아래 컴포넌트만 사용할 것. 목록에 없는 컴포넌트는 존재하지 않음
+- import 경로: `@neobnsrnd-team/reactive-springware`
+- TypeScript로 작성하고 props interface를 포함할 것
+
+## Core (원자 컴포넌트 — Button, Input, Badge 등 단일 HTML 요소 수준)
+
+### Badge
+
+```typescript
+import React from 'react';
+
+/** primary: 시스템 공통 파란색 | brand: 현재 은행 브랜드색 */
+export type BadgeVariant = 'primary' | 'brand' | 'success' | 'danger' | 'warning' | 'neutral';
+
+export interface BadgeProps {
+  /** 배지 색상 변형. 기본: 'neutral' */
+  variant?:   BadgeVariant;
+  /** dot 모드일 때는 children 없이도 사용 가능 */
+  children?:  React.ReactNode;
+  /** true이면 텍스트 없이 점(dot)만 표시 */
+  dot?:       boolean;
+  className?: string;
+}
+```
+
+### Button
+
+```typescript
+import React from 'react';
+
+export type ButtonVariant = 'primary' | 'outline' | 'ghost' | 'danger';
+export type ButtonSize    = 'sm' | 'md' | 'lg';
+/**
+ * 버튼 내부 콘텐츠 정렬 방향.
+ * - `center` (기본): 텍스트+아이콘을 가운데 정렬
+ * - `between`: 아코디언 트리거 등에서 좌우 분리
+ */
+export type ButtonJustify = 'center' | 'between';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** 버튼 외형 변형. 기본: 'primary' */
+  variant?:   ButtonVariant;
+  /** 버튼 크기. 기본: 'md' */
+  size?:      ButtonSize;
+  /** true이면 로딩 스피너 표시 및 aria-busy 처리 */
+  loading?:   boolean;
+  /** true이면 정방형 아이콘 전용 버튼 (텍스트 숨김) */
+  iconOnly?:  boolean;
+  leftIcon?:  React.ReactNode;
+  rightIcon?: React.ReactNode;
+  /** true이면 w-full 적용 */
+  fullWidth?: boolean;
+  /** 내부 정렬. 기본: 'center' */
+  justify?:   ButtonJustify;
+}
+
+export interface ButtonGroupProps {
+  children:   React.ReactNode;
+  className?: string;
+}
+```
+
+### Input
+
+```typescript
+import React from 'react';
+
+export type InputSize            = 'md' | 'lg';
+export type InputValidationState = 'default' | 'error' | 'success';
+
+export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  /** 입력 필드 레이블 */
+  label?:           string;
+  /** 안내 문구 또는 에러 메시지. validationState='error' 시 빨간색으로 표시 */
+  helperText?:      string;
+  /** 유효성 상태. 기본: 'default' */
+  validationState?: InputValidationState;
+  /**
+   * 입력 필드 높이. 기본: 'md'.
+   * HTMLInputElement의 size(number)와 충돌하므로 Omit 후 재정의.
+   */
+  size?:            InputSize;
+  leftIcon?:        React.ReactNode;
+  /** 우측 버튼/단위 슬롯 (인증번호 전송, 단위 텍스트 등) */
+  rightElement?:    React.ReactNode;
+  /** true이면 w-full 적용 */
+  fullWidth?:       boolean;
+  /**
+   * 입력값 포맷 패턴. `#`은 숫자 한 자리, 그 외 문자는 구분자로 그대로 삽입된다.
+   * 숫자만 입력받고, 최대 자릿수는 패턴의 `#` 개수로 자동 제한된다.
+   *
+   * @example
+   * '###-######-#####'  // 하나은행  → 012-345678-90123
+   * '######-##-######'  // KB국민은행 → 012345-67-890123
+   */
+  formatPattern?:   string;
+  /**
+   * 한국 휴대폰번호 포맷 적용 여부.
+   * 자릿수에 따라 포맷이 동적으로 전환된다.
+   * - 10자리: 010-XXX-XXXX  (3-3-4)
+   * - 11자리: 010-XXXX-XXXX (3-4-4)
+   * `formatPattern`과 함께 사용하면 `phoneFormat`이 우선 적용된다.
+   */
+  phoneFormat?:     boolean;
+}
+```
+
+### Select
+
+```typescript
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+export interface SelectProps {
+  /** 드롭다운 선택지 목록 */
+  options:    SelectOption[];
+  /** 현재 선택된 값 */
+  value:      string;
+  /** 선택 변경 핸들러 */
+  onChange:   (value: string) => void;
+  /** 접근성 레이블 (aria-label) */
+  'aria-label'?: string;
+  className?: string;
+}
+```
+
+### Typography
+
+```typescript
+import React from 'react';
+
+export type TypographyVariant = 'heading' | 'subheading' | 'body-lg' | 'body' | 'body-sm' | 'caption';
+export type TypographyWeight  = 'normal' | 'medium' | 'bold';
+export type TypographyColor   = 'heading' | 'base' | 'label' | 'secondary' | 'muted' | 'brand' | 'danger' | 'success';
+
+export interface TypographyProps {
+  /** 텍스트 크기 변형. 기본: 'body' */
+  variant?:   TypographyVariant;
+  /** 폰트 굵기. 기본: variant별 기본값 적용 */
+  weight?:    TypographyWeight;
+  /** 텍스트 색상. 기본: 'base' */
+  color?:     TypographyColor;
+  /** true이면 font-numeric(Manrope) 적용 — 금액·숫자 표시용 */
+  numeric?:   boolean;
+  /** 렌더링할 HTML 태그. 기본: 'p' */
+  as?:        React.ElementType;
+  children:   React.ReactNode;
+  className?: string;
+}
+
+/* 하위 호환성 — 기존 TextProps 참조가 있는 고객 코드를 위해 alias 유지 */
+export type TextProps    = TypographyProps;
+export type TextVariant  = TypographyVariant;
+export type TextWeight   = TypographyWeight;
+export type TextColor    = TypographyColor;
+```
+
+## Layout (페이지 구조 컴포넌트 — PageLayout, Stack, Grid, Inline 등)
+
+### AppBrandHeader
+
+```typescript
+export interface AppBrandHeaderProps {
+  /**
+   * 브랜드 이니셜 — 원형 배지 내부에 표시.
+   * 예: 'H' (하나은행), 'K' (국민은행), 'S' (신한은행)
+   */
+  brandInitial: string;
+  /**
+   * 브랜드명 — 이니셜 배지 오른쪽에 표시.
+   * 예: '하나은행'
+   */
+  brandName: string;
+  className?: string;
+}
+```
+
+### BlankPageLayout
+
+```typescript
+import React from 'react';
+
+export interface BlankPageLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * 콘텐츠 세로 정렬 방식.
+   * - 'top': 상단 정렬 (기본값 — 온보딩 스크롤 화면)
+   * - 'center': 수직 중앙 정렬 (로그인 폼 등 단일 블록 화면)
+   */
+  align?: 'top' | 'center';
+  className?: string;
+}
+```
+
+### BottomNav
+
+```typescript
+import React from 'react';
+
+export interface BottomNavItem {
+  /** 항목 고유 식별자 (activeId 비교에 사용) */
+  id:          string;
+  /** 비활성 상태 아이콘 */
+  icon:        React.ReactNode;
+  /** 활성 상태 아이콘. 미전달 시 icon 재사용 */
+  activeIcon?: React.ReactNode;
+  /** 탭 레이블 텍스트 */
+  label:       string;
+  /** 탭 클릭 핸들러 */
+  onClick:     () => void;
+}
+
+export interface BottomNavProps {
+  /** 탭 항목 목록 */
+  items:      BottomNavItem[];
+  /** 현재 활성 탭 id */
+  activeId:   string;
+  className?: string;
+}
+```
+
+### Grid
+
+```typescript
+import React from 'react';
+
+import type { StackGap } from '../Stack/types';
+
+export interface GridProps {
+  children:      React.ReactNode;
+  /**
+   * 모바일 기준 열 수. 기본: 2.
+   */
+  cols?:         1 | 2 | 3 | 4;
+  /**
+   * 태블릿(md 이상) 기준 열 수. 미전달 시 cols 값 유지.
+   */
+  tabletCols?:   2 | 3 | 4;
+  /** 셀 간격. 기본: 'sm' */
+  gap?:          StackGap;
+  className?:    string;
+}
+```
+
+### HomePageLayout
+
+```typescript
+import React from 'react';
+
+export interface HomePageLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** 헤더 타이틀 (앱 이름 또는 서비스명, 예: '하나은행') */
+  title: string;
+  /**
+   * 타이틀 좌측에 표시할 로고 아이콘 슬롯.
+   * 미전달 시 로고 영역 렌더링 안 함
+   */
+  logo?: React.ReactNode;
+  /**
+   * 헤더 우측 슬롯.
+   * 미전달 시 기본 프로필·벨·메뉴 3개 아이콘 버튼 표시
+   */
+  rightAction?: React.ReactNode;
+  /**
+   * 알림 뱃지 표시 여부.
+   * rightAction을 직접 전달한 경우 무시됨.
+   * 기본: false
+   */
+  hasNotification?: boolean;
+  /** 하단 글로벌 탭바 영역 여백 자동 추가 여부. 기본: true */
+  withBottomNav?: boolean;
+  className?: string;
+}
+```
+
+### Inline
+
+```typescript
+import React from 'react';
+
+import type { StackGap } from '../Stack/types';
+
+export type InlineAlign   = 'start' | 'center' | 'end' | 'baseline' | 'stretch';
+export type InlineJustify = 'start' | 'center' | 'end' | 'between' | 'around' | 'evenly';
+
+export interface InlineProps {
+  children:   React.ReactNode;
+  /** 요소 간 간격. 기본: 'sm' */
+  gap?:       StackGap;
+  /** 교차축(세로) 정렬. 기본: 'center' */
+  align?:     InlineAlign;
+  /** 주축(가로) 정렬. 기본: 'start' */
+  justify?:   InlineJustify;
+  /** true이면 flex-wrap 적용 */
+  wrap?:      boolean;
+  /** 렌더링할 HTML 태그. 기본: 'div' */
+  as?:        React.ElementType;
+  className?: string;
+}
+```
+
+### ModalSlideOver
+
+```typescript
+import type { ReactNode } from 'react';
+
+export interface ModalSlideOverProps {
+  /** 모달 내부에 렌더링할 콘텐츠 */
+  children: ReactNode;
+  /** 백드롭 클릭 시 호출. 미전달 시 백드롭 클릭으로 닫기 비활성 */
+  onClose?: () => void;
+  /** 슬라이드 방향 (기본: 'right') */
+  direction?: 'right' | 'bottom';
+  /** z-index 레벨 (기본: 50) */
+  zIndex?: number;
+}
+```
+
+### PageLayout
+
+```typescript
+import React from 'react';
+
+export interface PageLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** 상단 헤더 타이틀 */
+  title:         string;
+  /** 전달 시 헤더 좌측에 뒤로가기(<) 버튼 표시 */
+  onBack?:       () => void;
+  /** 헤더 우측 슬롯 (알림·설정·닫기 버튼 등) */
+  rightAction?:  React.ReactNode;
+  /**
+   * 화면 하단 고정 액션 바 슬롯 (iOS 스타일 하단 버튼 영역).
+   * 전달 시 화면 하단에 blur 배경 고정 바가 렌더링되며,
+   * 본문 스크롤 영역에 동일한 높이의 spacer가 추가되어
+   * 마지막 콘텐츠가 고정 바에 가려지지 않는다.
+   */
+  bottomBar?:    React.ReactNode;
+  className?:    string;
+}
+```
+
+### Section
+
+```typescript
+import React from 'react';
+
+export interface SectionProps {
+  /** 섹션 제목. 전달 시 SectionHeader 노출, 미전달 시 제목 없이 콘텐츠만 렌더링 */
+  title?: string;
+  /** 제목 옆 숫자 배지 (항목 수 등) */
+  badge?: number;
+  /** 우측 액션 레이블 (예: '전체보기') */
+  actionLabel?: string;
+  /** 액션 클릭 핸들러 */
+  onAction?: () => void;
+  /** 섹션 내부 콘텐츠 */
+  children: React.ReactNode;
+  /** SectionHeader와 children 사이, 그리고 children 내부 항목 간격. 기본: 'md' */
+  gap?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+  className?: string;
+}
+```
+
+### Stack
+
+```typescript
+import React from 'react';
+
+export type StackGap   = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+export type StackAlign = 'start' | 'center' | 'end' | 'stretch';
+
+export interface StackProps {
+  children:   React.ReactNode;
+  /** 자식 요소 간 간격. 기본: 'md' */
+  gap?:       StackGap;
+  /** 교차축(가로) 정렬. 기본: 'stretch' */
+  align?:     StackAlign;
+  /** 렌더링할 HTML 태그. 기본: 'div' */
+  as?:        React.ElementType;
+  className?: string;
+}
+```
+
+## Modules (분자 컴포넌트 — 2개 이상 Core 조합, 도메인 무관)
+
+### AccountSelectItem
+
+```typescript
+import React from 'react';
+
+export interface AccountSelectItemProps {
+  /**
+   * 아이콘 슬롯.
+   * lucide-react 아이콘 컴포넌트를 전달한다.
+   * 선택 상태에 따라 컨테이너 배경·색상이 자동 전환된다.
+   */
+  icon?: React.ReactNode;
+  /** 계좌 명칭 (예: \"하나 주거래 통장\") */
+  accountName: string;
+  /** 계좌번호 (예: \"123-456-789012\") */
+  accountNumber: string;
+  /**
+   * 잔액 표시 문자열 (예: \"3,000,000원\").
+   * 포맷 처리는 호출자에서 완료 후 전달한다.
+   */
+  balance: string;
+  /**
+   * 선택 상태. 기본값: false
+   * - true : 브랜드 배경(bg-brand-5) + 브랜드 아이콘 원 + 우측 체크 아이콘
+   * - false: 기본 배경 + 중립 아이콘 원
+   */
+  selected?: boolean;
+  /** 클릭 핸들러 */
+  onClick?: () => void;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### ActionLinkItem
+
+```typescript
+import React from 'react';
+
+export interface ActionLinkItemProps {
+  /**
+   * 아이콘 슬롯.
+   * lucide-react Icon 컴포넌트 또는 이미지 요소를 전달한다.
+   * @example <Share2 className="size-5" />
+   */
+  icon: React.ReactNode;
+  /**
+   * 아이콘 배경 원의 추가 className.
+   * 브랜드별 아이콘 배경색을 지정할 때 사용한다.
+   * 기본값: 'bg-brand-10 text-brand-text' (브랜드 청록색 반투명)
+   * @example "bg-[#fee500]" — 카카오톡 노란색 배경
+   */
+  iconBgClassName?: string;
+  /** 링크 레이블 텍스트 */
+  label: string;
+  /**
+   * 상하 패딩 크기. 기본값: 'md'.
+   * - 'md': py-standard (16px) — 카드형 단독 액션 버튼
+   * - 'sm': py-sm (8px)       — 목록 내 행처럼 촘촘하게 나열할 때
+   */
+  size?: 'sm' | 'md';
+  /**
+   * 카드 테두리 표시 여부. 기본값: true.
+   * false로 설정하면 border·shadow가 제거되어 목록 내 행(row) 형태로 사용 가능.
+   * @example showBorder={false} — 전체 메뉴 화면의 메뉴 목록 행
+   */
+  showBorder?: boolean;
+  /** 클릭 이벤트 핸들러 */
+  onClick?: () => void;
+  /** 추가 CSS className */
+  className?: string;
+}
+```
+
+### AlertBanner
+
+```typescript
+import React from 'react';
+
+/**
+ * 배너의 의미·색상 조합을 결정하는 intent.
+ * - 'warning' : 주의·경고 (amber/노란색)
+ * - 'danger'  : 오류·위험 (red)
+ * - 'success' : 완료·성공 (green)
+ * - 'info'    : 안내·정보 (blue)
+ */
+export type AlertBannerIntent = 'warning' | 'danger' | 'success' | 'info';
+
+export interface AlertBannerProps {
+  /**
+   * 배너 의미·색상 조합. 기본값: 'warning'
+   * Figma 이체 확인 화면의 주의 배너는 'warning'을 사용한다.
+   */
+  intent?: AlertBannerIntent;
+  /**
+   * 배너 텍스트 콘텐츠.
+   * 문자열 또는 ReactNode(강조 span 포함) 모두 허용한다.
+   */
+  children: React.ReactNode;
+  /**
+   * 좌측 아이콘 슬롯 override.
+   * 미전달 시 intent별 기본 아이콘이 자동 사용된다.
+   * @example icon={<Lock className="size-4" />}
+   */
+  icon?: React.ReactNode;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### AmountInput
+
+```typescript
+export interface AmountInputProps {
+  /** 원화 단위 숫자 값. 부모에서 관리하는 controlled 값 */
+  value:       number | null;
+  /** 값 변경 시 호출. 유효한 숫자 또는 null 전달 */
+  onChange:    (value: number | null) => void;
+  /** 입력 필드 레이블. 기본: '금액' */
+  label?:      string;
+  /** 도움말 또는 에러 메시지 */
+  helperText?: string;
+  /** 에러 상태 여부 */
+  hasError?:   boolean;
+  /** 빠른 금액 선택 버튼 목록 (단위: 원). 예: [10000, 50000, 100000] */
+  quickAmounts?: number[];
+  /** 최대 입력 가능 금액 (원). 초과 시 hasError로 처리 */
+  maxAmount?:  number;
+  /**
+   * 이체 한도 안내 텍스트. 금액 입력 행 우측에 표시된다.
+   * 예: '1회 5,000,000원 / 1일 10,000,000원'
+   */
+  transferLimitText?: string;
+  disabled?:   boolean;
+  /** 플레이스홀더. 기본: '금액을 입력하세요' */
+  placeholder?: string;
+  className?:  string;
+}
+```
+
+### BalanceToggle
+
+```typescript
+export interface BalanceToggleProps {
+  /** true = 잔액 숨김 상태, false = 잔액 표시 상태 */
+  hidden: boolean
+  /** 토글 클릭 시 호출되는 핸들러 */
+  onToggle: () => void
+  className?: string
+}
+```
+
+### BankSelectGrid
+
+```typescript
+/** 은행 목록 단일 항목 */
+export interface BankItem {
+  /** 은행 식별 코드. 예: 'hana', 'kb', 'shinhan' */
+  code: string;
+  /** 화면에 표시할 은행명. 예: '하나은행' */
+  name: string;
+  /** 은행 로고/아이콘 (ReactNode). 미전달 시 기본 아이콘 표시 */
+  icon?: React.ReactNode;
+}
+
+export interface BankSelectGridProps {
+  /** 선택 가능한 은행 목록 */
+  banks: BankItem[];
+  /** 현재 선택된 은행 코드 */
+  selectedCode?: string;
+  /** 은행 선택 핸들러 */
+  onSelect: (code: string) => void;
+  /** 한 행에 표시할 열 수 (기본: 4) */
+  columns?: 3 | 4;
+}
+```
+
+### BottomSheet
+
+```typescript
+import React from 'react';
+
+/**
+ * 시트 최대 높이 프리셋.
+ * - 'auto': 콘텐츠 높이에 맞춤 (최대 90dvh)
+ * - 'half': 화면 절반(50dvh)
+ * - 'full': 전체 화면(90dvh)
+ */
+export type BottomSheetSnap = 'auto' | 'half' | 'full';
+
+export interface BottomSheetProps {
+  /** 시트 열림 여부 */
+  open: boolean;
+  /** 시트 닫기 핸들러 (백드롭 클릭, ESC 키, 닫기 버튼 공통) */
+  onClose: () => void;
+  /** 시트 상단 타이틀. 미전달 시 타이틀 영역 렌더링 안 함 */
+  title?: string;
+  /** 본문 슬롯 */
+  children?: React.ReactNode;
+  /** 하단 고정 버튼 영역 슬롯 */
+  footer?: React.ReactNode;
+  /**
+   * 시트 최대 높이 프리셋. 기본: 'auto'
+   * 콘텐츠가 프리셋 높이를 초과하면 본문 영역이 내부 스크롤로 전환
+   */
+  snap?: BottomSheetSnap;
+  /**
+   * 백드롭 클릭으로 닫기 비활성화 여부.
+   * 필수 액션이 있는 시트(예: 약관 동의)에서 true로 설정.
+   * 기본: false
+   */
+  disableBackdropClose?: boolean;
+  /**
+   * 헤더 우측 X(닫기) 버튼 숨김 여부. 기본: false
+   * Footer 버튼으로만 닫기를 처리하는 시트(예: 이체 확인)에서 true로 설정한다.
+   * true로 설정해도 ESC 키·백드롭 클릭 닫기는 유지된다.
+   */
+  hideCloseButton?: boolean;
+  className?: string;
+}
+```
+
+### Card
+
+```typescript
+import React from 'react';
+
+export interface CardProps {
+  children:     React.ReactNode;
+  /** true이면 hover/active 인터랙션 스타일 활성화 */
+  interactive?: boolean;
+  /** 전달 시 <button> 태그로 렌더링 */
+  onClick?:     () => void;
+  /**
+   * true이면 카드 내부 padding을 제거한다.
+   * CardHighlight 등 카드 전체 너비를 차지하는 섹션을 구성할 때 사용한다.
+   * 이 경우 내부 콘텐츠에서 직접 padding을 지정해야 한다.
+   */
+  noPadding?:   boolean;
+  className?:   string;
+}
+
+export interface CardHeaderProps {
+  title:      string;
+  subtitle?:  string;
+  /** 헤더 우측 버튼/링크 슬롯 */
+  action?:    React.ReactNode;
+  /** 헤더 좌측 아이콘 슬롯 */
+  icon?:      React.ReactNode;
+}
+
+export interface CardRowProps {
+  label:            string;
+  value:            string;
+  /** 금액 강조 등 값 텍스트 스타일 override */
+  valueClassName?:  string;
+}
+
+/**
+ * 우측에 임의 ReactNode를 배치하는 카드 행 컴포넌트.
+ * value가 단순 문자열이 아닌 경우(편집 아이콘, 액션 버튼 포함 행 등)에 사용한다.
+ * 예) 메모 편집 행, 상대계좌 + 이체하기 버튼 행
+ */
+export interface CardActionRowProps {
+  /** 행 좌측 레이블 */
+  label:      string;
+  /** 행 우측에 자유롭게 배치할 ReactNode */
+  children:   React.ReactNode;
+  className?: string;
+}
+
+/**
+ * 카드 하단의 강조 섹션 컴포넌트.
+ * 이체 후 잔액 등 핵심 수치를 브랜드 색상 배경으로 강조 표시할 때 사용한다.
+ * Card의 noPadding prop과 함께 사용하면 카드 전체 너비를 채울 수 있다.
+ */
+export interface CardHighlightProps {
+  /** 좌측 레이블 텍스트 (예: "이체 후 잔액") */
+  label:            string;
+  /** 우측 값 텍스트 (예: "2,900,000원") */
+  value:            string;
+  /** 값 텍스트 스타일 override */
+  valueClassName?:  string;
+}
+```
+
+### Checkbox
+
+```typescript
+import React from 'react';
+
+export interface CheckboxProps {
+  /** 체크 상태 */
+  checked: boolean;
+  /** 상태 변경 핸들러 */
+  onChange: (checked: boolean) => void;
+  /** 우측 레이블 텍스트 또는 ReactNode */
+  label?: React.ReactNode;
+  /**
+   * label prop이 없을 때 스크린리더용 접근성 이름.
+   * label이 없으면 반드시 전달해야 WCAG 접근성 기준을 충족한다.
+   */
+  ariaLabel?: string;
+  /**
+   * 체크박스 모양. 기본: 'square'
+   * - 'square' : 둥근 모서리 사각형 (기본값, 일반 체크박스)
+   * - 'circle' : 원형 (라디오 버튼 느낌의 단독 선택 등에 사용)
+   */
+  shape?: 'square' | 'circle';
+  /** 비활성화 여부 */
+  disabled?: boolean;
+  /**
+   * 체크박스 input의 id.
+   * 전달 시 label htmlFor와 연결되어 레이블 클릭으로도 체크 상태 변경 가능.
+   */
+  id?: string;
+  className?: string;
+}
+```
+
+### CollapsibleSection
+
+```typescript
+import type React from 'react';
+
+export interface CollapsibleSectionProps {
+  /**
+   * 항상 노출되는 헤더 영역.
+   * 클릭 시 콘텐츠 표시/숨김이 토글된다.
+   */
+  header: React.ReactNode;
+  /** 펼침 상태에서만 표시되는 콘텐츠 */
+  children: React.ReactNode;
+  /**
+   * 초기 펼침 여부.
+   * @default true — 기본적으로 펼쳐진 상태로 렌더링
+   */
+  defaultExpanded?: boolean;
+  /**
+   * 헤더 텍스트 영역 정렬.
+   * - 'left'  : 텍스트를 왼쪽 정렬 (화살표는 항상 우측 끝 고정)
+   * - 'center': 텍스트를 가운데 정렬
+   * @default 'center'
+   */
+  headerAlign?: 'left' | 'center';
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### DatePicker
+
+```typescript
+import type React from 'react';
+
+export type DatePickerMode = 'single' | 'range';
+
+export interface DatePickerProps {
+  /** 선택 모드. 기본: 'single' */
+  mode?:          DatePickerMode;
+  /** single 모드에서 사용하는 선택된 날짜 */
+  value?:         Date | null;
+  /** range 모드에서 사용하는 시작·종료 날짜 */
+  rangeValue?:    [Date | null, Date | null];
+  onChange?:      (date: Date | null) => void;
+  onRangeChange?: (range: [Date | null, Date | null]) => void;
+  minDate?:       Date;
+  maxDate?:       Date;
+  placeholder?:   string;
+  label?:         string;
+  disabled?:      boolean;
+  className?:     string;
+  /**
+   * 외부에서 달력 열림 상태를 제어할 때 사용 (제어 모드).
+   * 이 prop이 제공되면 내장 트리거 버튼을 렌더링하지 않는다.
+   */
+  open?:          boolean;
+  /** 달력 열림 상태 변경 콜백 (제어 모드 전용) */
+  onOpenChange?:  (open: boolean) => void;
+  /**
+   * 달력 패널 위치 계산의 기준이 되는 외부 트리거 요소 (제어 모드 전용).
+   * 미제공 시 내장 triggerRef를 사용한다.
+   */
+  anchorRef?:     React.RefObject<HTMLElement | null>;
+}
+```
+
+### DividerWithLabel
+
+```typescript
+export interface DividerWithLabelProps {
+  /** 구분선 중앙에 표시할 텍스트 (예: '다른 로그인 방식') */
+  label: string;
+  className?: string;
+}
+```
+
+### DropdownMenu
+
+```typescript
+import React from 'react';
+
+/** 드롭다운 메뉴 단일 항목 */
+export interface DropdownMenuItem {
+  /** 표시 레이블 */
+  label: string;
+  /** 좌측 아이콘 (선택) */
+  icon?: React.ReactNode;
+  /** 항목 클릭 핸들러 */
+  onClick: () => void;
+  /**
+   * 항목 스타일 변형. 기본: 'default'
+   * - 'default' : 일반 텍스트 색상
+   * - 'danger'  : 위험 액션(예: 로그아웃·삭제)에 사용, semantic-danger 색상 적용
+   */
+  variant?: 'default' | 'danger';
+}
+
+export interface DropdownMenuProps {
+  /** 드롭다운을 열고 닫는 트리거 요소 */
+  children: React.ReactNode;
+  /** 드롭다운에 표시할 항목 목록 */
+  items: DropdownMenuItem[];
+  /**
+   * 패널 정렬 방향. 기본: 'right'
+   * - 'right' : 트리거 우측 기준 좌측으로 패널 정렬 (우측 끝 버튼에 적합)
+   * - 'left'  : 트리거 좌측 기준 우측으로 패널 정렬
+   */
+  align?: 'left' | 'right';
+  className?: string;
+}
+```
+
+### EmptyState
+
+```typescript
+import React from 'react';
+
+export interface EmptyStateProps {
+  /** SVG 또는 img 요소. 도메인별 일러스트를 외부에서 주입 */
+  illustration?: React.ReactNode;
+  title:         string;
+  description?:  string;
+  /** CTA 버튼 등 액션 슬롯 */
+  action?:       React.ReactNode;
+  className?:    string;
+}
+```
+
+### ErrorState
+
+```typescript
+export interface ErrorStateProps {
+  /** 사용자에게 표시할 에러 메시지 */
+  title?: string;
+  /** 상세 설명 (선택) */
+  description?: string;
+  /** 재시도 버튼 클릭 핸들러. 전달 시 재시도 버튼 노출 */
+  onRetry?: () => void;
+  /** 재시도 버튼 레이블. 기본: '다시 시도' */
+  retryLabel?: string;
+  className?: string;
+}
+```
+
+### InfoRow
+
+```typescript
+export interface InfoRowProps {
+  /** 행 좌측 레이블 텍스트 (예: "출금계좌") */
+  label: string;
+  /** 행 우측 값 텍스트 (예: "하나 123-456-789012") */
+  value: string;
+  /**
+   * 값 텍스트에 추가할 Tailwind 클래스.
+   * 수수료 0원처럼 특정 행 값에 브랜드·강조 색상을 적용할 때 사용한다.
+   * @example valueClassName="text-brand-text"
+   * @example valueClassName="text-base"  — 금액처럼 한 단계 큰 텍스트
+   */
+  valueClassName?: string;
+  /**
+   * 하단 구분선 표시 여부. 기본값: true
+   * 목록 마지막 행이나 구분선이 불필요한 경우 false로 설정한다.
+   */
+  showBorder?: boolean;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### LabelValueRow
+
+```typescript
+import type React from 'react';
+
+export interface LabelValueRowProps {
+  /** 좌측 레이블 텍스트 (caption 크기, muted 색상) */
+  label: string;
+  /**
+   * 우측 값 영역.
+   * 문자열 또는 스타일이 필요한 경우 ReactNode를 전달한다.
+   * (예: 금액에 numeric 폰트·색상 적용 시 <span> 전달)
+   */
+  value: React.ReactNode;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### Modal
+
+```typescript
+import React from 'react';
+
+export type ModalSize      = 'sm' | 'md' | 'lg' | 'fullscreen';
+/**
+ * 모달 헤더 타이틀 정렬 방향.
+ * - 'left'  (기본): 타이틀 좌측 정렬, X 버튼 우측 배치 (일반 확인 모달)
+ * - 'center': 타이틀 중앙 정렬, X 버튼 절대 배치 우측 (경고/안내 모달)
+ */
+export type ModalTitleAlign = 'left' | 'center';
+
+export interface ModalProps {
+  /** 모달 표시 여부 */
+  open:              boolean;
+  /** 닫기 요청 핸들러 (ESC 키, 배경 클릭 포함) */
+  onClose:           () => void;
+  /** 헤더 제목. 생략 시 닫기 버튼만 표시 */
+  title?:            string;
+  /** 본문 영역. 내용이 길면 내부 스크롤 */
+  children:          React.ReactNode;
+  /** 하단 버튼 영역. Button 조합 권장 */
+  footer?:           React.ReactNode;
+  /**
+   * 데스크톱 기준 모달 최대 너비.
+   * 모바일에서는 항상 전체 너비 Bottom Sheet.
+   * @default 'md'
+   */
+  size?:             ModalSize;
+  /** true이면 배경 클릭으로 닫기 비활성화 */
+  disableBackdropClose?: boolean;
+  /**
+   * 헤더 타이틀 정렬.
+   * - 'left'  (기본): 타이틀 좌측, X 버튼 우측 (일반 확인 모달)
+   * - 'center': 타이틀 중앙, X 버튼 절대 우측 (경고·안내 모달)
+   * @default 'left'
+   */
+  titleAlign?:       ModalTitleAlign;
+  className?:        string;
+}
+```
+
+### NoticeItem
+
+```typescript
+import React from 'react';
+
+export interface NoticeItemProps {
+  /**
+   * 아이콘 슬롯.
+   * lucide-react Icon 요소를 전달한다.
+   */
+  icon:             React.ReactNode;
+  /**
+   * 아이콘 배경 원의 추가 className.
+   * 기본값: 'bg-brand-5 text-brand-text'
+   * @example "bg-[#ecfdf5] text-success-text" — 초록색 배경
+   */
+  iconBgClassName?: string;
+  /** 공지 제목 */
+  title:            string;
+  /** 공지 부제목 (미전달 시 미노출) */
+  description?:     string;
+  /** 항목 클릭 핸들러 */
+  onClick?:         () => void;
+  /**
+   * 하단 구분선 표시 여부.
+   * 목록의 마지막 항목에는 false를 전달한다.
+   * 기본값: true
+   */
+  showDivider?:     boolean;
+  className?:       string;
+}
+```
+
+### NumberKeypad
+
+```typescript
+export interface NumberKeypadProps {
+  /**
+   * 키패드에 표시할 숫자 배열 (0~9, 셔플 상태).
+   * - digits[0..8]: 3×3 그리드 (행 우선 순서)
+   * - digits[9]: 하단 행 중앙 버튼
+   * 길이는 반드시 10이어야 한다.
+   */
+  digits: number[];
+  /**
+   * 숫자 버튼 클릭 시 호출.
+   * @param digit - 클릭된 숫자 (0~9)
+   */
+  onDigitPress: (digit: number) => void;
+  /** 지우기(⌫) 버튼 클릭 시 호출 */
+  onDelete: () => void;
+  /** 재배열 버튼 클릭 시 호출 — 고객이 digits를 다시 셔플해서 전달해야 한다 */
+  onShuffle: () => void;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### OtpInput
+
+```typescript
+/** OTP 자릿수. 기본 6자리, 필요 시 4자리 PIN 용도로도 사용 */
+export type OtpLength = 4 | 6;
+
+export interface OtpInputProps {
+  /** OTP 자릿수. 기본: 6 */
+  length?: OtpLength;
+  /** 입력 완료(length개 모두 입력) 시 호출. 완성된 OTP 문자열 전달 */
+  onComplete?: (otp: string) => void;
+  /** 각 자릿수 변경 시 호출 */
+  onChange?: (otp: string) => void;
+  /** 에러 상태 여부 (빨간 테두리 표시) */
+  error?: boolean;
+  /** 비활성화 여부 */
+  disabled?: boolean;
+  /** 숫자 마스킹 여부 (비밀번호 스타일). 기본: false */
+  masked?: boolean;
+  /** 추가 클래스 */
+  className?: string;
+}
+```
+
+### PinConfirmSheet
+
+```typescript
+export interface PinConfirmSheetProps {
+  /** 시트 열림 여부 */
+  open: boolean;
+  /** 닫기 핸들러 */
+  onClose: () => void;
+  /**
+   * PIN 입력 완료 핸들러.
+   * pinLength 자리가 모두 입력되면 자동 호출된다.
+   * @param pin - 입력된 PIN 문자열
+   */
+  onConfirm: (pin: string) => void;
+  /** 시트 상단 타이틀. 기본: '비밀번호 입력' */
+  title?: string;
+  /** PIN 자릿수. 기본: 4 */
+  pinLength?: number;
+}
+```
+
+### PinDotIndicator
+
+```typescript
+export interface PinDotIndicatorProps {
+  /**
+   * 전체 도트 수 (비밀번호 자릿수).
+   * 기본값: 4 — 계좌 비밀번호 4자리에 맞춤
+   */
+  length?: number;
+  /**
+   * 채워진(입력된) 도트 수.
+   * 0 ≤ filledCount ≤ length 범위여야 한다.
+   */
+  filledCount: number;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### RecentRecipientItem
+
+```typescript
+export interface RecentRecipientItemProps {
+  /** 수취인명. 예: '홍길동' */
+  name: string;
+  /** 은행명. 예: '하나은행' */
+  bankName: string;
+  /** 마스킹된 계좌번호. 예: '123-****-5678' */
+  maskedAccount: string;
+  /** 항목 클릭 핸들러 (해당 수취인 정보로 이체 폼 자동 입력) */
+  onClick: () => void;
+}
+```
+
+### SectionHeader
+
+```typescript
+export interface SectionHeaderProps {
+  /** 섹션 제목 텍스트 */
+  title: string;
+  /**
+   * 제목 우측에 표시할 계좌/항목 수 배지 (예: 2 → '2').
+   * 미전달 시 배지 미노출.
+   */
+  badge?: number;
+  /** 우측 액션 레이블 (예: '전체보기'). 미전달 시 액션 영역 미노출 */
+  actionLabel?: string;
+  /** 액션 클릭 핸들러. actionLabel과 함께 전달해야 동작 */
+  onAction?: () => void;
+  /** 추가 클래스 */
+  className?: string;
+}
+```
+
+### SelectableItem
+
+```typescript
+import React from 'react';
+
+export interface SelectableItemProps {
+  /**
+   * 아이콘 슬롯.
+   * lucide-react 아이콘 컴포넌트를 전달한다.
+   * 선택 상태에 따라 컨테이너 배경·아이콘 색상이 자동 전환된다.
+   */
+  icon: React.ReactNode;
+  /** 표시할 레이블 텍스트 (예: "하나은행", "KB국민은행") */
+  label: string;
+  /**
+   * 선택 상태. 기본값: false
+   * - true : 브랜드 배경(bg-brand-5) + 브랜드 아이콘 원 + 브랜드 텍스트
+   * - false: 중립 배경(bg-surface-subtle) + 회색 아이콘 원 + label 텍스트
+   */
+  selected?: boolean;
+  /** 클릭 핸들러 */
+  onClick?: () => void;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### SelectableListItem
+
+```typescript
+export interface SelectableListItemProps {
+  /** 표시 레이블 */
+  label: string;
+  /** 선택 여부 */
+  isSelected: boolean;
+  /** 클릭 핸들러 */
+  onClick: () => void;
+}
+```
+
+### SidebarNav
+
+```typescript
+/** 사이드바 네비게이션 개별 항목 */
+export interface SidebarNavItem {
+  /** 항목 고유 식별자 */
+  id: string;
+  /** 표시할 레이블 텍스트 */
+  label: string;
+}
+
+export interface SidebarNavProps {
+  /** 네비게이션 항목 목록 */
+  items: SidebarNavItem[];
+  /** 현재 활성화된 항목 id */
+  activeId: string;
+  /**
+   * 항목 클릭 시 호출되는 콜백.
+   * 선택된 항목의 id를 인자로 전달한다.
+   */
+  onItemChange: (id: string) => void;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### StepIndicator
+
+```typescript
+export interface StepIndicatorProps {
+  /** 전체 단계 수 */
+  total: number;
+  /** 현재 진행 중인 단계 (1-based) */
+  current: number;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### SuccessHero
+
+```typescript
+export interface SuccessHeroProps {
+  /**
+   * 받는 사람 이름 (예: "홍길동").
+   * 타이틀에 "{recipientName}님께" 형태로 삽입된다.
+   */
+  recipientName: string;
+  /**
+   * 이체 금액 문자열 (예: "50,000원").
+   * 타이틀에 "{amount} 이체 완료" 형태로 삽입된다.
+   */
+  amount: string;
+  /**
+   * 부제목 텍스트.
+   * 기본값: "성공적으로 이체되었습니다."
+   */
+  subtitle?: string;
+  /** 추가 CSS className */
+  className?: string;
+}
+```
+
+### TabNav
+
+```typescript
+export interface TabNavItem {
+  /** 탭 고유 식별자 */
+  id:    string;
+  /** 탭 레이블 텍스트 */
+  label: string;
+}
+
+/**
+ * 탭 스타일 변형.
+ * - 'underline': 활성 탭 하단 인디케이터 라인 (기본값). 상단 내비게이션 탭에 사용.
+ * - 'pill': 활성 탭에 둥근 배경 채움. 상품 카테고리·필터 탭에 사용.
+ */
+export type TabNavVariant = 'underline' | 'pill';
+
+export interface TabNavProps {
+  /** 탭 목록 */
+  items:        TabNavItem[];
+  /** 현재 활성 탭 id */
+  activeId:     string;
+  /**
+   * 탭 변경 핸들러.
+   * @param id - 클릭된 탭 id
+   */
+  onTabChange:  (id: string) => void;
+  /**
+   * 탭 스타일 변형.
+   * @default 'underline'
+   */
+  variant?:     TabNavVariant;
+  /**
+   * 탭 버튼이 컨테이너 전체 너비를 균등하게 채울지 여부.
+   * true: 각 탭이 flex-1로 균등 분할 (Figma의 "full width" 탭 패턴)
+   * false: 탭이 콘텐츠 너비만큼만 차지 (기본값)
+   * @default false
+   */
+  fullWidth?:   boolean;
+  className?:   string;
+}
+```
+
+### TransactionList
+
+```typescript
+/** API 응답 flat 배열의 단일 거래 항목 */
+export interface TransactionItem {
+  id:       string;
+  /** ISO 8601 형식. 예: '2026-03-26T14:30:00Z' */
+  date:     string;
+  title:    string;
+  amount:   number;
+  balance?: number;
+  type:     'deposit' | 'withdrawal' | 'transfer';
+}
+
+/** 날짜별로 그룹핑된 거래 내역 (프론트엔드 변환 후 구조) */
+export interface TransactionGroup {
+  /** 표시용 날짜 문자열 (dateHeaderFormat에 따라 형식이 결정됨) */
+  date:   string;
+  items:  TransactionItem[];
+}
+
+/**
+ * 날짜 그룹 헤더 표시 형식.
+ * - 'month-day'      : 'MM월 DD일'       (기본값, 연도 생략)
+ * - 'year-month-day' : 'YYYY년 MM월 DD일' (연도 포함)
+ */
+export type DateHeaderFormat = 'month-day' | 'year-month-day';
+
+export type TransactionType = 'deposit' | 'withdrawal' | 'transfer';
+
+export interface TransactionListItemProps {
+  type:      TransactionType;
+  title:     string;
+  /** 표시용 날짜 문자열 */
+  date:      string;
+  /** 원화 단위 숫자. 컴포넌트 내부에서 Intl.NumberFormat으로 포맷 */
+  amount:    number;
+  /** 거래 후 잔액 */
+  balance?:  number;
+  onClick?:  () => void;
+}
+
+export interface TransactionListProps {
+  /** API 응답 flat 배열. 컴포넌트 내부에서 날짜별로 그룹핑 */
+  items:      TransactionItem[];
+  /** 로딩 상태 */
+  loading?:   boolean;
+  /** 빈 목록 표시 메시지. 기본: '거래 내역이 없어요' */
+  emptyMessage?: string;
+  /**
+   * 거래 항목 클릭 핸들러.
+   * 전달 시 각 항목이 <button>으로 렌더링되며 hover/active 인터랙션이 활성화된다.
+   * 예: 항목 클릭 → 거래 상세 바텀시트 오픈
+   */
+  onItemClick?: (item: TransactionItem) => void;
+  /**
+   * 날짜 그룹 헤더 표시 형식.
+   * - 'month-day'      : 'MM월 DD일'       (기본값)
+   * - 'year-month-day' : 'YYYY년 MM월 DD일'
+   */
+  dateHeaderFormat?: DateHeaderFormat;
+  className?: string;
+}
+```
+
+### TransactionSearchFilter
+
+```typescript
+/**
+ * 퀵 기간 선택 옵션.
+ * 선택 시 오늘 기준으로 startDate·endDate를 자동 계산한다.
+ */
+export type QuickPeriod = '1m' | '3m' | '6m' | '12m';
+
+/**
+ * 거래 내역 정렬 순서.
+ * - recent: 최근순 (기본값)
+ * - old: 과거순
+ */
+export type SortOrder = 'recent' | 'old';
+
+/**
+ * 거래 유형 필터.
+ * - all: 전체 (기본값)
+ * - deposit: 입금만
+ * - withdrawal: 출금만
+ */
+export type TransactionType = 'all' | 'deposit' | 'withdrawal';
+
+/** 조회 버튼 클릭 시 상위로 전달되는 검색 파라미터 */
+export interface TransactionSearchParams {
+  /** ISO 날짜 형식 'YYYY-MM-DD' */
+  startDate: string;
+  /** ISO 날짜 형식 'YYYY-MM-DD' */
+  endDate: string;
+  sortOrder: SortOrder;
+  transactionType: TransactionType;
+}
+
+export interface TransactionSearchFilterProps {
+  /** 현재 적용된 검색 조건. 초기값 및 외부 동기화에 사용 */
+  value: TransactionSearchParams;
+  /**
+   * 조회 버튼 클릭 시 호출.
+   * 폼 내부 상태(localParams)를 기준으로 호출되므로
+   * 조회 전까지는 외부 value에 영향을 주지 않는다.
+   */
+  onSearch: (params: TransactionSearchParams) => void;
+  /** 초기 펼침 여부. 기본: false (접힌 상태) */
+  defaultExpanded?: boolean;
+  className?: string;
+}
+```
+
+### TransferForm
+
+```typescript
+export interface TransferFormData {
+  /** 받는 계좌번호 */
+  toAccount: string;
+  /** 이체 금액 (원) */
+  amount:    number;
+  /** 메모 (선택) */
+  memo:      string;
+}
+
+export interface TransferFormProps {
+  /** 이체 가능 최대 금액 (내 계좌 잔액) */
+  availableBalance?: number;
+  /** 폼 제출 핸들러. 최종 확인 전에 호출됨 */
+  onSubmit:          (data: TransferFormData) => void;
+  /** 폼 제출 처리 중 여부 (버튼 로딩 상태) */
+  submitting?:       boolean;
+  className?:        string;
+}
+```
+
+### TransferLimitInfo
+
+```typescript
+export interface TransferLimitInfoProps {
+  /** 1회 이체 한도 (원). 예: 1000000 */
+  perTransferLimit: number;
+  /** 1일 이체 한도 (원). 예: 5000000 */
+  dailyLimit: number;
+  /** 오늘 이미 이체한 누적 금액 (원). 전달 시 잔여 한도 함께 표시 */
+  usedAmount?: number;
+}
+```
+
+## Biz (도메인 특화 컴포넌트 — 금융 비즈니스 로직 포함)
+
+### biz/banking
+
+#### AccountSelectorCard
+
+```typescript
+import React from 'react';
+
+export interface AccountSelectorCardProps {
+  /** 계좌명. 예: '하나 주거래 통장' */
+  accountName: string;
+  /** 계좌번호. 예: '123-456-789012'. 마스킹 없이 그대로 표시 */
+  accountNumber: string;
+  /**
+   * 우측 원형 버튼 내 아이콘.
+   * 미전달 시 WalletMinimal 아이콘을 기본으로 사용한다.
+   */
+  icon?: React.ReactNode;
+  /**
+   * 계좌명 영역 클릭 시 콜백.
+   * 계좌 변경 드롭다운 혹은 BottomSheet를 열 때 사용한다.
+   */
+  onAccountChange?: () => void;
+  /** 우측 원형 아이콘 버튼 클릭 시 콜백. 예: 계좌 상세 이동 */
+  onIconClick?: () => void;
+  /**
+   * 우측 원형 아이콘 버튼의 aria-label.
+   * 미전달 시 기본값 '계좌 상세' 사용.
+   * 카드 상세·이체 등 다른 용도로 재사용 시 실제 기능에 맞게 전달한다.
+   */
+  iconAriaLabel?: string;
+  /**
+   * 출금가능금액 표시 문자열.
+   * 전달 시 계좌번호 아래에 브랜드 색상으로 렌더링된다.
+   * 예: '출금가능금액: 3,000,000원'
+   */
+  availableBalance?: string;
+  className?: string;
+}
+```
+
+#### AccountSummaryCard
+
+```typescript
+import React from 'react';
+
+/**
+ * 계좌 유형.
+ * - deposit:       예금(입출금) 계좌
+ * - savings:       적금·저축 계좌
+ * - loan:          대출 계좌 — 금액 danger 색상, 기본 레이블 '대출잔액'
+ * - foreignDeposit: 외화예금 계좌 — balanceDisplay로 외화 포맷 전달
+ * - retirement:    퇴직연금 계좌 — 기본 레이블 '적립금'
+ * - securities:    증권 계좌 — 기본 레이블 '평가금액'
+ */
+export type AccountType =
+  | 'deposit'
+  | 'savings'
+  | 'loan'
+  | 'foreignDeposit'
+  | 'retirement'
+  | 'securities';
+
+export interface AccountSummaryCardProps {
+  /** 계좌 유형. 유형별 금액 레이블·색상·배지 용도가 달라짐 */
+  type:           AccountType;
+  /** 예: '급여 통장', '청약저축' */
+  accountName:    string;
+  /** 예: '123-456-789012'. 화면에 마스킹 없이 그대로 표시 */
+  accountNumber:  string;
+  /** 원화 단위 숫자. 컴포넌트 내부에서 Intl.NumberFormat('ko-KR') 처리 */
+  balance:        number;
+  /**
+   * 화면 표시용 잔액 문자열.
+   * 전달 시 balance의 내부 포맷 변환을 건너뛰고 이 값을 그대로 표시.
+   * 다중 통화(USD·EUR 등) 또는 Repository에서 이미 포맷한 경우에 사용.
+   * (예: '$1,000.00', '총 $1,000.00 (약 1,350,000원)')
+   */
+  balanceDisplay?: string;
+  /**
+   * 금액 영역 레이블. 미전달 시 type별 기본값 사용.
+   * - deposit: '잔액'
+   * - savings: '납입금액'
+   * - loan: '대출잔액'
+   */
+  balanceLabel?:  string;
+  /**
+   * 배지 텍스트. 미전달 시 배지 영역 렌더링 안 함.
+   * - deposit: '주거래', '급여' 등
+   * - savings: 'D-30' (만기일) 등
+   * - loan: '변동금리', '고정금리' 등
+   */
+  badgeText?:     string;
+  /**
+   * 카드 우측 상단 더보기 버튼 종류.
+   * - 'chevron': 다음 화면으로 이동하는 > 아이콘
+   * - 'ellipsis': 추가 옵션 메뉴를 여는 ... 아이콘
+   * 미전달 시 더보기 버튼 미노출.
+   */
+  moreButton?:    'chevron' | 'ellipsis';
+  /** 더보기 버튼 클릭 핸들러. moreButton과 함께 전달해야 동작 */
+  onMoreClick?:   () => void;
+  onClick?:       () => void;
+  /** 이체·내역 버튼 슬롯. 각 버튼은 균등 너비로 확장됨 */
+  actions?:       React.ReactNode;
+  className?:     string;
+}
+```
+
+### biz/card
+
+#### AccountSelectCard
+
+```typescript
+export interface AccountSelectCardProps {
+  /** 은행명. 예: '하나은행' */
+  bankName: string;
+  /** 마스킹된 계좌번호. 예: '123-****-5678' */
+  maskedAccount: string;
+  /** 선택 여부 */
+  isSelected: boolean;
+  /** 클릭 핸들러 */
+  onClick: () => void;
+}
+```
+
+#### BillingPeriodLabel
+
+```typescript
+export interface BillingPeriodLabelProps {
+  /** 이용기간 시작일. 예: '2025.03.01' */
+  startDate:  string;
+  /** 이용기간 종료일. 예: '2025.03.31' */
+  endDate:    string;
+  className?: string;
+}
+```
+
+#### CardBenefitSummary
+
+```typescript
+/** 혜택 항목 단일 정보 */
+export interface BenefitItem {
+  /** 혜택 레이블. 예: '이번달 할인', '캐시백' */
+  label: string;
+  /** 혜택 금액 또는 포인트 (원 또는 P). 예: 12500 */
+  amount: number;
+  /** 단위 표시. 예: '원', 'P' (기본: '원') */
+  unit?: string;
+}
+
+export interface CardBenefitSummaryProps {
+  /** 보유 포인트 잔액 */
+  points: number;
+  /** 이번달 혜택 항목 목록 (할인·캐시백 등) */
+  benefits: BenefitItem[];
+  /** 포인트 상세 클릭 핸들러 */
+  onPointDetail?: () => void;
+  /** 혜택 상세 클릭 핸들러 */
+  onBenefitDetail?: () => void;
+}
+```
+
+#### CardChipItem
+
+```typescript
+export interface CardChipItemProps {
+  /** 카드명. 예: '하나 머니 체크카드' */
+  name: string;
+  /** 마스킹된 카드번호. 예: '1234-****-****-5678' */
+  maskedNumber: string;
+}
+```
+
+#### CardInfoPanel
+
+```typescript
+export interface CardInfoRow {
+  /** 좌측 레이블. 예: '결제 계좌', '결제일' */
+  label: string;
+  /**
+   * 우측 값. '\n' 포함 시 줄바꿈으로 표시.
+   * 예: '하나은행\n123456****1234'
+   */
+  value: string;
+}
+
+export interface CardInfoSection {
+  /** 섹션 제목. 예: '결제정보', '카드 이용기간' */
+  title: string;
+  rows: CardInfoRow[];
+}
+
+export interface CardInfoPanelProps {
+  sections: CardInfoSection[];
+  className?: string;
+}
+```
+
+#### CardLinkedBalance
+
+```typescript
+export interface CardLinkedBalanceProps {
+  /** 연결계좌 잔액 (원) */
+  balance:    number;
+  /** true: 금액 마스킹 표시 */
+  hidden:     boolean;
+  /** 보기/숨기기 버튼 클릭 */
+  onToggle:   () => void;
+  className?: string;
+}
+```
+
+#### CardManagementPanel
+
+```typescript
+/** 카드 관리 네비게이션 단일 행 데이터 */
+export interface CardManagementNavRow {
+  /** 행 레이블 */
+  label:    string;
+  /** 우측 보조 텍스트 (카드번호·계좌번호 등). 미전달 시 미노출 */
+  subText?: string;
+  /** 행 클릭 핸들러 */
+  onClick?: () => void;
+}
+
+export interface CardManagementPanelProps {
+  /** 네비게이션 행 목록. 순서대로 렌더링되며 개수 제한 없음 */
+  rows:       CardManagementNavRow[];
+  className?: string;
+}
+```
+
+#### CardPaymentActions
+
+```typescript
+export interface CardPaymentActionsProps {
+  /** 분할납부 버튼 클릭 핸들러 */
+  onInstallment?: () => void;
+  /** 즉시결제 버튼 클릭 핸들러 */
+  onImmediatePayment?: () => void;
+  /** 일부결제금액이월약정(리볼빙) 버튼 클릭 핸들러 */
+  onRevolving?: () => void;
+  className?: string;
+}
+```
+
+#### CardPaymentItem
+
+```typescript
+import React from 'react';
+
+export interface CardPaymentItemProps {
+  /** 가맹점·서비스 아이콘 (lucide-react 등 React 노드) */
+  icon:               React.ReactNode;
+  /**
+   * 아이콘 배경 Tailwind 클래스.
+   * 미전달 시 기본 bg-brand-10 사용.
+   * 예: 'bg-surface-subtle', 'bg-danger-surface'
+   */
+  iconBgClassName?:   string;
+  /** 카드 영문명. 예: 'HANA MONEY CHECK' */
+  cardEnName:         string;
+  /** 카드 한글명 또는 가맹점명. 예: '하나 머니 체크카드' */
+  cardName:           string;
+  /** 결제 금액 (원). 양수: 결제, 음수: 취소/환불 */
+  amount:             number;
+  /** "상세보기" 버튼 클릭 핸들러. 미전달 시 버튼 미노출 */
+  onDetailClick?:     () => void;
+  /** 행 전체 클릭 핸들러 */
+  onClick?:           () => void;
+  className?:         string;
+}
+```
+
+#### CardPaymentSummary
+
+```typescript
+export interface CardPaymentSummaryProps {
+  /** 출금예정일. 예: '2026.04.08' */
+  dateFull: string;
+  /** 청구 년월. 예: '26년 4월' */
+  dateYM: string;
+  /** 오늘날짜. 예: '04.08' */
+  dateMD: string;
+  /** 총 청구금액 (원) */
+  totalAmount: number;
+  /** 리볼빙 금액 (원). 0이면 표시하지 않음 */
+  revolving?: number;
+  /** 카드론 금액 (원). 0이면 표시하지 않음 */
+  cardLoan?: number;
+  /** 현금서비스 금액 (원). 0이면 표시하지 않음 */
+  cashAdvance?: number;
+  /** 리볼빙(일부결제금액이월약정) 버튼 클릭 핸들러. 미전달 시 버튼 비활성 */
+  onRevolving?: () => void;
+  /** 카드론(장기카드대출) 버튼 클릭 핸들러. 미전달 시 버튼 비활성 */
+  onCardLoan?: () => void;
+  /** 현금서비스(단기카드대출) 버튼 클릭 핸들러. 미전달 시 버튼 비활성 */
+  onCashAdvance?: () => void;
+  /** 날짜(년월) 영역 클릭 핸들러. 전달 시 날짜 선택 모달 등을 열 수 있음 */
+  onDateClick?: () => void;
+  className?: string;
+}
+```
+
+#### CardPerformanceBar
+
+```typescript
+export interface CardPerformanceBarProps {
+  /** 카드명. 예: '하나 머니 체크카드' */
+  cardName: string;
+  /** 이번달 이용금액 (원) */
+  currentAmount: number;
+  /** 혜택 달성을 위한 목표 실적 금액 (원) */
+  targetAmount: number;
+  /** 목표 달성 시 제공되는 혜택 설명. 예: '전월 실적 달성 시 캐시백 1%' */
+  benefitDescription?: string;
+  /** 실적 상세 클릭 핸들러 */
+  onDetail?: () => void;
+}
+```
+
+#### CardPillTab
+
+```typescript
+export interface CardPillTabProps {
+  /** 탭 레이블 (카드명 등) */
+  label: string;
+  /** 선택 여부 */
+  isSelected: boolean;
+  /** 클릭 핸들러 */
+  onClick: () => void;
+}
+```
+
+#### CardSummaryCard
+
+```typescript
+import React from 'react';
+
+/**
+ * 카드 유형.
+ * - credit: 신용카드 — 사용금액 + 한도 표시, warning/danger 색상 분기
+ * - check: 체크카드 — 연결 계좌 잔액 표시
+ * - prepaid: 선불카드 — 충전 잔액 표시
+ */
+export type CardType = 'credit' | 'check' | 'prepaid';
+
+export interface CardSummaryCardProps {
+  /** 카드 유형. 유형별 레이블·색상이 달라짐 */
+  type:             CardType;
+  /** 카드 상품명. 예: '하나 머니 체크카드', '1Q카드' */
+  cardName:         string;
+  /**
+   * 마스킹된 카드 번호. 예: '1234 **** **** 5678'
+   * 컴포넌트는 그대로 표시하며 마스킹 처리는 호출자 책임
+   */
+  cardNumber:       string;
+  /**
+   * 기준 금액.
+   * - credit: 당월 사용금액
+   * - check/prepaid: 잔액
+   */
+  amount:           number;
+  /**
+   * 한도 금액 (credit 타입 전용).
+   * 전달 시 "사용금액 / 한도" 형태로 표시하며 한도 대비 사용률 색상 분기.
+   */
+  limitAmount?:     number;
+  /**
+   * 배지 텍스트. 미전달 시 배지 미노출.
+   * - credit: '포인트 적립', '캐시백' 등 혜택 유형
+   * - check: '주거래' 등
+   * - prepaid: '잔액 부족' 경고 배지 등
+   */
+  badgeText?:       string;
+  onClick?:         () => void;
+  /** 결제내역·충전 버튼 슬롯 */
+  actions?:         React.ReactNode;
+  className?:       string;
+}
+```
+
+#### CardVisual
+
+```typescript
+import React from 'react';
+
+export type CardBrand = 'VISA' | 'Mastercard' | 'AMEX' | 'JCB' | 'UnionPay';
+
+export interface CardVisualProps {
+  /** 카드 이미지 슬롯 (img 또는 SVG 컴포넌트) */
+  cardImage:  React.ReactNode;
+  /** 카드 브랜드 */
+  brand:      CardBrand;
+  /** 카드명. 예: '하나 머니 체크카드' */
+  cardName:   string;
+  /**
+   * compact 모드.
+   * true: 스크롤로 카드 영역을 벗어났을 때 스티키 헤더용 — 브랜드+카드명 한 줄 말줄임.
+   * false(기본): 카드 이미지 + 브랜드 + 카드명 풀 레이아웃.
+   */
+  compact?:   boolean;
+  className?: string;
+}
+```
+
+#### LoanMenuBar
+
+```typescript
+import React from 'react'
+
+export interface LoanMenuBarItem {
+  id: string
+  /** 메뉴 아이콘 (lucide-react ReactNode) */
+  icon: React.ReactNode
+  /** 메뉴 레이블 텍스트 */
+  label: string
+  /** 메뉴 클릭 핸들러 */
+  onClick: () => void
+}
+
+export interface LoanMenuBarProps {
+  /** 메뉴 항목 목록. 보통 단기카드대출 / 장기카드대출 / 리볼빙 3종 */
+  items: LoanMenuBarItem[]
+  className?: string
+}
+```
+
+#### PaymentAccountCard
+
+```typescript
+import type React from 'react';
+
+export interface PaymentAccountCardProps {
+  /** 결제 계좌 명칭. 예: '하나은행 결제계좌' */
+  title: string;
+  /** 출금 가능 시간. 예: '365일 06:00~23:30' */
+  hours: string;
+  /** 당행/타행을 구분하는 아이콘 (lucide-react 컴포넌트) */
+  icon: React.ReactNode;
+}
+```
+
+#### QuickShortcutCard
+
+```typescript
+import React from 'react'
+
+export interface QuickShortcutCardProps {
+  /** 메인 타이틀 (e.g. "내 쿠폰", "카드 신청") */
+  title: string
+  /** 서브 텍스트 (e.g. "3장 사용가능", "맞춤형 추천") */
+  subtitle: string
+  /**
+   * 우측 아이콘 슬롯 (lucide-react ReactNode)
+   * 전달하지 않으면 아이콘 영역이 렌더링되지 않는다.
+   */
+  icon?: React.ReactNode
+  /** 카드 클릭 핸들러 */
+  onClick?: () => void
+  className?: string
+}
+```
+
+#### StatementHeroCard
+
+```typescript
+export interface StatementHeroCardProps {
+  /** 원화 명세서 금액 (정수, 자동 포맷) */
+  amount: number;
+  /**
+   * 결제일 표시 텍스트
+   * @example "12월 25일"
+   */
+  dueDate: string;
+  /**
+   * 카드 상단 설명 레이블
+   * @default "이번 달 명세서"
+   */
+  label?: string;
+  /** 상세 화살표 클릭 핸들러 (전달 시 화살표 아이콘 노출) */
+  onDetail?: () => void;
+  /** true이면 금액을 마스킹 처리하여 숨긴다 */
+  hidden?: boolean;
+  className?: string;
+}
+```
+
+#### StatementTotalCard
+
+```typescript
+export interface StatementTotalCardProps {
+  /** 총 결제금액 (원) */
+  amount: number;
+  /**
+   * 금액 상단 배지 텍스트.
+   * - '예정': 결제 예정 상태
+   * - 미전달: 배지 미노출
+   */
+  badge?: '예정';
+  /** 금액 우측 화살표 클릭 → 이용내역 화면 이동 */
+  onDetailClick?: () => void;
+  /** 분할납부 버튼 클릭 핸들러 */
+  onInstallment?: () => void;
+  /** 즉시결제 버튼 클릭 핸들러 */
+  onImmediatePayment?: () => void;
+  /** 일부결제금액이월약정(리볼빙) 버튼 클릭 핸들러 */
+  onRevolving?: () => void;
+  className?: string;
+}
+```
+
+#### SummaryCard
+
+```typescript
+import React from 'react';
+
+/**
+ * asset  — 총 자산 카드. 좌측 액센트 바 없음, 금액 강조 색상 브랜드
+ * spending — 이번 달 소비 카드. 좌측 도메인 액센트 바 적용, 금액 기본 색상
+ */
+export type SummaryCardVariant = 'asset' | 'spending';
+
+export interface SummaryCardAction {
+  /** 버튼 레이블 */
+  label: string;
+  /** 버튼 클릭 핸들러 */
+  onClick: () => void;
+  /**
+   * 활성 상태. true 시 도메인 액센트 배경(--domain-card-accent)으로 강조
+   * @default false
+   */
+  active?: boolean;
+}
+
+export interface SummaryCardProps {
+  /** 카드 유형 — 레이아웃과 색상에 영향 */
+  variant: SummaryCardVariant;
+  /** 한글 메인 제목 (e.g. "총 자산", "이번 달 소비") */
+  title: string;
+  /** 원화 금액 (정수, 자동 포맷) */
+  amount: number;
+  /** 우측 상단 아이콘 슬롯 */
+  icon?: React.ReactNode;
+  /** 하단 액션 버튼 목록 */
+  actions?: SummaryCardAction[];
+  /** 카드 전체 클릭 핸들러 */
+  onClick?: () => void;
+  /** true이면 금액을 마스킹 처리하여 숨긴다 */
+  hidden?: boolean;
+  className?: string;
+}
+```
+
+#### UsageHistoryFilterSheet
+
+```typescript
+export interface CardOption {
+  value: string;
+  label: string;
+}
+
+export type ApprovalType = 'approved' | 'confirmed';
+export type CardType     = 'all' | 'credit' | 'check';
+export type RegionType   = 'all' | 'domestic' | 'overseas';
+export type UsageType    = 'all' | 'lump' | 'installment' | 'cashAdvance' | 'cancel';
+export type PeriodType   = 'thisMonth' | '1month' | '3months' | 'custom';
+
+export interface SearchFilter {
+  approval:      ApprovalType;
+  cardType:      CardType;
+  /** 선택된 카드 value. 'all' 이면 전체 */
+  selectedCard:  string;
+  region:        RegionType;
+  usageType:     UsageType;
+  period:        PeriodType;
+  /** period === 'custom' 일 때 선택된 월. 예: '2026-03' */
+  customMonth?:  string;
+}
+
+export interface UsageHistoryFilterSheetProps {
+  open: boolean;
+  onClose: () => void;
+  cardOptions: CardOption[];
+  /** 필터 확정 시 호출. filter.customMonth에 선택 월이 담긴다. */
+  onApply: (filter: SearchFilter) => void;
+}
+```
+
+#### UsageTransactionItem
+
+```typescript
+/** 가맹점 상세 정보 — 상세 BottomSheet 아코디언에 표시 */
+export interface MerchantInfo {
+  address?:      string;
+  phone?:        string;
+  businessType?: string;
+}
+
+/** 이용내역 단건 */
+export interface Transaction {
+  id: string;
+  /** 사용처(가맹점명) */
+  merchant: string;
+  /** 결제 금액(원). 음수: 취소/환불 */
+  amount: number;
+  /** 거래일. 예: '2026.04.08' */
+  date: string;
+  /** 거래구분. 예: '일시불' | '할부(3개월)' | '단기카드대출' | '취소' */
+  type: string;
+  /** 승인번호 */
+  approvalNumber: string;
+  /** 거래상태. 예: '승인' | '결제확정' | '취소' */
+  status: string;
+  /** 이용카드명 */
+  cardName: string;
+  /** 가맹점 상세 정보 */
+  merchantInfo?: MerchantInfo;
+}
+
+export interface UsageTransactionItemProps {
+  tx: Transaction;
+  /**
+   * 전달 시 행이 버튼으로 렌더링되며 클릭 시 상세 BottomSheet를 노출한다.
+   * 미전달 시 행은 div로 렌더링되고 상세 BottomSheet를 노출하지 않는다.
+   */
+  onClick?: () => void;
+}
+```
+
+### biz/common
+
+#### BannerCarousel
+
+```typescript
+import React from 'react';
+
+export type BannerVariant = 'promo' | 'info' | 'warning';
+
+export interface BannerCarouselItem {
+  id:           string;
+  /** 배너 색상 변형. 기본: 'promo' */
+  variant?:     BannerVariant;
+  title:        string;
+  description?: string;
+  /** 우측 CTA 슬롯 */
+  action?:      React.ReactNode;
+  /** 전달 시 닫기(×) 버튼 표시 */
+  onClose?:     () => void;
+}
+
+export interface BannerCarouselProps {
+  items:               BannerCarouselItem[];
+  /**
+   * 자동 재생 간격(ms). 기본: 3000.
+   * items.length < 2이면 자동 재생 비활성화.
+   */
+  autoPlayInterval?:   number;
+  className?:          string;
+}
+```
+
+#### BrandBanner
+
+```typescript
+import React from 'react';
+
+export interface BrandBannerProps {
+  /**
+   * 배너 소제목 — 주요 타이틀 위에 표시되는 작은 텍스트.
+   * (예: '개인 맞춤 혜택')
+   */
+  subtitle?: string;
+  /**
+   * 배너 주요 타이틀.
+   * (예: '나만을 위한 특별한 한아멤버스')
+   */
+  title: string;
+  /**
+   * 우측 아이콘 슬롯 — 흰색 반투명 원형 컨테이너 내부에 렌더링됨.
+   * 미전달 시 아이콘 영역 미표시.
+   */
+  icon?: React.ReactNode;
+  /**
+   * 배너 클릭 핸들러.
+   * 전달 시 button 태그로 렌더링되어 클릭 가능 배너가 됨.
+   */
+  onClick?: () => void;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+#### QuickMenuGrid
+
+```typescript
+import React from 'react';
+
+export interface QuickMenuItem {
+  id:      string;
+  icon:    React.ReactNode;
+  label:   string;
+  onClick: () => void;
+  /** 알림 배지 숫자. 0 또는 미전달 시 배지 미노출 */
+  badge?:  number;
+  /**
+   * 아이콘 컨테이너 형태.
+   * - 'circle'  : 원형 (기본값)
+   * - 'rounded' : 각이 둥근 사각형
+   */
+  iconShape?: 'circle' | 'rounded';
+}
+
+export interface QuickMenuGridProps {
+  items:      QuickMenuItem[];
+  /**
+   * 열 수. 기본: 4.
+   * 아이템 수에 따라 4열(기본) 또는 3열 권장.
+   */
+  cols?:      2 | 3 | 4;
+  className?: string;
+}
+```
+
+#### UserProfile
+
+```typescript
+export interface UserProfileProps {
+  /** 표시할 사용자 이름 (예: '김하나님') */
+  name: string;
+  /**
+   * 최근 접속 일시 문자열 (예: '2023.11.01 10:30:15').
+   * 미전달 시 최근 접속 행 미표시.
+   */
+  lastLogin?: string;
+  /**
+   * 내 정보 관리 클릭 핸들러.
+   * onProfileManageClick 또는 onLogoutClick 중 하나라도 전달되면 설정 버튼이 표시된다.
+   */
+  onProfileManageClick?: () => void;
+  /**
+   * 로그아웃 클릭 핸들러.
+   * onProfileManageClick 또는 onLogoutClick 중 하나라도 전달되면 설정 버튼이 표시된다.
+   */
+  onLogoutClick?: () => void;
+  /** 추가 Tailwind 클래스 */
+  className?: string;
+}
+```
+
+### biz/insurance
+
+#### InsuranceSummaryCard
+
+```typescript
+import React from 'react';
+
+/**
+ * 보험 유형.
+ * - life: 생명보험 — 사망·만기 보장
+ * - health: 건강보험 — 실손·암 보장
+ * - car: 자동차보험 — 차량 보장
+ */
+export type InsuranceType = 'life' | 'health' | 'car';
+
+/**
+ * 보험 계약 상태.
+ * - active: 정상 유지 중
+ * - pending: 납입 유예
+ * - expired: 만기 또는 해지
+ */
+export type InsuranceStatus = 'active' | 'pending' | 'expired';
+
+export interface InsuranceSummaryCardProps {
+  /** 보험 유형. 유형별 아이콘·레이블이 달라짐 */
+  type:              InsuranceType;
+  /** 보험 상품명. 예: '하나생명 통합종신보험', '하나손해 운전자보험' */
+  insuranceName:     string;
+  /**
+   * 계약 번호 또는 증권 번호.
+   * 예: '2024-001-123456'
+   */
+  contractNumber:    string;
+  /**
+   * 월 납입 보험료 (원화 단위 숫자).
+   * 내부에서 Intl.NumberFormat('ko-KR') 처리.
+   */
+  premium:           number;
+  /**
+   * 다음 납입일. 예: '2026.04.01'
+   * 표시용 문자열로 직접 전달 (포맷은 호출자 책임)
+   */
+  nextPaymentDate?:  string;
+  /** 계약 상태. 상태별 배지 색상이 달라짐 */
+  status:            InsuranceStatus;
+  /**
+   * 배지 텍스트 override. 미전달 시 status 기반 기본 텍스트 사용.
+   * - active: '정상'
+   * - pending: '유예'
+   * - expired: '만기'
+   */
+  badgeText?:        string;
+  onClick?:          () => void;
+  /** 보장 내역·청구 버튼 슬롯 */
+  actions?:          React.ReactNode;
+  className?:        string;
+}
+```

--- a/reactive-springware/generated/design-tokens.md
+++ b/reactive-springware/generated/design-tokens.md
@@ -1,0 +1,54 @@
+# Design Tokens
+
+> 이 파일은 `scripts/extract-design-tokens.ts`로 자동 생성됩니다. 직접 수정하지 마세요.
+> Claude API system prompt에 포함되어 하드코딩 방지용 레퍼런스로 사용됩니다.
+
+## 사용 규칙
+
+- 색상·간격·타이포는 반드시 CSS 변수(`var(--*)`) 또는 Tailwind 토큰 클래스를 사용할 것
+- `#FFFFFF`, `16px` 같은 하드코딩 금지
+- 브랜드 컬러(`--color-brand-*`)는 prop으로 노출하지 말고 토큰으로 고정할 것
+
+## Semantic Tokens (공통 고정값)
+
+모든 은행 브랜드에서 공통으로 사용되는 시맨틱 컬러. 컴포넌트 내부에 직접 적용.
+
+### color
+
+| CSS 변수 | 참조값 |
+|---------|--------|
+| `--color-brand` | `{brand.primary}` |
+| `--color-danger` | `#e11d48` |
+| `--color-text` | `#ffffff` |
+| `--color-border` | `#e2e8f0` |
+| `--color-surface` | `#ffffff` |
+| `--color-success` | `#16a34a` |
+| `--color-warning` | `#d97706` |
+| `--color-primary` | `#2563eb` |
+| `--color-info-surface` | `#eff6ff` |
+
+## Brand Tokens — hana (하나은행)
+
+브랜드별 가변 토큰. `data-brand="hana"` 속성으로 주입됨.
+컴포넌트 prop에 색상 값을 직접 전달하지 말 것.
+
+| CSS 변수 | 값 |
+|---------|-----|
+| `--brand-primary` | `#008485` |
+| `--brand-alt` | `#14b8a6` |
+| `--brand-fg` | `#ffffff` |
+| `--brand-text` | `#008485` |
+| `--brand-dark` | `#006e6f` |
+| `--brand-darker` | `#005859` |
+| `--brand-shadow` | `#00848540` |
+| `--brand-bg` | `#f5f8f8` |
+| `--brand-name` | `하나은행` |
+| `--brand-domain-card-accent` | `#caee5d` |
+| `--brand-domain-card-accentText` | `#546b00` |
+
+## Primitive Tokens (참고용 — 직접 사용 금지)
+
+Semantic/Brand 토큰이 참조하는 원시값. 컴포넌트에서 직접 사용하지 말 것.
+
+| CSS 변수 | 값 |
+|---------|-----|

--- a/reactive-springware/package.json
+++ b/reactive-springware/package.json
@@ -37,6 +37,7 @@
     "prepack": "npm run build",
     "build:manifest": "node scripts/build-manifest.mjs",
     "extract:manifest": "tsx scripts/extract-manifest.ts",
+    "generate:prompts": "npx tsx scripts/extract-components.ts && npx tsx scripts/extract-design-tokens.ts && npx tsx scripts/extract-component-map.ts",
     "build:all": "npm run build && npm run build:manifest && npm run extract:manifest",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --ext ts,tsx",

--- a/reactive-springware/scripts/extract-component-map.ts
+++ b/reactive-springware/scripts/extract-component-map.ts
@@ -1,0 +1,41 @@
+/**
+ * @file extract-component-map.ts
+ * @description docs/component-map.md를 읽어 generated/component-map.md로 복사한다.
+ *
+ *   component-map.md는 Figma → React 매핑 전략 문서로, 이미 최적화된 상태이므로
+ *   별도 파싱 없이 그대로 generated/ 디렉토리에 배치한다.
+ *
+ * @example
+ *   npx tsx scripts/extract-component-map.ts
+ */
+
+import { readFileSync, mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+const SOURCE = join(ROOT, 'docs', 'component-map.md');
+const OUTPUT_DIR = join(ROOT, 'generated');
+const OUTPUT_FILE = join(OUTPUT_DIR, 'component-map.md');
+
+function main() {
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+
+  const content = readFileSync(SOURCE, 'utf-8');
+
+  // 자동 생성 헤더를 파일 상단에 삽입하여 출처를 명확히 함
+  const header = [
+    '<!-- 이 파일은 scripts/extract-component-map.ts로 자동 생성됩니다. 직접 수정하지 마세요. -->',
+    '<!-- 원본: docs/component-map.md -->',
+    '',
+  ].join('\n');
+
+  writeFileSync(OUTPUT_FILE, header + content, 'utf-8');
+
+  const lines = content.split('\n').length;
+  console.log(`✅ component-map.md 복사 완료 (${lines}줄)`);
+  console.log(`   출력: ${OUTPUT_FILE}`);
+}
+
+main();

--- a/reactive-springware/scripts/extract-components.ts
+++ b/reactive-springware/scripts/extract-components.ts
@@ -1,0 +1,162 @@
+/**
+ * @file extract-components.ts
+ * @description component-library 아래 모든 types.ts 파일을 읽어
+ *   component-types.md 마크다운 파일로 변환한다.
+ *
+ *   Claude API system prompt에 포함할 컴포넌트 API 레퍼런스를 생성하는 용도.
+ *   런타임에 TypeScript 파일을 직접 읽을 수 없는 Java 백엔드를 위해 텍스트로 변환.
+ *
+ * @example
+ *   npx tsx scripts/extract-components.ts
+ */
+
+import { readdirSync, readFileSync, mkdirSync, writeFileSync, statSync } from 'fs';
+import { join, relative, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+const COMPONENT_LIB = join(ROOT, 'component-library');
+const OUTPUT_DIR = join(ROOT, 'generated');
+const OUTPUT_FILE = join(OUTPUT_DIR, 'component-types.md');
+
+/** component-library 하위 카테고리 순서 (Claude에게 계층 구조를 명확히 전달하기 위해 고정) */
+const CATEGORY_ORDER = ['core', 'layout', 'modules', 'biz'];
+
+interface ComponentEntry {
+  category: string;     // core / layout / modules / biz
+  subCategory: string;  // banking, card, common, ... (biz 전용)
+  name: string;         // 컴포넌트명 (디렉토리명)
+  content: string;      // types.ts 파일 전체 내용
+}
+
+/** 재귀적으로 types.ts 파일을 탐색하여 ComponentEntry 배열로 반환 */
+function collectTypes(dir: string): ComponentEntry[] {
+  const entries: ComponentEntry[] = [];
+
+  const walk = (current: string) => {
+    const items = readdirSync(current);
+
+    // types.ts 가 있는 디렉토리 = 컴포넌트 루트
+    if (items.includes('types.ts')) {
+      const rel = relative(COMPONENT_LIB, current);
+      const parts = rel.split(/[/\\]/);
+
+      // parts[0] = category (core/layout/modules/biz)
+      // parts[1] = subCategory 또는 componentName
+      // parts[2] = componentName (biz의 경우)
+      const category = parts[0] ?? 'unknown';
+      const subCategory = parts.length >= 3 ? parts[1] : '';
+      const name = parts[parts.length - 1];
+
+      const content = readFileSync(join(current, 'types.ts'), 'utf-8');
+      entries.push({ category, subCategory, name, content });
+    }
+
+    // 하위 디렉토리 재귀 탐색 (node_modules, .storybook 제외)
+    for (const item of items) {
+      if (item === 'node_modules' || item.startsWith('.')) continue;
+      const full = join(current, item);
+      if (statSync(full).isDirectory()) walk(full);
+    }
+  };
+
+  walk(dir);
+  return entries;
+}
+
+/** 컴포넌트 목록을 카테고리별로 그룹핑 */
+function groupByCategory(entries: ComponentEntry[]): Map<string, ComponentEntry[]> {
+  const map = new Map<string, ComponentEntry[]>();
+  for (const entry of entries) {
+    const list = map.get(entry.category) ?? [];
+    list.push(entry);
+    map.set(entry.category, list);
+  }
+  return map;
+}
+
+/** 카테고리 레이블 (Claude가 계층을 이해하도록 설명 포함) */
+function categoryLabel(category: string): string {
+  const labels: Record<string, string> = {
+    core: 'Core (원자 컴포넌트 — Button, Input, Badge 등 단일 HTML 요소 수준)',
+    layout: 'Layout (페이지 구조 컴포넌트 — PageLayout, Stack, Grid, Inline 등)',
+    modules: 'Modules (분자 컴포넌트 — 2개 이상 Core 조합, 도메인 무관)',
+    biz: 'Biz (도메인 특화 컴포넌트 — 금융 비즈니스 로직 포함)',
+  };
+  return labels[category] ?? category;
+}
+
+/** JSDoc 주석을 제거하고 타입 정의만 추출 (파일 상단 JSDoc 제거, 인라인 주석은 유지) */
+function stripFileJsDoc(content: string): string {
+  // 파일 최상단의 /** ... */ 블록 제거 (import 전의 JSDoc만)
+  return content.replace(/^\/\*\*[\s\S]*?\*\/\s*\n/, '');
+}
+
+function main() {
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+
+  const entries = collectTypes(COMPONENT_LIB);
+  const grouped = groupByCategory(entries);
+
+  const lines: string[] = [
+    '# Component Types',
+    '',
+    '> 이 파일은 `scripts/extract-components.ts`로 자동 생성됩니다. 직접 수정하지 마세요.',
+    '> Claude API system prompt에 포함되어 컴포넌트 API 레퍼런스로 사용됩니다.',
+    '',
+    '## 사용 규칙',
+    '',
+    '- 아래 컴포넌트만 사용할 것. 목록에 없는 컴포넌트는 존재하지 않음',
+    '- import 경로: `@neobnsrnd-team/reactive-springware`',
+    '- TypeScript로 작성하고 props interface를 포함할 것',
+    '',
+  ];
+
+  // 카테고리 순서대로 출력
+  for (const category of CATEGORY_ORDER) {
+    const categoryEntries = grouped.get(category);
+    if (!categoryEntries || categoryEntries.length === 0) continue;
+
+    lines.push(`## ${categoryLabel(category)}`);
+    lines.push('');
+
+    // biz는 subCategory(banking/card/common 등)로 한 번 더 그룹핑
+    if (category === 'biz') {
+      const subGroups = new Map<string, ComponentEntry[]>();
+      for (const entry of categoryEntries) {
+        const sub = entry.subCategory || 'common';
+        const list = subGroups.get(sub) ?? [];
+        list.push(entry);
+        subGroups.set(sub, list);
+      }
+      for (const [sub, subEntries] of [...subGroups.entries()].sort()) {
+        lines.push(`### biz/${sub}`);
+        lines.push('');
+        for (const entry of subEntries.sort((a, b) => a.name.localeCompare(b.name))) {
+          lines.push(`#### ${entry.name}`);
+          lines.push('');
+          lines.push('```typescript');
+          lines.push(stripFileJsDoc(entry.content).trim());
+          lines.push('```');
+          lines.push('');
+        }
+      }
+    } else {
+      for (const entry of categoryEntries.sort((a, b) => a.name.localeCompare(b.name))) {
+        lines.push(`### ${entry.name}`);
+        lines.push('');
+        lines.push('```typescript');
+        lines.push(stripFileJsDoc(entry.content).trim());
+        lines.push('```');
+        lines.push('');
+      }
+    }
+  }
+
+  writeFileSync(OUTPUT_FILE, lines.join('\n'), 'utf-8');
+  console.log(`✅ component-types.md 생성 완료 (${entries.length}개 컴포넌트)`);
+  console.log(`   출력: ${OUTPUT_FILE}`);
+}
+
+main();

--- a/reactive-springware/scripts/extract-design-tokens.ts
+++ b/reactive-springware/scripts/extract-design-tokens.ts
@@ -1,0 +1,149 @@
+/**
+ * @file extract-design-tokens.ts
+ * @description design-tokens/figma-tokens/ 아래 JSON 파일을 파싱하여
+ *   design-tokens.md 마크다운 파일로 변환한다.
+ *
+ *   semantic.json(공통 시맨틱 토큰)과 brand.hana.json(하나은행 브랜드 토큰)을 포함.
+ *   Claude가 하드코딩 대신 CSS 변수를 사용하도록 유도하는 용도.
+ *
+ * @example
+ *   npx tsx scripts/extract-design-tokens.ts
+ */
+
+import { readFileSync, mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+const TOKENS_DIR = join(ROOT, 'design-tokens', 'figma-tokens');
+const OUTPUT_DIR = join(ROOT, 'generated');
+const OUTPUT_FILE = join(OUTPUT_DIR, 'design-tokens.md');
+
+type TokenNode = {
+  $type?: string;
+  $value?: string | number;
+  [key: string]: TokenNode | string | number | undefined;
+};
+
+/**
+ * 중첩된 토큰 객체를 평탄화하여 { path: value } 형태로 변환.
+ * $type / $value 키를 가진 노드가 실제 토큰 값.
+ */
+function flattenTokens(
+  node: TokenNode,
+  prefix: string = '',
+  result: Record<string, string> = {}
+): Record<string, string> {
+  if (node.$type !== undefined && node.$value !== undefined) {
+    result[prefix] = String(node.$value);
+    return result;
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key.startsWith('$') || value === undefined) continue;
+    const nextPrefix = prefix ? `${prefix}.${key}` : key;
+    flattenTokens(value as TokenNode, nextPrefix, result);
+  }
+
+  return result;
+}
+
+/** 토큰 경로(dot 표기)를 CSS 변수명으로 변환. 예: color.brand.5 → --color-brand-5 */
+function toCssVar(path: string): string {
+  return '--' + path.replace(/\./g, '-');
+}
+
+/** JSON 파일을 읽어 파싱 */
+function readJson(filePath: string): TokenNode {
+  return JSON.parse(readFileSync(filePath, 'utf-8')) as TokenNode;
+}
+
+function main() {
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+
+  const lines: string[] = [
+    '# Design Tokens',
+    '',
+    '> 이 파일은 `scripts/extract-design-tokens.ts`로 자동 생성됩니다. 직접 수정하지 마세요.',
+    '> Claude API system prompt에 포함되어 하드코딩 방지용 레퍼런스로 사용됩니다.',
+    '',
+    '## 사용 규칙',
+    '',
+    '- 색상·간격·타이포는 반드시 CSS 변수(`var(--*)`) 또는 Tailwind 토큰 클래스를 사용할 것',
+    '- `#FFFFFF`, `16px` 같은 하드코딩 금지',
+    '- 브랜드 컬러(`--color-brand-*`)는 prop으로 노출하지 말고 토큰으로 고정할 것',
+    '',
+  ];
+
+  // ── Semantic 토큰 ──────────────────────────────────────────────
+  const semantic = readJson(join(TOKENS_DIR, 'semantic.json'));
+  const semanticFlat = flattenTokens(semantic);
+
+  lines.push('## Semantic Tokens (공통 고정값)');
+  lines.push('');
+  lines.push('모든 은행 브랜드에서 공통으로 사용되는 시맨틱 컬러. 컴포넌트 내부에 직접 적용.');
+  lines.push('');
+
+  // 카테고리별(color, spacing, radius 등) 그룹핑
+  const semanticGroups = new Map<string, string[]>();
+  for (const [path, value] of Object.entries(semanticFlat)) {
+    const group = path.split('.')[0];
+    const list = semanticGroups.get(group) ?? [];
+    list.push(`| \`${toCssVar(path)}\` | \`${value}\` |`);
+    semanticGroups.set(group, list);
+  }
+
+  for (const [group, rows] of semanticGroups) {
+    lines.push(`### ${group}`);
+    lines.push('');
+    lines.push('| CSS 변수 | 참조값 |');
+    lines.push('|---------|--------|');
+    lines.push(...rows);
+    lines.push('');
+  }
+
+  // ── 하나은행 브랜드 토큰 ────────────────────────────────────────
+  const hana = readJson(join(TOKENS_DIR, 'brand.hana.json'));
+  const hanaFlat = flattenTokens(hana);
+
+  lines.push('## Brand Tokens — hana (하나은행)');
+  lines.push('');
+  lines.push('브랜드별 가변 토큰. `data-brand="hana"` 속성으로 주입됨.');
+  lines.push('컴포넌트 prop에 색상 값을 직접 전달하지 말 것.');
+  lines.push('');
+  lines.push('| CSS 변수 | 값 |');
+  lines.push('|---------|-----|');
+
+  for (const [path, value] of Object.entries(hanaFlat)) {
+    lines.push(`| \`${toCssVar(path)}\` | \`${value}\` |`);
+  }
+  lines.push('');
+
+  // ── Primitive 토큰 (참고용 요약) ────────────────────────────────
+  const primitives = readJson(join(TOKENS_DIR, 'primitives.json'));
+  const primFlat = flattenTokens(primitives);
+
+  lines.push('## Primitive Tokens (참고용 — 직접 사용 금지)');
+  lines.push('');
+  lines.push('Semantic/Brand 토큰이 참조하는 원시값. 컴포넌트에서 직접 사용하지 말 것.');
+  lines.push('');
+  lines.push('| CSS 변수 | 값 |');
+  lines.push('|---------|-----|');
+
+  // primitive는 양이 많으므로 color만 포함
+  for (const [path, value] of Object.entries(primFlat)) {
+    if (path.startsWith('color') || path.startsWith('primitive')) {
+      lines.push(`| \`${toCssVar(path)}\` | \`${value}\` |`);
+    }
+  }
+  lines.push('');
+
+  writeFileSync(OUTPUT_FILE, lines.join('\n'), 'utf-8');
+
+  const tokenCount = Object.keys(semanticFlat).length + Object.keys(hanaFlat).length;
+  console.log(`✅ design-tokens.md 생성 완료 (${tokenCount}개 토큰)`);
+  console.log(`   출력: ${OUTPUT_FILE}`);
+}
+
+main();


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
- #4

## ✨ 변경 사항 (Changes)

### 1. React Generate 메뉴 초기 구현
- 메뉴 등록 (`react_generate`, URL: `/react-generate`) 및 권한 설정 (`REACT_GENERATE:R/W`)
- Java 패키지 구조: `domain/reactgenerate/` — controller / service / mapper / dto / enums / ai / figma
- API 엔드포인트: `POST /api/react-generate/generate`, `/{id}/request-approval`, `/{id}/approve`
- Thymeleaf 템플릿: Figma URL 입력 → 화면/코드 미리보기 탭 → 승인 요청/승인 버튼
- DB 테이블 `REACT_GENERATE_HIS` 설계 및 MyBatis Mapper 구현 (Oracle/MySQL DDL 포함)
- 생성 상태 관리: `GENERATED` → `PENDING_APPROVAL` → `APPROVED`

### 2. Figma API 연동
- `FigmaUrlParser`: URL에서 `fileKey`, `nodeId` 파싱 (퍼센트 인코딩·대시 구분자 모두 처리)
- `FigmaApiClient`: `GET /v1/files/{fileKey}/nodes` 호출, `X-Figma-Token` 인증
- `FigmaDesignExtractor`: 원시 Figma JSON → 프롬프트용 컨텍스트 변환 (RGBA→HEX, 깊이 4 재귀 탐색)
- `FigmaDesignContext` / `FigmaNodeSummary`: Claude에 전달할 정제된 디자인 정보

### 3. Claude API 연동
- `reactive-springware` 컴포넌트 추출 스크립트 3종 (`extract-components.ts`, `extract-design-tokens.ts`, `extract-component-map.ts`)
- `PromptLoader`: `classpath:prompts/` 파일 `@PostConstruct` 시 캐싱
- `PromptBuilder`: Figma 디자인 컨텍스트를 ASCII 트리(├─ └─)로 포맷하여 user prompt 구성
- `ClaudeApiClient`: `POST /v1/messages` 호출, ` ```tsx ``` ` 코드 블록 추출

## ⚠️ 고려 및 주의 사항

- **환경변수 필수**: `.env`에 `FIGMA_ACCESS_TOKEN`(Figma Personal Access Token), `CLAUDE_API_KEY` 추가 필요
- **DDL 적용 필요**: `docs/sql/oracle/01_create_tables.sql` 또는 `docs/sql/mysql/01_create_tables.sql`의 `REACT_GENERATE_HIS` 테이블 생성 스크립트 실행 필요
- **프롬프트 파일**: `admin/src/main/resources/prompts/`에 `reactive-springware` 추출 산출물이 포함되어 있으며, 컴포넌트 라이브러리 변경 시 `npm run generate:prompts` 재실행 후 동기화 필요

## 💬 리뷰 포인트

- `FigmaApiClient`: `RestTemplate` URI 템플릿 변수로 base URL을 전달하면 URL-인코딩 문제가 발생하므로 문자열 연결로 처리 (`props.getUrl() + NODES_PATH`)
- `PromptBuilder.buildUserPrompt()`: Figma 노드 트리를 ASCII 트리로 변환하는 포맷 방식 — Claude의 코드 생성 정확도에 영향
- `FigmaDesignExtractor`: 노드 탐색 깊이를 `MAX_DEPTH=4`로 제한하여 토큰 비용 절감