### PR TITLE
feat: JWT 인증 강화, 하나카드 공여기간 유틸리티 및 카드 화면 실데이터 연동

### DIFF
--- a/demo/backend/package-lock.json
+++ b/demo/backend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "hnc-demo-backend",
       "version": "1.0.0",
       "dependencies": {
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.18.3",
@@ -241,6 +242,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.0.7",

--- a/demo/backend/package.json
+++ b/demo/backend/package.json
@@ -8,6 +8,7 @@
     "dev": "nodemon server.js"
   },
   "dependencies": {
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.18.3",

--- a/demo/backend/server.js
+++ b/demo/backend/server.js
@@ -14,15 +14,29 @@
 
 require("dotenv").config();
 
-const express = require("express");
-const cors = require("cors");
+const express      = require("express");
+const cors         = require("cors");
+const cookieParser = require("cookie-parser");
 const { apiLogger } = require("./utils/logger");
 const jwt = require("jsonwebtoken");
 const { initPool, withConnection, closePool } = require("./db");
 const { detectBrand, maskCardNumber } = require("./utils/cardBrand");
+const { getBillingPeriod }            = require("./utils/billingPeriod");
+const { getBillingSummaryByMonth }    = require("./utils/billingByMonth");
 
-const JWT_SECRET = process.env.JWT_SECRET || "dev-secret";
-const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "8h";
+const JWT_SECRET          = process.env.JWT_SECRET          || "dev-secret";
+// Access Token: 짧은 TTL — 만료 시 Refresh Token으로 재발급
+const JWT_ACCESS_EXPIRES_IN  = process.env.JWT_ACCESS_EXPIRES_IN  || "30m";
+// Refresh Token: 긴 TTL — httpOnly 쿠키로 관리 (JS 접근 불가)
+const JWT_REFRESH_SECRET     = process.env.JWT_REFRESH_SECRET     || "dev-refresh-secret";
+const JWT_REFRESH_EXPIRES_IN = process.env.JWT_REFRESH_EXPIRES_IN || "7d";
+
+/**
+ * POC용 인메모리 Refresh Token 저장소.
+ * 프로덕션에서는 Redis 또는 DB 테이블로 교체해야 한다.
+ * Map<userId, refreshToken>
+ */
+const refreshTokenStore = new Map();
 
 /** 보호 라우트에 적용할 JWT 검증 미들웨어 */
 function verifyToken(req, res, next) {
@@ -53,9 +67,13 @@ app.use(
         return cb(null, true);
       cb(new Error(`CORS blocked: ${origin}`));
     },
+    // withCredentials 요청(httpOnly 쿠키 전송)을 허용하기 위해 필수
+    credentials: true,
   }),
 );
 app.use(express.json());
+// httpOnly 쿠키(Refresh Token) 파싱
+app.use(cookieParser());
 app.use(apiLogger);
 
 // ── 개발용: D_SPIDERLINK의 POC_ 테이블 목록 및 컬럼 확인 ────────────────────
@@ -90,6 +108,51 @@ app.get("/api/dev/tables", async (_req, res) => {
   }
 });
 
+/**
+ * GET /api/dev/usage-stat
+ * POC_카드사용내역 "이용자" 컬럼 분포 진단용 엔드포인트.
+ *
+ * 반환:
+ *   totalCount   — 테이블 전체 레코드 수
+ *   distribution — { value, trimmedValue, count } 목록 (이용자 값별 건수)
+ *
+ * "이용자" 값의 선행/후행 공백이나 대소문자 차이가
+ * WHERE "이용자" = :userId 필터에서 레코드가 누락되는 주 원인이므로
+ * 원본 값(value)과 TRIM 값(trimmedValue)을 함께 반환한다.
+ */
+app.get("/api/dev/usage-stat", async (_req, res) => {
+  try {
+    const [countResult, distResult] = await Promise.all([
+      withConnection((conn) =>
+        conn.execute(
+          `SELECT COUNT(*) AS TOTAL_CNT FROM D_SPIDERLINK.POC_카드사용내역`,
+        ),
+      ),
+      withConnection((conn) =>
+        conn.execute(
+          `SELECT "이용자"        AS RAW_VAL,
+                  TRIM("이용자") AS TRIM_VAL,
+                  COUNT(*)       AS CNT
+             FROM D_SPIDERLINK.POC_카드사용내역
+            GROUP BY "이용자", TRIM("이용자")
+            ORDER BY CNT DESC`,
+        ),
+      ),
+    ]);
+
+    res.json({
+      totalCount:   countResult.rows[0]?.TOTAL_CNT ?? 0,
+      distribution: (distResult.rows || []).map((r) => ({
+        value:        r.RAW_VAL,       // DB에 실제 저장된 값 (공백 포함 가능)
+        trimmedValue: r.TRIM_VAL,      // 앞뒤 공백 제거 후 값
+        count:        r.CNT,
+      })),
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 app.get("/api/dev/columns/:tbl", async (req, res) => {
   try {
     const tbl = req.params.tbl.toUpperCase();
@@ -98,8 +161,9 @@ app.get("/api/dev/columns/:tbl", async (req, res) => {
         `SELECT COLUMN_NAME, DATA_TYPE
            FROM ALL_TAB_COLUMNS
           WHERE OWNER = 'D_SPIDERLINK'
-            AND TABLE_NAME = '${tbl}'
+            AND TABLE_NAME = :tbl
           ORDER BY COLUMN_ID`,
+        { tbl }, // SQL 인젝션 방지: bind variable 사용
       ),
     );
     res.json({ table: tbl, columns: result.rows });
@@ -164,21 +228,39 @@ app.post("/api/auth/login", async (req, res) => {
       console.warn("[login] LAST_LOGIN_DTIME 업데이트 실패:", e.message),
     );
 
-    const token = jwt.sign(
-      {
-        userId: row.USER_ID,
-        userName: row.USER_NAME,
-        userGrade: row.USER_GRADE,
-      },
-      JWT_SECRET,
-      { expiresIn: JWT_EXPIRES_IN },
-    );
+    const payload = {
+      userId:    row.USER_ID,
+      userName:  row.USER_NAME,
+      userGrade: row.USER_GRADE,
+    };
+
+    // Access Token: 짧은 TTL, Authorization 헤더로 전달
+    const accessToken = jwt.sign(payload, JWT_SECRET, {
+      expiresIn: JWT_ACCESS_EXPIRES_IN,
+    });
+
+    // Refresh Token: 긴 TTL, httpOnly 쿠키로 전달 (JS 접근 불가 → XSS 방지)
+    const refreshToken = jwt.sign(payload, JWT_REFRESH_SECRET, {
+      expiresIn: JWT_REFRESH_EXPIRES_IN,
+    });
+
+    // 인메모리 저장소에 등록 (탈취 감지용 — 저장값과 다르면 무효화)
+    refreshTokenStore.set(row.USER_ID, refreshToken);
+
+    // SameSite=lax: CSRF 방지 / path=/api/auth: 인증 경로에만 쿠키 전송
+    res.cookie("refreshToken", refreshToken, {
+      httpOnly: true,
+      secure:   false, // POC: HTTP 허용 (프로덕션에서는 true + HTTPS 필수)
+      sameSite: "lax",
+      maxAge:   7 * 24 * 60 * 60 * 1000, // 7일 (ms)
+      path:     "/api/auth",
+    });
 
     return res.json({
-      success: true,
-      token,
-      userId: row.USER_ID,
-      userName: row.USER_NAME,
+      success:   true,
+      token:     accessToken, // 기존 키 유지 (프론트 AuthUser.token 호환)
+      userId:    row.USER_ID,
+      userName:  row.USER_NAME,
       userGrade: row.USER_GRADE,
     });
   } catch (err) {
@@ -187,6 +269,55 @@ app.post("/api/auth/login", async (req, res) => {
       .status(500)
       .json({ success: false, message: "서버 오류가 발생했습니다." });
   }
+});
+
+/**
+ * POST /api/auth/refresh
+ * Refresh Token(httpOnly 쿠키)으로 새 Access Token 발급.
+ * 저장된 토큰과 불일치 시 탈취로 간주하고 해당 유저의 토큰을 무효화한다.
+ */
+app.post("/api/auth/refresh", (req, res) => {
+  const refreshToken = req.cookies?.refreshToken;
+
+  if (!refreshToken) {
+    return res.status(401).json({ error: "Refresh Token이 없습니다." });
+  }
+
+  try {
+    const decoded = jwt.verify(refreshToken, JWT_REFRESH_SECRET);
+    const stored  = refreshTokenStore.get(decoded.userId);
+
+    // 저장된 토큰과 불일치 → 탈취된 토큰으로 간주, 즉시 무효화
+    if (stored !== refreshToken) {
+      refreshTokenStore.delete(decoded.userId);
+      return res.status(401).json({ error: "유효하지 않은 Refresh Token입니다." });
+    }
+
+    const newAccessToken = jwt.sign(
+      { userId: decoded.userId, userName: decoded.userName, userGrade: decoded.userGrade },
+      JWT_SECRET,
+      { expiresIn: JWT_ACCESS_EXPIRES_IN },
+    );
+
+    return res.json({ accessToken: newAccessToken });
+  } catch {
+    return res.status(401).json({ error: "Refresh Token이 만료되었거나 유효하지 않습니다." });
+  }
+});
+
+/**
+ * POST /api/auth/logout
+ * Authorization: Bearer <accessToken>
+ * 인메모리 Refresh Token 삭제 + 쿠키 만료 처리.
+ */
+app.post("/api/auth/logout", verifyToken, (req, res) => {
+  // 인메모리 저장소에서 Refresh Token 제거
+  refreshTokenStore.delete(req.user.userId);
+
+  // 클라이언트 쿠키 만료 (maxAge=0)
+  res.clearCookie("refreshToken", { path: "/api/auth" });
+
+  return res.json({ success: true });
 });
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -448,10 +579,13 @@ function getDateRange(period, customMonth) {
 app.get("/api/transactions", verifyToken, async (req, res) => {
   try {
     const userId = req.user.userId;
-    const { cardId, period, customMonth, usageType } = req.query;
+    const { cardId, period, customMonth, usageType, fromDate: qFromDate, toDate: qToDate } = req.query;
 
-    // ── 날짜 범위 계산 ────────────────────────────────────────────
-    const { fromDate, toDate } = getDateRange(period, customMonth);
+    // ── 날짜 범위 계산 ─────────────────────────────────────────────
+    // fromDate/toDate 직접 전달 시 우선 사용, 없으면 period/customMonth로 계산
+    const { fromDate: rangeFrom, toDate: rangeTo } = getDateRange(period, customMonth);
+    const fromDate = qFromDate || rangeFrom;
+    const toDate   = qToDate   || rangeTo;
 
     // ── 동적 WHERE 절 구성 ───────────────────────────────────────
     let sql = `
@@ -510,73 +644,147 @@ app.get("/api/transactions", verifyToken, async (req, res) => {
  * GET /api/payment-statement
  * 결제예정금액 / 이용대금명세서 탭 데이터를 반환합니다.
  *
+ * Query Params (모두 선택):
+ *   paymentDay — 카드 결제일(1~31). 공여기간 계산 기준. 미전달 시 DB 첫 카드 결제일 사용.
+ *   yearMonth  — 'YYYY-MM'. 전달 시 결제예정일(YYMMDD) LIKE 필터로 전환 (공여기간 미적용).
+ *
  * Response 200:
  *   {
- *     dueDate: string,          // YYMMDD (결제예정일)
- *     totalAmount: number,      // 승인 건 이용금액 합계
- *     items: [{ cardNo, cardName, amount }],
- *     cardInfo: { paymentBank, paymentAccount, paymentDay }
+ *     dueDate      : string,   // YYMMDD (결제예정일, 대표값)
+ *     totalAmount  : number,
+ *     items        : [{ cardNo, cardName, amount, dueDate }],
+ *     cardInfo     : { paymentBank, paymentAccount, paymentDay } | null,
+ *     billingPeriod: { usageStart, usageEnd, dueDate } | null  // 'YYYY.MM.DD' 형식
  *   }
  */
 app.get("/api/payment-statement", verifyToken, async (req, res) => {
   try {
     const userId = req.user.userId;
+    const { yearMonth, paymentDay } = req.query;
 
-    const [txResult, cardResult] = await withConnection((conn) =>
-      Promise.all([
-        // 승인된 거래만 카드별 집계
-        conn.execute(
-          `SELECT "카드번호", "카드명", "이용금액", "결제예정일"
-             FROM D_SPIDERLINK.POC_카드사용내역
-            WHERE "이용자" = :userId AND "승인여부" = 'Y'`,
-          { userId },
-        ),
-        // 첫 번째 카드의 결제정보 (infoSections 용)
-        conn.execute(
-          `SELECT "결제은행명", "결제계좌", "결제일"
-             FROM D_SPIDERLINK.POC_카드리스트
-            WHERE "사용자아이디" = :userId
-              AND ROWNUM = 1
-            ORDER BY "결제순번" NULLS LAST`,
-          { userId },
-        ),
-      ]),
+    // ── 1. 카드 정보 조회 (결제은행·계좌·결제일) ───────────────────
+    // 전체 카드를 조회하여 카드별 결제일(cardSettings)을 구성한다.
+    // getBillingSummaryByMonth가 각 카드의 공여기간을 개별 적용하기 위해 필요.
+    const cardResult = await withConnection((conn) =>
+      conn.execute(
+        `SELECT "카드번호", "결제은행명", "결제계좌", "결제일"
+           FROM D_SPIDERLINK.POC_카드리스트
+          WHERE "사용자아이디" = :userId
+          ORDER BY "결제순번" NULLS LAST`,
+        { userId },
+      ),
     );
+    const cardRows = cardResult.rows || [];
 
-    const txRows   = txResult.rows   || [];
-    const cardRows = cardResult.rows  || [];
-
-    // ── 가장 많이 등장하는 결제예정일 ──────────────────────────
-    const dueDateCount = {};
-    txRows.forEach((r) => {
-      const d = r["결제예정일"];
-      if (d) dueDateCount[d] = (dueDateCount[d] || 0) + 1;
+    // { 카드번호: 결제일(number) } — getBillingSummaryByMonth에 전달
+    const cardSettings = {};
+    cardRows.forEach((row) => {
+      const no = String(row["카드번호"] ?? "").trim();
+      if (no) cardSettings[no] = Number(row["결제일"] ?? 25);
     });
-    const dueDate =
-      Object.entries(dueDateCount).sort((a, b) => b[1] - a[1])[0]?.[0] ?? "";
 
-    // ── 카드+결제예정일 조합별 이용금액 합계 (결제일이 다를 수 있음) ──
-    const cardMap = {};
-    txRows.forEach((r) => {
-      const key = `${r["카드번호"]}_${r["결제예정일"] ?? ""}`;
-      if (!cardMap[key])
-        cardMap[key] = { cardNo: r["카드번호"], cardName: r["카드명"] ?? "", amount: 0, dueDate: r["결제예정일"] ?? "" };
-      cardMap[key].amount += Number(r["이용금액"] ?? 0);
-    });
-    const items       = Object.values(cardMap);
-    const totalAmount = items.reduce((sum, item) => sum + item.amount, 0);
-
-    // ── 결제정보 (첫 번째 카드 기준) ──────────────────────────
-    const ci = cardRows[0];
+    const ci = cardRows[0] ?? null;
     const cardInfo = ci
       ? {
           paymentBank:    ci["결제은행명"] ?? "",
           paymentAccount: String(ci["결제계좌"] ?? ""),
-          paymentDay:     ci["결제일"] ?? "",
+          paymentDay:     String(ci["결제일"] ?? ""),
         }
       : null;
 
-    res.json({ dueDate, totalAmount, items, cardInfo });
+    // ── 2. 이용내역 조회 범위 결정 ──────────────────────────────────
+    // 이용일자(useDate)를 포함해야 getBillingSummaryByMonth가 공여기간을 계산할 수 있다.
+    let txSql = `SELECT "카드번호", "카드명", "이용금액", "결제예정일", "이용일자"
+                   FROM D_SPIDERLINK.POC_카드사용내역
+                  WHERE "이용자" = :userId AND "승인여부" = 'Y'`;
+    const txBinds = { userId };
+    let billingPeriodFormatted = null;
+
+    if (yearMonth) {
+      /* 카드별 공여기간 기반 필터:
+       * 어떤 결제일(1~27)이든 선택 청구월의 이용 시작일은 최소 2개월 전 이후다.
+       * 보수적 범위(targetMonth-2 ~ targetMonth 말일)로 DB를 조회하고,
+       * 정밀 필터링은 getBillingSummaryByMonth가 카드별로 수행한다. */
+      const [y, m] = yearMonth.split("-").map(Number);
+      let fromYear = y, fromMonth = m - 2;
+      if (fromMonth <= 0) { fromYear--; fromMonth += 12; }
+      const toDay = new Date(y, m, 0).getDate(); // targetMonth 말일
+      txBinds.fromDate = `${fromYear}${String(fromMonth).padStart(2, "0")}01`;
+      txBinds.toDate   = `${y}${String(m).padStart(2, "0")}${String(toDay).padStart(2, "0")}`;
+      txSql += ` AND "이용일자" >= :fromDate AND "이용일자" <= :toDate`;
+    } else {
+      /* 공여기간 필터: 전달받은 paymentDay 또는 DB 결제일 기준으로 이용일자 범위 산정 */
+      const D = paymentDay ?? cardInfo?.paymentDay;
+      if (D) {
+        try {
+          const bp = getBillingPeriod(new Date(), D);
+          txSql += ` AND "이용일자" >= :fromDate AND "이용일자" <= :toDate`;
+          txBinds.fromDate = bp.fromDate; // YYYYMMDD
+          txBinds.toDate   = bp.toDate;   // YYYYMMDD
+          billingPeriodFormatted = bp.formatted; // { usageStart, usageEnd, dueDate }
+        } catch (e) {
+          console.warn("[payment-statement] 공여기간 계산 실패:", e.message);
+        }
+      }
+    }
+
+    // ── 3. 이용내역 조회 ─────────────────────────────────────────────
+    const txResult = await withConnection((conn) => conn.execute(txSql, txBinds));
+    const txRows = txResult.rows || [];
+
+    // ── 4. 집계 (yearMonth 유무에 따라 분기) ──────────────────────────
+    let items, totalAmount, dueDate;
+
+    if (yearMonth) {
+      /* 카드별 결제일 공여기간을 개별 적용해 청구월을 정확히 판단 */
+      const rawItems = txRows.map((r) => ({
+        cardNo:   String(r["카드번호"] ?? ""),
+        cardName: r["카드명"] ?? "",
+        useDate:  String(r["이용일자"] ?? ""),
+        amount:   Number(r["이용금액"] ?? 0),
+        dueDate:  r["결제예정일"] ?? "",
+      }));
+      const summary = getBillingSummaryByMonth(rawItems, yearMonth, cardSettings);
+
+      /* 카드+결제예정일 조합별 재집계 (응답 포맷을 기존과 동일하게 유지) */
+      const cardMap = {};
+      summary.items.forEach((item) => {
+        const key = `${item.cardNo}_${item.dueDate}`;
+        if (!cardMap[key]) cardMap[key] = { cardNo: item.cardNo, cardName: item.cardName, amount: 0, dueDate: item.dueDate };
+        cardMap[key].amount += item.amount;
+      });
+      items       = Object.values(cardMap);
+      totalAmount = summary.totalAmount;
+
+      /* 대표 결제예정일 — 가장 많이 등장하는 값 */
+      const cnt = {};
+      summary.items.forEach((i) => { if (i.dueDate) cnt[i.dueDate] = (cnt[i.dueDate] || 0) + 1; });
+      dueDate = Object.entries(cnt).sort((a, b) => b[1] - a[1])[0]?.[0] ?? "";
+
+    } else {
+      /* 공여기간 기반 조회 — 기존 집계 로직 유지 */
+      const cardMap = {};
+      txRows.forEach((r) => {
+        const key = `${r["카드번호"]}_${r["결제예정일"] ?? ""}`;
+        if (!cardMap[key]) cardMap[key] = { cardNo: r["카드번호"], cardName: r["카드명"] ?? "", amount: 0, dueDate: r["결제예정일"] ?? "" };
+        cardMap[key].amount += Number(r["이용금액"] ?? 0);
+      });
+      items       = Object.values(cardMap);
+      totalAmount = items.reduce((sum, i) => sum + i.amount, 0);
+
+      const cnt = {};
+      txRows.forEach((r) => { const d = r["결제예정일"]; if (d) cnt[d] = (cnt[d] || 0) + 1; });
+      dueDate = Object.entries(cnt).sort((a, b) => b[1] - a[1])[0]?.[0] ?? "";
+    }
+
+    res.json({
+      dueDate,
+      totalAmount,
+      items,
+      cardInfo,
+      /** 공여기간 정보 — yearMonth 선택 시 null, 결제일 기반 조회 시 'YYYY.MM.DD' 형식 */
+      billingPeriod: billingPeriodFormatted,
+    });
   } catch (err) {
     console.error("[GET /api/payment-statement]", err);
     res.status(500).json({ error: "DB 조회 중 오류가 발생했습니다." });

--- a/demo/backend/utils/billingByMonth.js
+++ b/demo/backend/utils/billingByMonth.js
@@ -1,0 +1,365 @@
+/**
+ * @file billingByMonth.js
+ * @description 카드별 개별 결제일 기반 청구월 필터링 유틸리티.
+ *
+ * ── 두 가지 접근 방식 ────────────────────────────────────────────────────────
+ *
+ *   [Forward — getItemBillingMonth]
+ *     이용일자 + 결제일 → 청구월 산출
+ *     "이 이용이 몇 월에 청구되나?" 를 건별로 판단할 때 사용.
+ *
+ *   [Reverse — getBillingPeriodForMonth 기반]
+ *     청구월 + 결제일 → 이용 기간(startDate ~ endDate) 역산 후 범위 비교
+ *     "이 청구월에 포함될 이용내역은 뭔가?" 를 효율적으로 필터링할 때 사용.
+ *     getBillingSummaryByMonth / getPaymentExpectedList 가 이 방식을 채택한다.
+ *
+ * ── 역산 방식의 장점 ─────────────────────────────────────────────────────────
+ *   - 카드(결제일)의 종류(N)만큼만 getBillingPeriodForMonth를 호출하고
+ *     이후 필터링은 YYYYMMDD 문자열 비교(O(1))로 처리 → 항목 수에 비례하지 않음
+ *   - 동일 결제일의 기간은 periodCache로 중복 계산 방지
+ */
+
+"use strict";
+
+const { getBillingPeriod, getBillingPeriodForMonth } = require("./billingPeriod");
+
+/** cardSettings에 카드번호가 없을 때 사용할 기본 결제일 */
+const DEFAULT_PAYMENT_DAY = 25;
+
+// ── 내부 헬퍼 ────────────────────────────────────────────────────────────────
+
+/**
+ * "YYYYMMDD" 문자열 → Date 객체
+ * @param {string} s
+ * @returns {Date}
+ */
+function parseYYYYMMDD(s) {
+  return new Date(
+    parseInt(s.slice(0, 4), 10),
+    parseInt(s.slice(4, 6), 10) - 1,
+    parseInt(s.slice(6, 8), 10),
+  );
+}
+
+// ── 공개 함수 (Forward) ──────────────────────────────────────────────────────
+
+/**
+ * 이용일자(YYYYMMDD)와 카드 결제일(paymentDay)을 받아
+ * 해당 이용이 속하는 청구월("YYYY-MM")을 반환한다. (Forward 방식)
+ *
+ * @param {string}        useDate    - "YYYYMMDD"
+ * @param {number|string} paymentDay - 카드 결제일 (1~31)
+ * @returns {string} "YYYY-MM"
+ *
+ * @example
+ *   getItemBillingMonth('20260314', 25) // '2026-04'  (3월 14일 → 4월 청구)
+ *   getItemBillingMonth('20260312', 25) // '2026-03'  (3월 12일 → 3월 청구)
+ *   getItemBillingMonth('20260314',  1) // '2026-05'  (3월 14일 → 5월 청구)
+ */
+function getItemBillingMonth(useDate, paymentDay) {
+  const useDateObj = parseYYYYMMDD(useDate);
+  const { dueDate } = getBillingPeriod(useDateObj, paymentDay);
+  const y = dueDate.getFullYear();
+  const m = String(dueDate.getMonth() + 1).padStart(2, "0");
+  return `${y}-${m}`;
+}
+
+/**
+ * 이용내역 단건의 청구월을 cardSettings를 참조하여 반환한다.
+ *
+ * @param {{ cardNo: string, useDate: string }} item
+ * @param {Record<string, number>} cardSettings - { 카드번호: 결제일 }
+ * @returns {string} "YYYY-MM"
+ */
+function calculateItemBillingMonth(item, cardSettings) {
+  const paymentDay = cardSettings[item.cardNo] ?? DEFAULT_PAYMENT_DAY;
+  return getItemBillingMonth(item.useDate, paymentDay);
+}
+
+// ── 공개 함수 (Reverse) ──────────────────────────────────────────────────────
+
+/**
+ * getBillingSummaryByMonth
+ * 역산 방식으로 targetMonth에 청구될 이용내역을 필터링한다.
+ *
+ * 동작:
+ *   1. 고유 결제일(paymentDay)별로 getBillingPeriodForMonth를 한 번씩만 호출해
+ *      이용 기간(fromDate ~ toDate)을 캐시한다.
+ *   2. 각 항목의 useDate가 해당 카드의 이용 기간 내에 있는지 문자열 비교로 필터링한다.
+ *      (YYYYMMDD는 사전식 정렬 = 날짜 순이므로 >=, <= 비교 가능)
+ *
+ * @param {Array<{
+ *   cardNo:   string,
+ *   cardName: string,
+ *   useDate:  string,  // "YYYYMMDD"
+ *   amount:   number,
+ *   dueDate?: string,
+ * }>} allItems
+ *
+ * @param {string}                targetMonth  - "YYYY-MM"
+ * @param {Record<string,number>} cardSettings - { 카드번호: 결제일 }
+ *
+ * @returns {{
+ *   targetMonth:  string,
+ *   totalAmount:  number,
+ *   byCard: Array<{
+ *     cardNo, cardName, paymentDay,
+ *     billingStart, billingEnd,
+ *     totalAmount, items
+ *   }>,
+ *   items: Array,
+ * }}
+ *
+ * @example
+ *   // 2026-04 청구월, D=25 카드
+ *   // billingStart='2026.03.13', billingEnd='2026.04.12' 범위 항목만 포함
+ *   getBillingSummaryByMonth(allItems, '2026-04', { '4531...': 25, '5412...': 1 })
+ */
+function getBillingSummaryByMonth(allItems, targetMonth, cardSettings) {
+  // ── 결제일(paymentDay)별 이용 기간 캐시 ────────────────────────────────
+  // 같은 결제일 카드가 여러 장이어도 getBillingPeriodForMonth는 한 번만 호출됨
+  const periodCache = new Map();
+
+  function getPeriod(paymentDay) {
+    if (!periodCache.has(paymentDay)) {
+      periodCache.set(paymentDay, getBillingPeriodForMonth(targetMonth, paymentDay));
+    }
+    return periodCache.get(paymentDay);
+  }
+
+  // ── useDate 범위 기반 필터링 + 카드별 집계 ─────────────────────────────
+  /** @type {Map<string, { cardNo, cardName, paymentDay, billingStart, billingEnd, totalAmount, items }>} */
+  const cardMap = new Map();
+
+  for (const item of allItems) {
+    const paymentDay = cardSettings[item.cardNo] ?? DEFAULT_PAYMENT_DAY;
+    let period;
+    try {
+      period = getPeriod(paymentDay);
+    } catch {
+      continue; // 결제일 파싱 실패 시 해당 항목 제외
+    }
+
+    // YYYYMMDD 문자열은 사전식 정렬 = 날짜 순 → 부등호 비교 가능
+    if (item.useDate < period.fromDate || item.useDate > period.toDate) continue;
+
+    if (!cardMap.has(item.cardNo)) {
+      cardMap.set(item.cardNo, {
+        cardNo:       item.cardNo,
+        cardName:     item.cardName,
+        paymentDay,
+        billingStart: period.formatted.usageStart,
+        billingEnd:   period.formatted.usageEnd,
+        totalAmount:  0,
+        items:        [],
+      });
+    }
+    const entry = cardMap.get(item.cardNo);
+    entry.totalAmount += item.amount;
+    entry.items.push(item);
+  }
+
+  const byCard       = [...cardMap.values()];
+  const totalAmount  = byCard.reduce((sum, c) => sum + c.totalAmount, 0);
+  const filteredItems = byCard.flatMap((c) => c.items);
+
+  return { targetMonth, totalAmount, byCard, items: filteredItems };
+}
+
+/**
+ * getPaymentExpectedList
+ * 카드 중심(cardData) 구조로 yearMonth 청구 내역을 필터링한다.
+ *
+ * getBillingSummaryByMonth가 flat items + cardSettings 구조를 받는 반면,
+ * 이 함수는 카드별로 items가 내장된 구조를 받는다.
+ *
+ * 역산 단계:
+ *   1. yearMonth + card.paymentDay → getBillingPeriodForMonth로 이용 기간 계산
+ *   2. item.useDate 가 [fromDate, toDate] 범위 내인지 체크
+ *
+ * @param {string} yearMonth - "YYYY-MM"
+ * @param {Array<{
+ *   cardNo:     string,
+ *   cardName:   string,
+ *   paymentDay: number,
+ *   items:      Array<{ useDate: string, amount: number, [key: string]: any }>
+ * }>} cardData - 카드별 이용내역 (카드 중심 구조)
+ *
+ * @returns {{
+ *   yearMonth:   string,
+ *   totalAmount: number,
+ *   byCard: Array<{
+ *     cardNo:       string,
+ *     cardName:     string,
+ *     paymentDay:   number,
+ *     billingStart: string,  // 'YYYY.MM.DD'
+ *     billingEnd:   string,
+ *     totalAmount:  number,
+ *     items:        Array,
+ *   }>
+ * }}
+ *
+ * @example — 2026-04 선택 시 각 카드별 이용 기간
+ *   트래블로그 (D=25) : 2026.03.13 ~ 2026.04.12
+ *   JADE First  (D=1) : 2026.02.19 ~ 2026.03.18
+ *   아멕스 골드(D=10) : 2026.02.28 ~ 2026.03.27
+ *
+ *   item { cardNo: 트래블로그, useDate: '20260315', amount: 50000 }
+ *     → 2026.03.13 ~ 2026.04.12 내 → 4월 청구 포함 ✓
+ *
+ *   item { cardNo: JADE First, useDate: '20260315', amount: 100000 }
+ *     → 2026.02.19 ~ 2026.03.18 내 → 4월 청구 포함 ✓
+ *
+ *   item { cardNo: JADE First, useDate: '20260319', amount: 30000 }
+ *     → 2026.03.19 > 2026.03.18 → 4월 청구 제외 ✗ (5월 청구분)
+ */
+function getPaymentExpectedList(yearMonth, cardData) {
+  let grandTotal = 0;
+
+  const byCard = cardData.map((card) => {
+    const { fromDate, toDate, formatted } = getBillingPeriodForMonth(
+      yearMonth,
+      card.paymentDay,
+    );
+
+    // YYYYMMDD 문자열 비교로 범위 필터링
+    const filteredItems = (card.items ?? []).filter(
+      (item) => item.useDate >= fromDate && item.useDate <= toDate,
+    );
+
+    const cardTotal = filteredItems.reduce((sum, i) => sum + i.amount, 0);
+    grandTotal += cardTotal;
+
+    return {
+      cardNo:       card.cardNo,
+      cardName:     card.cardName,
+      paymentDay:   card.paymentDay,
+      billingStart: formatted.usageStart, // 이용 시작일 'YYYY.MM.DD'
+      billingEnd:   formatted.usageEnd,   // 이용 종료일 'YYYY.MM.DD'
+      totalAmount:  cardTotal,
+      items:        filteredItems,
+    };
+  });
+
+  return { yearMonth, totalAmount: grandTotal, byCard };
+}
+
+/**
+ * calculateRemainingAmount
+ * 대시보드용 '남은 결제 예정 금액' 산출 함수.
+ *
+ * getBillingSummaryByMonth / getPaymentExpectedList의 반환값(paymentData)을 받아
+ * 오늘(currentDate)을 기준으로 각 카드의 결제 예정일(dueDate)을 계산하고
+ * paid(결제일 경과) / remaining(결제 예정) 으로 분류한다.
+ *
+ * ── dueDate 계산 방법 ────────────────────────────────────────────────────────
+ *   dueDate = yearMonth의 연/월 + 카드 결제일(paymentDay)
+ *   e.g. yearMonth='2026-04', paymentDay=25 → dueDate=2026-04-25
+ *   말일 초과 클램프: paymentDay=31이고 해당 월이 30일이면 30일로 처리
+ *
+ * ── 분류 기준 ────────────────────────────────────────────────────────────────
+ *   dueDate <  오늘(currentDate) 00:00 → paid     (결제일 경과, 합산 제외)
+ *   dueDate >= 오늘(currentDate) 00:00 → remaining (오늘 포함 결제 예정)
+ *
+ * @param {{
+ *   targetMonth?: string,       // "YYYY-MM" — getBillingSummaryByMonth 반환 시 포함
+ *   yearMonth?:   string,       // "YYYY-MM" — getPaymentExpectedList  반환 시 포함
+ *   totalAmount:  number,
+ *   byCard: Array<{
+ *     cardNo:      string,
+ *     cardName:    string,
+ *     paymentDay:  number,
+ *     totalAmount: number,
+ *     items:       Array,
+ *   }>
+ * }} paymentData - getBillingSummaryByMonth 또는 getPaymentExpectedList 의 반환값
+ *
+ * @param {Date} [currentDate=new Date()] - 기준일 (기본: 오늘. 테스트 시 주입 가능)
+ *
+ * @returns {{
+ *   yearMonth:        string,
+ *   totalAmount:      number,
+ *   paidAmount:       number,   // 결제일 경과 금액
+ *   remainingAmount:  number,   // 남은 결제 예정 금액
+ *   byCard: Array<{
+ *     cardNo:     string,
+ *     cardName:   string,
+ *     paymentDay: number,
+ *     dueDate:    string,   // 'YYYY.MM.DD'
+ *     status:     'paid' | 'remaining',
+ *     amount:     number,
+ *   }>
+ * }}
+ *
+ * @example
+ *   // 오늘: 2026-04-14
+ *   // yearMonth: '2026-04'
+ *   // Card A: paymentDay=10, amount=500,000
+ *   //   dueDate=2026-04-10 < 2026-04-14 → paid
+ *   // Card B: paymentDay=25, amount=1,200,000
+ *   //   dueDate=2026-04-25 >= 2026-04-14 → remaining
+ *   //
+ *   // 결과:
+ *   //   totalAmount    = 1,700,000
+ *   //   paidAmount     =   500,000
+ *   //   remainingAmount = 1,200,000
+ */
+function calculateRemainingAmount(paymentData, currentDate = new Date()) {
+  // targetMonth(getBillingSummaryByMonth) 또는 yearMonth(getPaymentExpectedList) 둘 다 수용
+  const yearMonth = paymentData.targetMonth ?? paymentData.yearMonth;
+  const [y, m]    = yearMonth.split("-").map(Number);
+
+  // 오늘 00:00 기준 — 시간 차이로 인한 오판 방지
+  const today = new Date(currentDate);
+  today.setHours(0, 0, 0, 0);
+
+  let paidAmount      = 0;
+  let remainingAmount = 0;
+
+  const byCard = paymentData.byCard.map((card) => {
+    // 해당 월의 말일을 초과하는 결제일은 말일로 클램프
+    // e.g. paymentDay=31, 4월 → 30일
+    const lastDay = new Date(y, m, 0).getDate();
+    const dueDay  = Math.min(card.paymentDay, lastDay);
+    const dueDate = new Date(y, m - 1, dueDay); // 00:00
+
+    // dueDate < today → 결제일 경과(paid), 그 외 → 결제 예정(remaining)
+    const isPaid = dueDate < today;
+
+    if (isPaid) {
+      paidAmount += card.totalAmount;
+    } else {
+      remainingAmount += card.totalAmount;
+    }
+
+    const dueDateStr = `${y}.${String(m).padStart(2, "0")}.${String(dueDay).padStart(2, "0")}`;
+
+    return {
+      cardNo:     card.cardNo,
+      cardName:   card.cardName,
+      paymentDay: card.paymentDay,
+      dueDate:    dueDateStr,               // 'YYYY.MM.DD'
+      status:     isPaid ? "paid" : "remaining",
+      amount:     card.totalAmount,
+    };
+  });
+
+  return {
+    yearMonth,
+    totalAmount:     paymentData.totalAmount,
+    paidAmount,
+    remainingAmount,
+    byCard,
+  };
+}
+
+module.exports = {
+  // Forward
+  getItemBillingMonth,
+  calculateItemBillingMonth,
+  // Reverse
+  getBillingSummaryByMonth,
+  getPaymentExpectedList,
+  // Dashboard
+  calculateRemainingAmount,
+};

--- a/demo/backend/utils/billingPeriod.js
+++ b/demo/backend/utils/billingPeriod.js
@@ -1,0 +1,302 @@
+/**
+ * @file billingPeriod.js
+ * @description 하나카드 공식 결제일별 신용공여기간 계산 유틸리티 (개인회원 일시불·할부 기준).
+ *
+ * 출처: https://www.hanacard.co.kr/OSA15000000N.web
+ *
+ * ── 공식 규칙 (결제일 D, 결제월 M 기준) ─────────────────────────────────
+ *
+ *   [D ≤ 12]
+ *     이용 기간 시작: (M-2)월 (D+18)일
+ *     이용 기간 종료: (M-1)월 (D+17)일
+ *     결제 예정일  :  M월      D 일
+ *     e.g. D=1  → 전전월 19일 ~ 전월 18일 / 결제 당월 1일
+ *          D=10 → 전전월 28일 ~ 전월 27일 / 결제 당월 10일
+ *          D=12 → 전전월 30일 ~ 전월 29일 / 결제 당월 12일
+ *
+ *   [D = 13]
+ *     이용 기간: 전월 1일 ~ 전월 말일
+ *     결제 예정일: 당월 13일
+ *
+ *   [D ≥ 14]
+ *     이용 기간 시작: (M-1)월 (D-12)일
+ *     이용 기간 종료:  M월    (D-13)일
+ *     결제 예정일  :  M월      D 일
+ *     e.g. D=14 → 전월  2일 ~ 당월  1일 / 결제 당월 14일
+ *          D=25 → 전월 13일 ~ 당월 12일 / 결제 당월 25일
+ *          D=27 → 전월 15일 ~ 당월 14일 / 결제 당월 27일
+ *
+ * ── 결제월(M) 결정 기준 ──────────────────────────────────────────────────
+ *   기준일(baseDate)이 속한 이용 기간의 결제월은 cutoff(기준일)로 판단한다.
+ *
+ *   cutoff = D+17   (D ≤ 12): baseDay ≤ D+17 → 결제월=당월, 초과 → 결제월=익월
+ *   cutoff = 말일   (D = 13): baseDay ≤ 말일(항상 true) → 결제월=익월 (전월이 종료월)
+ *   cutoff = D-13   (D ≥ 14): baseDay ≤ D-13 → 결제월=당월, 초과 → 결제월=익월
+ *
+ * ── 말일 클램프 ──────────────────────────────────────────────────────────
+ *   계산된 일(day)이 해당 월 말일을 초과하면 말일로 클램프.
+ *   e.g. D=12, 이용 종료: 전월 29일 → 전월이 2월이면 2월 28일(또는 29일)
+ *
+ * ── 지원 결제일 ──────────────────────────────────────────────────────────
+ *   하나카드 개인회원: 1, 5, 7, 8, 10, 12, 13, 14, 15, 17, 18, 20, 21, 23, 25, 27
+ *   범위 외 값 입력 시 경고를 출력하되 계산은 수행한다.
+ *
+ * @example
+ *   const p = getBillingPeriod(new Date('2026-04-14'), 25);
+ *   // p.fromDate          → '20260313'  (전월 13일)
+ *   // p.toDate            → '20260412'  (당월 12일)
+ *   // p.dueDateStr        → '20260425'  (당월 25일)
+ *   // p.formatted.usageStart → '2026.03.13'
+ *
+ * @example
+ *   getBillingPeriod(new Date('2026-04-14'), 1)
+ *   // fromDate: '20260319', toDate: '20260418', dueDateStr: '20260501'
+ */
+
+"use strict";
+
+// ── 내부 헬퍼 ────────────────────────────────────────────────────────────
+
+/** 특정 연/월(1-based)의 마지막 날짜를 반환 */
+function lastDayOfMonth(year, month) {
+  return new Date(year, month, 0).getDate();
+}
+
+/**
+ * (year, month)에 offset 개월을 더한 { year, month } 반환.
+ * month는 1-based(1~12). 음수 offset도 올바르게 처리.
+ */
+function addMonths(year, month, offset) {
+  const total = month - 1 + offset;
+  const m0 = ((total % 12) + 12) % 12;
+  return { year: year + Math.floor(total / 12), month: m0 + 1 };
+}
+
+/**
+ * 지정 연/월/일로 Date 생성. day가 말일을 초과하면 말일로 클램프.
+ * 예) createDate(2026, 2, 30) → 2026-02-28
+ */
+function createDate(year, month, day) {
+  return new Date(year, month - 1, Math.min(day, lastDayOfMonth(year, month)));
+}
+
+/** Date → 'YYYYMMDD' 문자열 (DB WHERE 절 바인딩용) */
+function toYYYYMMDD(d) {
+  return [
+    d.getFullYear(),
+    String(d.getMonth() + 1).padStart(2, "0"),
+    String(d.getDate()).padStart(2, "0"),
+  ].join("");
+}
+
+/** Date → 'YYYY.MM.DD' 문자열 (화면 표시용) */
+function toDisplayDate(d) {
+  return [
+    d.getFullYear(),
+    String(d.getMonth() + 1).padStart(2, "0"),
+    String(d.getDate()).padStart(2, "0"),
+  ].join(".");
+}
+
+// ── 공개 상수 ────────────────────────────────────────────────────────────
+
+/** 하나카드 개인회원 결제일 선택 가능 목록 */
+const VALID_PAYMENT_DAYS = new Set([1, 5, 7, 8, 10, 12, 13, 14, 15, 17, 18, 20, 21, 23, 25, 27]);
+
+// ── 공개 함수 ────────────────────────────────────────────────────────────
+
+/**
+ * 기준 날짜(baseDate)와 카드 결제일(paymentDay)을 받아
+ * 해당 날짜가 속한 이용 기간(시작~종료)과 결제 예정일을 반환한다.
+ *
+ * @param {Date}          baseDate   - 기준 날짜 (오늘 또는 이용일)
+ * @param {number|string} paymentDay - 카드 결제일. 숫자 또는 숫자형 문자열.
+ * @returns {{
+ *   usageStart : Date,
+ *   usageEnd   : Date,
+ *   dueDate    : Date,
+ *   fromDate   : string,  // 'YYYYMMDD' — DB 이용일자 >= 조건
+ *   toDate     : string,  // 'YYYYMMDD' — DB 이용일자 <= 조건
+ *   dueDateStr : string,  // 'YYYYMMDD'
+ *   formatted  : { usageStart: string, usageEnd: string, dueDate: string }
+ * }}
+ *
+ * @throws {RangeError} paymentDay가 1~31 범위를 벗어날 때
+ */
+function getBillingPeriod(baseDate, paymentDay) {
+  const D = typeof paymentDay === "string" ? parseInt(paymentDay, 10) : paymentDay;
+  if (!Number.isInteger(D) || D < 1 || D > 31) {
+    throw new RangeError(
+      `paymentDay는 1~31 사이의 정수여야 합니다. (입력값: ${paymentDay})`
+    );
+  }
+  if (!VALID_PAYMENT_DAYS.has(D)) {
+    console.warn(
+      `[billingPeriod] 결제일 ${D}일은 하나카드 공식 결제일 목록에 없습니다. ` +
+      `유효 결제일: ${[...VALID_PAYMENT_DAYS].join(", ")}`
+    );
+  }
+
+  const baseYear  = baseDate.getFullYear();
+  const baseMonth = baseDate.getMonth() + 1; // 1-based
+  const baseDay   = baseDate.getDate();
+
+  let usageStart, usageEnd, dueDate;
+
+  if (D <= 12) {
+    // ── [D ≤ 12] ──────────────────────────────────────────────────
+    // 이용 종료일 = (결제월 M-1), D+17일
+    // 이용 시작일 = (결제월 M-2), D+18일
+    // 결제 예정일 = (결제월 M),   D일
+    //
+    // cutoff = D+17: baseDay ≤ D+17 → 결제월=당월, 초과 → 결제월=익월
+    const payPart = baseDay <= D + 17
+      ? { year: baseYear, month: baseMonth }
+      : addMonths(baseYear, baseMonth, 1);
+
+    const endPart   = addMonths(payPart.year, payPart.month, -1); // M-1
+    const startPart = addMonths(payPart.year, payPart.month, -2); // M-2
+
+    usageEnd   = createDate(endPart.year,   endPart.month,   D + 17);
+    usageStart = createDate(startPart.year, startPart.month, D + 18);
+    dueDate    = createDate(payPart.year,   payPart.month,   D);
+
+  } else if (D === 13) {
+    // ── [D = 13] ──────────────────────────────────────────────────
+    // 이용 기간 = 전월 1일 ~ 전월 말일
+    // 결제 예정일 = 당월 13일
+    //
+    // baseDate가 어느 날이든 이용 종료월 = 전월(즉, 결제월 = 익월)
+    const payPart = addMonths(baseYear, baseMonth, 1); // 결제월 = 익월
+    const endPart = { year: baseYear, month: baseMonth }; // 이용 종료월 = 전월
+
+    usageStart = new Date(endPart.year, endPart.month - 1, 1);
+    usageEnd   = createDate(endPart.year, endPart.month, lastDayOfMonth(endPart.year, endPart.month));
+    dueDate    = createDate(payPart.year, payPart.month, 13);
+
+  } else {
+    // ── [D ≥ 14] ──────────────────────────────────────────────────
+    // 이용 종료일 = (결제월 M),   D-13일
+    // 이용 시작일 = (결제월 M-1), D-12일
+    // 결제 예정일 = (결제월 M),   D일
+    //
+    // cutoff = D-13: baseDay ≤ D-13 → 결제월=당월, 초과 → 결제월=익월
+    const payPart = baseDay <= D - 13
+      ? { year: baseYear, month: baseMonth }
+      : addMonths(baseYear, baseMonth, 1);
+
+    const startPart = addMonths(payPart.year, payPart.month, -1); // M-1
+
+    usageEnd   = createDate(payPart.year,   payPart.month,   D - 13);
+    usageStart = createDate(startPart.year, startPart.month, D - 12);
+    dueDate    = createDate(payPart.year,   payPart.month,   D);
+  }
+
+  return {
+    usageStart,
+    usageEnd,
+    dueDate,
+    /** DB "이용일자" >= 조건 바인딩용 YYYYMMDD 문자열 */
+    fromDate:   toYYYYMMDD(usageStart),
+    /** DB "이용일자" <= 조건 바인딩용 YYYYMMDD 문자열 */
+    toDate:     toYYYYMMDD(usageEnd),
+    dueDateStr: toYYYYMMDD(dueDate),
+    formatted: {
+      usageStart: toDisplayDate(usageStart),
+      usageEnd:   toDisplayDate(usageEnd),
+      dueDate:    toDisplayDate(dueDate),
+    },
+  };
+}
+
+/**
+ * 청구월(targetMonth)과 결제일(paymentDay)로부터
+ * 해당 청구월에 해당하는 이용 기간(시작~종료)을 역산한다.
+ *
+ * getBillingPeriod()의 역방향 계산:
+ *   getBillingPeriod        : 이용일(baseDate) + 결제일 → 결제예정일 산출  (forward)
+ *   getBillingPeriodForMonth: 청구월(targetMonth) + 결제일 → 이용 기간 역산 (reverse)
+ *
+ * ── 역산 공식 (getBillingPeriod와 대칭) ──────────────────────────────────
+ *   [D ≤ 12]  이용 시작: (M-2)월 (D+18)일  /  이용 종료: (M-1)월 (D+17)일
+ *   [D = 13]  이용 시작: (M-1)월  1일       /  이용 종료: (M-1)월 말일
+ *   [D ≥ 14]  이용 시작: (M-1)월 (D-12)일  /  이용 종료:  M월   (D-13)일
+ *
+ * @param {string}         targetMonth - "YYYY-MM" 형식의 청구월
+ * @param {number|string}  paymentDay  - 카드 결제일 (1~31)
+ * @returns {{
+ *   usageStart : Date,
+ *   usageEnd   : Date,
+ *   fromDate   : string,  // 'YYYYMMDD' — DB "이용일자" >= 조건
+ *   toDate     : string,  // 'YYYYMMDD' — DB "이용일자" <= 조건
+ *   formatted  : { usageStart: string, usageEnd: string }
+ * }}
+ *
+ * @example
+ *   getBillingPeriodForMonth('2026-04', 25)
+ *   // fromDate: '20260313', toDate: '20260412'  (전월 13일 ~ 당월 12일)
+ *
+ *   getBillingPeriodForMonth('2026-04', 1)
+ *   // fromDate: '20260219', toDate: '20260318'  (전전월 19일 ~ 전월 18일)
+ *
+ *   getBillingPeriodForMonth('2026-04', 13)
+ *   // fromDate: '20260301', toDate: '20260331'  (전월 1일 ~ 전월 말일)
+ */
+function getBillingPeriodForMonth(targetMonth, paymentDay) {
+  const [y, m] = targetMonth.split("-").map(Number);
+  const D = typeof paymentDay === "string" ? parseInt(paymentDay, 10) : paymentDay;
+
+  if (!Number.isInteger(D) || D < 1 || D > 31) {
+    throw new RangeError(
+      `paymentDay는 1~31 사이의 정수여야 합니다. (입력값: ${paymentDay})`,
+    );
+  }
+  if (!VALID_PAYMENT_DAYS.has(D)) {
+    console.warn(
+      `[billingPeriod] 결제일 ${D}일은 하나카드 공식 결제일 목록에 없습니다.`,
+    );
+  }
+
+  let usageStart, usageEnd;
+
+  if (D <= 12) {
+    // 이용 시작: (M-2)월 (D+18)일
+    // 이용 종료: (M-1)월 (D+17)일
+    const startPart = addMonths(y, m, -2);
+    const endPart   = addMonths(y, m, -1);
+    usageStart = createDate(startPart.year, startPart.month, D + 18);
+    usageEnd   = createDate(endPart.year,   endPart.month,   D + 17);
+  } else if (D === 13) {
+    // 이용 시작: (M-1)월 1일
+    // 이용 종료: (M-1)월 말일
+    const prevPart = addMonths(y, m, -1);
+    usageStart = new Date(prevPart.year, prevPart.month - 1, 1);
+    usageEnd   = createDate(
+      prevPart.year,
+      prevPart.month,
+      lastDayOfMonth(prevPart.year, prevPart.month),
+    );
+  } else {
+    // D ≥ 14
+    // 이용 시작: (M-1)월 (D-12)일
+    // 이용 종료:  M월   (D-13)일
+    const prevPart = addMonths(y, m, -1);
+    usageStart = createDate(prevPart.year, prevPart.month, D - 12);
+    usageEnd   = createDate(y, m, D - 13);
+  }
+
+  return {
+    usageStart,
+    usageEnd,
+    /** DB "이용일자" >= 조건 바인딩용 YYYYMMDD */
+    fromDate:  toYYYYMMDD(usageStart),
+    /** DB "이용일자" <= 조건 바인딩용 YYYYMMDD */
+    toDate:    toYYYYMMDD(usageEnd),
+    formatted: {
+      usageStart: toDisplayDate(usageStart),
+      usageEnd:   toDisplayDate(usageEnd),
+    },
+  };
+}
+
+module.exports = { getBillingPeriod, getBillingPeriodForMonth, VALID_PAYMENT_DAYS };

--- a/demo/front/package-lock.json
+++ b/demo/front/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "react-demo-app",
+  "name": "POC_HNC_DEMO",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "react-demo-app",
+      "name": "POC_HNC_DEMO",
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.2",
         "@tanstack/react-query": "^5.96.2",
+        "axios": "^1.15.0",
         "clsx": "^2.1.1",
         "lucide-react": "^1.7.0",
         "react": "^19.2.4",
@@ -1551,6 +1552,23 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1614,6 +1632,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -1693,6 +1724,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1767,6 +1810,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1774,6 +1826,20 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -1794,6 +1860,51 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -2092,6 +2203,42 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2106,6 +2253,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2114,6 +2270,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -2142,6 +2335,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2156,6 +2361,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hermes-estree": {
@@ -2642,6 +2886,36 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2831,6 +3105,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/punycode": {

--- a/demo/front/package.json
+++ b/demo/front/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/react-query": "^5.96.2",
+    "axios": "^1.15.0",
     "clsx": "^2.1.1",
     "lucide-react": "^1.7.0",
     "react": "^19.2.4",

--- a/demo/front/src/App.tsx
+++ b/demo/front/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-route
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { pageRoutes, modalRoutes } from '@/routes'
 import { AuthProvider, useAuth } from '@/contexts/AuthContext'
+import { useSessionActivity } from '@/hooks/useSessionActivity'
 import { PATHS } from '@/constants/paths'
 
 const queryClient = new QueryClient({
@@ -27,6 +28,9 @@ function AppRoutes() {
   const location   = useLocation()
   const background = (location.state as { background?: Location })?.background
   const { isLoggedIn } = useAuth()
+
+  // 클릭 이벤트 쓰로틀링 + 비활성 타임아웃으로 세션 만료 감지
+  useSessionActivity()
 
   // 로그인 안 된 상태에서 로그인 페이지 외 접근 시 리다이렉트
   if (!isLoggedIn && location.pathname !== PATHS.LOGIN) {

--- a/demo/front/src/api/axiosInstance.ts
+++ b/demo/front/src/api/axiosInstance.ts
@@ -1,0 +1,176 @@
+/**
+ * @file axiosInstance.ts
+ * @description Axios 싱글톤 인스턴스 + JWT 자동 갱신 인터셉터
+ *
+ * 토큰 저장 전략:
+ *   - Access Token  : localStorage (짧은 TTL, Authorization 헤더 삽입)
+ *   - Refresh Token : httpOnly 쿠키 (JS 접근 불가 → XSS 방지, 백엔드 관리)
+ *
+ * 요청 흐름:
+ *   1. 요청 인터셉터 : localStorage의 Access Token → Authorization 헤더 자동 삽입
+ *   2. 응답 인터셉터 : 401 수신 시 /api/auth/refresh 호출 (쿠키 자동 전송)
+ *      - 성공 : 새 Access Token으로 원래 요청 재시도
+ *      - 실패 : onAuthFailure 콜백 실행 → 로그인 페이지 리다이렉트
+ *   3. 동시 요청 처리 : isRefreshing 플래그 + 대기열로 중복 refresh 방지
+ *
+ * @example
+ *   const { data } = await axiosInstance.get('/cards');
+ */
+import axios, {
+  type AxiosResponse,
+  type InternalAxiosRequestConfig,
+} from 'axios';
+
+export const API_BASE    = 'http://localhost:3001/api';
+const        STORAGE_KEY = 'hnc_auth';
+
+// ── 모듈 레벨 인증 콜백 ─────────────────────────────────────────────────────
+// React 컴포넌트 트리 외부에서 AuthContext 메서드를 호출하기 위한 참조.
+// AuthProvider 마운트 시 registerAuthCallbacks()로 등록된다.
+type TokenRefreshedCb = (newToken: string) => void;
+type AuthFailureCb   = () => void;
+
+let _onTokenRefreshed: TokenRefreshedCb | null = null;
+let _onAuthFailure:    AuthFailureCb   | null = null;
+
+/**
+ * AuthProvider가 마운트될 때 호출하여 콜백을 등록한다.
+ *
+ * @param onRefreshed - 토큰 갱신 성공 시 React 상태 동기화용 콜백
+ * @param onFailure   - Refresh 실패(세션 완전 만료) 시 로그아웃 처리 콜백
+ */
+export function registerAuthCallbacks(
+  onRefreshed: TokenRefreshedCb,
+  onFailure:   AuthFailureCb,
+): void {
+  _onTokenRefreshed = onRefreshed;
+  _onAuthFailure    = onFailure;
+}
+
+// ── Refresh 대기열 ──────────────────────────────────────────────────────────
+// 여러 요청이 동시에 401을 받았을 때 Refresh가 한 번만 실행되도록 큐 관리.
+// Refresh 완료 후 새 토큰을 각 대기 요청에 배포하거나, 실패 시 reject 처리.
+let isRefreshing = false;
+
+interface QueueEntry {
+  resolve: (token: string) => void;
+  reject:  (err: unknown)  => void;
+}
+let refreshQueue: QueueEntry[] = [];
+
+function enqueueWaiter(
+  resolve: QueueEntry['resolve'],
+  reject:  QueueEntry['reject'],
+): void {
+  refreshQueue.push({ resolve, reject });
+}
+
+function flushQueue(newToken: string): void {
+  refreshQueue.forEach(({ resolve }) => resolve(newToken));
+  refreshQueue = [];
+}
+
+function rejectQueue(err: unknown): void {
+  refreshQueue.forEach(({ reject }) => reject(err));
+  refreshQueue = [];
+}
+
+// ── Axios 인스턴스 ──────────────────────────────────────────────────────────
+export const axiosInstance = axios.create({
+  baseURL:         API_BASE,
+  timeout:         10_000,
+  withCredentials: true, // httpOnly 쿠키(Refresh Token) 자동 전송
+  headers:         { 'Content-Type': 'application/json' },
+});
+
+/** localStorage에서 저장된 Access Token을 읽는다. */
+function readAccessToken(): string | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as { token?: string }).token ?? null : null;
+  } catch {
+    return null;
+  }
+}
+
+// ── 요청 인터셉터 ───────────────────────────────────────────────────────────
+/**
+ * 요청 전 localStorage에서 Access Token을 읽어 Authorization 헤더에 자동 삽입.
+ * 토큰이 없으면 헤더 없이 요청 진행 (공개 API 허용).
+ */
+axiosInstance.interceptors.request.use((config: InternalAxiosRequestConfig) => {
+  const token = readAccessToken();
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+// ── 응답 인터셉터 ───────────────────────────────────────────────────────────
+/**
+ * 401 응답 수신 시 처리 흐름:
+ *   1. 이미 재시도한 요청(_retry) → 그냥 reject (무한 루프 방지)
+ *   2. Refresh 진행 중 → 대기열 등록, 완료 후 새 토큰으로 재시도
+ *   3. Refresh 시도 (/api/auth/refresh, httpOnly 쿠키 자동 전송)
+ *      - 성공 → localStorage 갱신 + React 상태 콜백 + 원래 요청 재시도
+ *      - 실패 → 대기열 전체 reject + onAuthFailure 콜백 실행
+ */
+axiosInstance.interceptors.response.use(
+  (response: AxiosResponse) => response,
+  async (error) => {
+    // _retry 플래그: Refresh 실패 후 401이 다시 이 인터셉터를 트리거하는 무한 루프 방지
+    const original = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
+
+    if (error.response?.status !== 401 || original._retry) {
+      return Promise.reject(error);
+    }
+
+    // 다른 요청이 이미 Refresh 진행 중이면 완료를 기다렸다가 새 토큰으로 재시도
+    if (isRefreshing) {
+      return new Promise<AxiosResponse>((resolve, reject) => {
+        enqueueWaiter(
+          (newToken) => {
+            original._retry = true;
+            original.headers.Authorization = `Bearer ${newToken}`;
+            resolve(axiosInstance(original));
+          },
+          reject,
+        );
+      });
+    }
+
+    original._retry = true;
+    isRefreshing    = true;
+
+    try {
+      // axiosInstance 대신 axios 직접 사용 → 이 인터셉터 재진입 방지
+      // withCredentials: true 로 httpOnly 쿠키(Refresh Token) 자동 전송
+      const { data } = await axios.post<{ accessToken: string }>(
+        `${API_BASE}/auth/refresh`,
+        {},
+        { withCredentials: true },
+      );
+
+      const newToken = data.accessToken;
+
+      // localStorage의 Access Token만 갱신 (Refresh Token은 쿠키로 백엔드 관리)
+      const raw  = localStorage.getItem(STORAGE_KEY);
+      const auth = raw ? JSON.parse(raw) : {};
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...auth, token: newToken }));
+
+      _onTokenRefreshed?.(newToken);
+
+      isRefreshing = false;
+      flushQueue(newToken);
+
+      // 원래 실패한 요청 재시도
+      original.headers.Authorization = `Bearer ${newToken}`;
+      return axiosInstance(original);
+    } catch (refreshError) {
+      isRefreshing = false;
+      rejectQueue(refreshError);
+      _onAuthFailure?.();
+      return Promise.reject(refreshError);
+    }
+  },
+);

--- a/demo/front/src/contexts/AuthContext.tsx
+++ b/demo/front/src/contexts/AuthContext.tsx
@@ -4,9 +4,20 @@
  *
  * - 로그인 정보(userId, userName, userGrade, token)를 localStorage에 저장해
  *   새로고침 후에도 세션이 유지됩니다.
+ * - Refresh Token은 httpOnly 쿠키로 백엔드가 관리하므로 이 Context에서는 다루지 않습니다.
+ * - 마운트 시 registerAuthCallbacks()를 통해 Axios 인터셉터와 콜백을 연결합니다.
+ *   - onRefreshed : Access Token 갱신 성공 시 React 상태 동기화
+ *   - onFailure   : Refresh 실패 시 강제 로그아웃 (세션 완전 만료)
  * - useAuth() 훅으로 어느 컴포넌트에서든 로그인 상태를 읽고 login/logout을 호출합니다.
  */
-import { createContext, useContext, useState, type ReactNode } from 'react';
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  type ReactNode,
+} from 'react';
+import { registerAuthCallbacks } from '@/api/axiosInstance';
 
 const STORAGE_KEY = 'hnc_auth';
 
@@ -14,16 +25,15 @@ export interface AuthUser {
   userId:    string;
   userName:  string;
   userGrade: string;
-  token:     string;
+  token:     string; // Access Token (localStorage 저장, 짧은 TTL)
+  // Refresh Token은 httpOnly 쿠키로 백엔드 관리 — 이 인터페이스에 포함하지 않음
 }
 
 interface AuthContextValue {
-  user:          AuthUser | null;
-  isLoggedIn:    boolean;
-  login:         (user: AuthUser) => void;
-  logout:        () => void;
-  /** Authorization 헤더를 자동 첨부하고, 401 시 alert + 로그아웃 처리 */
-  fetchWithAuth: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
+  user:       AuthUser | null;
+  isLoggedIn: boolean;
+  login:      (user: AuthUser) => void;
+  logout:     () => void;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -40,9 +50,9 @@ function readStorage(): AuthUser | null {
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(readStorage);
 
-  const login = (user: AuthUser) => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(user));
-    setUser(user);
+  const login = (newUser: AuthUser) => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(newUser));
+    setUser(newUser);
   };
 
   const logout = () => {
@@ -50,21 +60,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(null);
   };
 
-  const fetchWithAuth = async (input: RequestInfo, init: RequestInit = {}): Promise<Response> => {
-    const token = (JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null') as AuthUser | null)?.token;
-    const res = await fetch(input, {
-      ...init,
-      headers: { ...init.headers, ...(token ? { Authorization: `Bearer ${token}` } : {}) },
-    });
-    if (res.status === 401) {
-      alert('세션이 만료되었습니다. 다시 로그인해 주세요.');
-      logout();
-    }
-    return res;
-  };
+  /**
+   * Axios 인터셉터와 인증 콜백 연결.
+   *
+   * 마운트 시 한 번만 등록한다. setState를 직접 참조하므로
+   * user/logout 의존성 없이도 항상 최신 상태를 갱신한다.
+   */
+  useEffect(() => {
+    registerAuthCallbacks(
+      // Access Token 갱신 성공: token 필드만 교체 (나머지 사용자 정보 유지)
+      (newToken: string) => {
+        setUser(prev => (prev ? { ...prev, token: newToken } : prev));
+      },
+      // Refresh 실패: 완전 세션 만료 → alert 노출 후 localStorage + 상태 초기화
+      () => {
+        alert('세션이 만료되었습니다. 다시 로그인해 주세요.');
+        localStorage.removeItem(STORAGE_KEY);
+        setUser(null);
+      },
+    );
+  }, []); // 마운트 시 한 번만 등록
 
   return (
-    <AuthContext.Provider value={{ user, isLoggedIn: !!user, login, logout, fetchWithAuth }}>
+    <AuthContext.Provider value={{ user, isLoggedIn: !!user, login, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/demo/front/src/hooks/useSessionActivity.ts
+++ b/demo/front/src/hooks/useSessionActivity.ts
@@ -1,0 +1,111 @@
+/**
+ * @file useSessionActivity.ts
+ * @description 클릭 이벤트 기반 세션 활동 감지 훅
+ *
+ * 두 가지 세션 만료 감지를 조합한다:
+ *   1. 비활성 타임아웃 : 마지막 클릭으로부터 SESSION_TIMEOUT 이상 경과 시 자동 로그아웃
+ *                       (1분 인터벌로 체크 — 마지막 클릭 후 사용자가 아무것도 안 하는 경우)
+ *   2. 토큰 만료 체크  : 클릭마다 쓰로틀링(THROTTLE_MS)을 적용해 JWT exp 필드를 디코딩,
+ *                       Access Token 만료 시 즉시 로그아웃
+ *                       (Axios 인터셉터가 API 호출 시점에 처리하지만,
+ *                        호출 없이 탭에만 머무는 경우를 대비한 클라이언트 사이드 보완)
+ *
+ * 쓰로틀링을 적용하는 이유:
+ *   빠른 연속 클릭 시마다 토큰 파싱·시간 비교 연산이 실행되지 않도록 부하 제어.
+ *
+ * @example
+ *   // BrowserRouter + AuthProvider 내부 컴포넌트에서 호출
+ *   function AppRoutes() {
+ *     useSessionActivity();
+ *     ...
+ *   }
+ */
+import { useEffect, useRef, useCallback } from 'react';
+import { useNavigate }                    from 'react-router-dom';
+import { useAuth }                        from '@/contexts/AuthContext';
+import { PATHS }                          from '@/constants/paths';
+
+/** 무활동 세션 타임아웃 (30분) — 마지막 클릭 이후 이 시간이 지나면 자동 로그아웃 */
+const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
+
+/** 토큰 만료 체크 쓰로틀 간격 (1분) — 빈번한 클릭 시 연산 부하 방지 */
+const THROTTLE_MS = 60 * 1000;
+
+export function useSessionActivity(): void {
+  const { isLoggedIn, logout, user } = useAuth();
+  const navigate = useNavigate();
+
+  /** 마지막 사용자 클릭 시각 (ms) — 비활성 감지 기준점 */
+  const lastActivityRef = useRef<number>(Date.now());
+  /** 마지막 토큰 만료 체크 시각 — 쓰로틀 기준점 */
+  const lastCheckRef    = useRef<number>(0);
+
+  /**
+   * 쓰로틀된 JWT 만료 체크.
+   *
+   * Access Token의 exp 클레임을 클라이언트 사이드에서 검증한다.
+   * Axios 인터셉터는 API 호출 시 401을 받아 Refresh를 시도하지만,
+   * 오래 열어둔 탭에서 API 호출 없이 클릭하는 경우를 조기에 감지하기 위해 사용한다.
+   */
+  const checkTokenExpiry = useCallback(() => {
+    if (!isLoggedIn || !user) return;
+
+    const now = Date.now();
+
+    // 쓰로틀: 마지막 체크로부터 THROTTLE_MS 미경과 시 스킵
+    if (now - lastCheckRef.current < THROTTLE_MS) return;
+    lastCheckRef.current = now;
+
+    try {
+      const parts = user.token.split('.');
+      // JWT 구조 검증 (header.payload.signature 3부분)
+      if (parts.length !== 3) return;
+
+      const payload = JSON.parse(atob(parts[1])) as { exp?: number };
+
+      if (payload.exp && now > payload.exp * 1000) {
+        // Access Token 만료 — Axios Refresh가 처리하지 못한 경우 강제 로그아웃
+        logout();
+        alert('세션이 만료되었습니다. 다시 로그인해 주세요.');
+        navigate(PATHS.LOGIN, { replace: true });
+      }
+    } catch {
+      // 토큰 파싱 오류는 무시 (Axios 인터셉터가 API 호출 시 별도 처리)
+    }
+  }, [isLoggedIn, user, logout, navigate]);
+
+  /**
+   * document 클릭 이벤트 핸들러.
+   * - 모든 클릭 : lastActivityRef 갱신 (비활성 타임아웃 리셋)
+   * - 쓰로틀 통과 시 : JWT 만료 체크 실행
+   */
+  const handleClick = useCallback(() => {
+    lastActivityRef.current = Date.now();
+    checkTokenExpiry();
+  }, [checkTokenExpiry]);
+
+  // ── 비활성 감지 인터벌 ─────────────────────────────────────────────────────
+  // 1분마다 마지막 클릭 시각을 확인해 SESSION_TIMEOUT 초과 시 로그아웃.
+  // 클릭 이벤트와 독립적으로 동작하므로 탭에 머물기만 한 경우도 감지한다.
+  useEffect(() => {
+    if (!isLoggedIn) return;
+
+    const intervalId = setInterval(() => {
+      if (Date.now() - lastActivityRef.current > SESSION_TIMEOUT_MS) {
+        logout();
+        alert('세션이 만료되었습니다. 다시 로그인해 주세요.');
+        navigate(PATHS.LOGIN, { replace: true });
+      }
+    }, 60_000); // 1분마다 체크
+
+    return () => clearInterval(intervalId);
+  }, [isLoggedIn, logout, navigate]);
+
+  // ── 클릭 이벤트 리스너 ────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!isLoggedIn) return;
+
+    document.addEventListener('click', handleClick);
+    return () => document.removeEventListener('click', handleClick);
+  }, [isLoggedIn, handleClick]);
+}

--- a/demo/front/src/pages/card/CardDashboardPage/index.tsx
+++ b/demo/front/src/pages/card/CardDashboardPage/index.tsx
@@ -109,6 +109,7 @@ export function CardDashboardPage({
   userName,
   statementAmount,
   statementDueDate,
+  spendingAmount,
   onNotification,
   onMenu,
   onStatementDetail,
@@ -301,7 +302,7 @@ export function CardDashboardPage({
           <SummaryCard
             variant="spending"
             title="이번 달 소비"
-            amount={842_300}
+            amount={spendingAmount ?? 0}
             hidden={amountHidden}
             icon={<Wallet size={32} />}
             actions={[

--- a/demo/front/src/pages/card/CardDashboardPage/index.tsx
+++ b/demo/front/src/pages/card/CardDashboardPage/index.tsx
@@ -107,6 +107,8 @@ const BOTTOM_NAV_ITEMS = (onBottomNavChange: (id: string) => void) => [
 
 export function CardDashboardPage({
   userName,
+  statementAmount,
+  statementDueDate,
   onNotification,
   onMenu,
   onStatementDetail,
@@ -245,8 +247,8 @@ export function CardDashboardPage({
         {/* ── 이번 달 명세서 히어로 카드 ────────────────── */}
         <div className="px-standard pt-standard">
           <StatementHeroCard
-            amount={1_250_000}
-            dueDate="1월 25일"
+            amount={statementAmount ?? 0}
+            dueDate={statementDueDate ?? '—'}
             onDetail={onStatementDetail}
             hidden={amountHidden}
           />

--- a/demo/front/src/pages/card/CardDashboardPage/types.ts
+++ b/demo/front/src/pages/card/CardDashboardPage/types.ts
@@ -9,6 +9,17 @@ export interface CardDashboardPageProps {
   /** 로그인 사용자명 — StatementHeroCard 위 인사말에 표시 */
   userName?: string;
 
+  /**
+   * StatementHeroCard에 표시할 이번 달 결제 예정 금액.
+   * /api/payment-statement 에서 공여기간 기준으로 집계된 totalAmount.
+   */
+  statementAmount?: number;
+  /**
+   * StatementHeroCard에 표시할 결제일 레이블 (예: "1월 25일").
+   * /api/payment-statement billingPeriod.dueDate 에서 변환.
+   */
+  statementDueDate?: string;
+
   /** 알림 아이콘 클릭 */
   onNotification?: () => void;
   /** 메뉴 아이콘 클릭 */

--- a/demo/front/src/pages/card/CardDashboardPage/types.ts
+++ b/demo/front/src/pages/card/CardDashboardPage/types.ts
@@ -15,6 +15,11 @@ export interface CardDashboardPageProps {
    */
   statementAmount?: number;
   /**
+   * SummaryCard(spending)에 표시할 당월 이용내역 합산 금액.
+   * /api/transactions?fromDate=YYYYMM01&toDate=YYYYMMlastDay 의 paymentSummary.totalAmount.
+   */
+  spendingAmount?: number;
+  /**
    * StatementHeroCard에 표시할 결제일 레이블 (예: "1월 25일").
    * /api/payment-statement billingPeriod.dueDate 에서 변환.
    */

--- a/demo/front/src/pages/card/PaymentStatementPage/index.tsx
+++ b/demo/front/src/pages/card/PaymentStatementPage/index.tsx
@@ -5,7 +5,6 @@
  * 화면 구성:
  *   - 상단바: 뒤로가기 / 활성 탭명 타이틀 / 닫기(X) 버튼
  *   - TabNav(underline, fullWidth): 결제예정금액 | 이용대금명세서
- *   - Select: 카드 목록 선택
  *   - [결제예정금액 탭]
  *       CardPaymentSummary → CardInfoPanel → 카드별 금액(CardPaymentItem)
  *   - [이용대금명세서 탭]
@@ -16,11 +15,8 @@
  *   실제 앱 구현 시 모든 상태·핸들러는 usePaymentStatement Hook으로 분리한다.
  *
  * @param initialTab          - 초기 활성 탭 ('payment' | 'statement', 기본: 'payment')
- * @param cardOptions         - 카드 선택 드롭다운 옵션 목록
- * @param initialCardValue    - 초기 선택 카드 value
  * @param paymentData         - 결제예정금액 탭 데이터
  * @param statementData       - 이용대금명세서 탭 데이터
- * @param onCardChange        - 카드 변경 핸들러
  * @param onDateClick         - 날짜 클릭 핸들러
  * @param onRevolving         - 리볼빙 버튼 클릭
  * @param onCardLoan          - 카드론 버튼 클릭
@@ -31,30 +27,29 @@
  * @param onBack              - 뒤로가기 핸들러
  * @param onClose             - 닫기(X) 핸들러
  */
-import React, { useState, useMemo } from 'react';
-import { X } from 'lucide-react';
+import { useState, useMemo } from "react";
+import { X, ChevronDown } from "lucide-react";
 
-import { PageLayout } from '@cl/layout/PageLayout';
-import { Button } from '@cl/core/Button';
-import { Select } from '@cl/core/Select';
-import { TabNav } from '@cl/modules/common/TabNav';
-import { Divider } from '@cl/modules/common/Divider';
-import { BottomSheet } from '@cl/modules/common/BottomSheet';
-import { SelectableListItem } from '@cl/modules/common/SelectableListItem';
-import { CollapsibleSection } from '@cl/modules/common/CollapsibleSection';
-import { Typography } from '@cl/core/Typography';
-import { CardPaymentSummary } from '@cl/biz/card/CardPaymentSummary';
-import { CardInfoPanel } from '@cl/biz/card/CardInfoPanel';
-import { CardPaymentItem } from '@cl/biz/card/CardPaymentItem';
-import { StatementTotalCard } from '@cl/biz/card/StatementTotalCard';
+import { PageLayout } from "@cl/layout/PageLayout";
+import { Button } from "@cl/core/Button";
+import { TabNav } from "@cl/modules/common/TabNav";
+import { Divider } from "@cl/modules/common/Divider";
+import { BottomSheet } from "@cl/modules/common/BottomSheet";
+import { SelectableListItem } from "@cl/modules/common/SelectableListItem";
+import { CollapsibleSection } from "@cl/modules/common/CollapsibleSection";
+import { Typography } from "@cl/core/Typography";
+import { CardPaymentSummary } from "@cl/biz/card/CardPaymentSummary";
+import { CardInfoPanel } from "@cl/biz/card/CardInfoPanel";
+import { CardPaymentItem } from "@cl/biz/card/CardPaymentItem";
+import { StatementTotalCard } from "@cl/biz/card/StatementTotalCard";
 
-import type { PaymentStatementPageProps, StatementTab } from './types';
-import { cn } from '@lib/cn';
+import type { PaymentStatementPageProps, StatementTab } from "./types";
+import { cn } from "@lib/cn";
 
 /** 탭 메타 — id/label 한 곳에서 관리해 타이틀·TabNav 둘 다 참조 */
 const TAB_ITEMS: { id: StatementTab; label: string }[] = [
-  { id: 'payment', label: '결제예정금액' },
-  { id: 'statement', label: '이용대금명세서' },
+  { id: "payment", label: "결제예정금액" },
+  { id: "statement", label: "이용대금명세서" },
 ];
 
 /** 월 옵션 단일 항목 */
@@ -78,7 +73,7 @@ function generateMonthOptions(): MonthOption[] {
     const year = d.getFullYear();
     const month = d.getMonth() + 1;
     options.push({
-      value: `${year}-${String(month).padStart(2, '0')}`,
+      value: `${year}-${String(month).padStart(2, "0")}`,
       /* 두 자리 연도 + 월. 예: '26년 4월' */
       dateYM: `${String(year).slice(2)}년 ${month}월`,
     });
@@ -89,23 +84,21 @@ function generateMonthOptions(): MonthOption[] {
 /** 오늘 기준 현재 월 value. 예: '2026-04' */
 function todayMonthValue(): string {
   const today = new Date();
-  return `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}`;
+  return `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}`;
 }
 
 /** 헤더 아이콘 버튼 공통 스타일 */
 const iconBtnCls = cn(
-  'flex items-center justify-center size-9 rounded-full',
-  'text-text-muted hover:bg-surface-raised hover:text-text-heading',
-  'transition-colors duration-150',
+  "flex items-center justify-center size-9 rounded-full",
+  "text-text-muted hover:bg-surface-raised hover:text-text-heading",
+  "transition-colors duration-150",
 );
 
 export function PaymentStatementPage({
-  initialTab = 'payment',
-  cardOptions,
-  initialCardValue,
+  initialTab = "payment",
+  initialMonth,
   paymentData,
   statementData,
-  onCardChange,
   onDateClick,
   onRevolving,
   onCardLoan,
@@ -117,33 +110,28 @@ export function PaymentStatementPage({
   onClose,
 }: PaymentStatementPageProps) {
   const [activeTab, setActiveTab] = useState<StatementTab>(initialTab);
-  const [selectedCard, setSelectedCard] = useState(
-    /* 초기 카드 value — 미전달 시 첫 번째 옵션으로 fallback */
-    initialCardValue ?? cardOptions[0]?.value ?? '',
-  );
   const [dateSheetOpen, setDateSheetOpen] = useState(false);
-  const [selectedMonth, setSelectedMonth] = useState(todayMonthValue);
+  /** 초기값: 전달받은 initialMonth 우선, 없으면 오늘 기준 월 */
+  const [selectedMonth, setSelectedMonth] = useState(
+    initialMonth ?? todayMonthValue(),
+  );
 
   /** 월 옵션 목록 — 렌더마다 재계산하지 않도록 메모이제이션 */
-  const monthOptions = useMemo(generateMonthOptions, []);
+  const monthOptions = useMemo(() => generateMonthOptions(), []);
 
   /** 현재 선택된 월의 dateYM 레이블. CardPaymentSummary에 전달 */
   const selectedDateYM =
-    monthOptions.find((o) => o.value === selectedMonth)?.dateYM ?? paymentData.dateYM;
+    monthOptions.find((o) => o.value === selectedMonth)?.dateYM ??
+    paymentData.dateYM;
 
   /** 활성 탭 레이블을 헤더 타이틀로 사용 */
-  const activeLabel = TAB_ITEMS.find((t) => t.id === activeTab)?.label ?? '';
-
-  function handleCardChange(value: string) {
-    setSelectedCard(value);
-    onCardChange?.(value);
-  }
+  const activeLabel = TAB_ITEMS.find((t) => t.id === activeTab)?.label ?? "";
 
   function handleMonthSelect(option: MonthOption) {
     setSelectedMonth(option.value);
     setDateSheetOpen(false);
-    /* 외부 핸들러에도 선택 결과 전파 */
-    onDateClick?.();
+    /* 선택된 월 값('YYYY-MM')을 외부 핸들러에 전파 */
+    onDateClick?.(option.value);
   }
 
   return (
@@ -163,8 +151,8 @@ export function PaymentStatementPage({
           />
         }
       >
-        {/* ── 탭 + 카드 선택 — 스크롤 영역 최상단 고정 ────────────────── */}
-        <div className="flex flex-col gap-md px-standard pt-md pb-sm">
+        {/* ── 탭 + 조회 월 선택 버튼 — 스크롤 영역 최상단 ────────── */}
+        <div className="flex flex-col px-standard pt-md pb-sm gap-sm">
           {/* underline 탭: 두 탭이 균등하게 너비를 나눔 */}
           <TabNav
             items={TAB_ITEMS}
@@ -173,18 +161,20 @@ export function PaymentStatementPage({
             variant="pill"
             fullWidth
           />
-
-          {/* 카드 선택 드롭다운 */}
-          <Select
-            options={cardOptions}
-            value={selectedCard}
-            onChange={handleCardChange}
-            aria-label="카드 선택"
-          />
+          {/* 조회 월 선택 버튼 — 가운데 정렬, 두 탭 공통 기간 필터 역할 */}
+          <Button
+            variant="ghost"
+            size="md"
+            rightIcon={<ChevronDown className="size-4" />}
+            onClick={() => setDateSheetOpen(true)}
+            className="mx-auto text-lg text-text-muted"
+          >
+            {selectedDateYM}
+          </Button>
         </div>
 
         {/* ── 결제예정금액 탭 콘텐츠 ─────────────────────────────────── */}
-        {activeTab === 'payment' && (
+        {activeTab === "payment" && (
           <div className="flex flex-col gap-lg px-standard pb-xl">
             {/* 총 청구금액 요약 카드 — 날짜 클릭 시 월 선택 BottomSheet 오픈 */}
             <CardPaymentSummary
@@ -195,6 +185,7 @@ export function PaymentStatementPage({
               revolving={paymentData.revolving}
               cardLoan={paymentData.cardLoan}
               cashAdvance={paymentData.cashAdvance}
+              hideDateButton
               onDateClick={() => setDateSheetOpen(true)}
               onRevolving={onRevolving}
               onCardLoan={onCardLoan}
@@ -208,7 +199,12 @@ export function PaymentStatementPage({
 
             {/* 카드별 금액 목록 */}
             <div className="flex flex-col">
-              <Typography variant="body-sm" weight="bold" color="heading" className="mb-xs">
+              <Typography
+                variant="body-sm"
+                weight="bold"
+                color="heading"
+                className="mb-xs"
+              >
                 카드별 금액
               </Typography>
               <div className="flex flex-col divide-y divide-border-subtle">
@@ -230,7 +226,7 @@ export function PaymentStatementPage({
         )}
 
         {/* ── 이용대금명세서 탭 콘텐츠 ──────────────────────────────── */}
-        {activeTab === 'statement' && (
+        {activeTab === "statement" && (
           <div className="flex flex-col gap-lg px-standard pb-xl">
             {/* 총 결제금액 카드 — 분할납부·즉시결제·리볼빙 액션 포함 */}
             <StatementTotalCard
@@ -246,7 +242,12 @@ export function PaymentStatementPage({
 
             {/* 카드별 금액 목록 */}
             <div className="flex flex-col">
-              <Typography variant="body-sm" weight="bold" color="heading" className="mb-xs">
+              <Typography
+                variant="body-sm"
+                weight="bold"
+                color="heading"
+                className="mb-xs"
+              >
                 카드별 금액
               </Typography>
               <div className="flex flex-col divide-y divide-border-subtle">
@@ -274,37 +275,46 @@ export function PaymentStatementPage({
              * 각 항목은 기본 접힘(defaultExpanded=false)으로 시작.
              * 실제 안내 본문은 운영 정책에 따라 교체한다. */}
             <div className="flex flex-col gap-xs">
-              <Typography variant="body-sm" weight="bold" color="heading" className="mb-xs">
+              <Typography
+                variant="body-sm"
+                weight="bold"
+                color="heading"
+                className="mb-xs"
+              >
                 꼭! 알아두세요
               </Typography>
 
               {[
                 {
-                  title: '이용안내',
+                  title: "이용안내",
                   content:
-                    '이용대금명세서는 매월 결제일 기준으로 발행됩니다. 결제 금액은 카드사 정책에 따라 변동될 수 있으며, 정확한 내용은 고객센터로 문의하시기 바랍니다.',
+                    "이용대금명세서는 매월 결제일 기준으로 발행됩니다. 결제 금액은 카드사 정책에 따라 변동될 수 있으며, 정확한 내용은 고객센터로 문의하시기 바랍니다.",
                   defaultExpanded: true,
                 },
                 {
-                  title: '해외 이용안내',
+                  title: "해외 이용안내",
                   content:
-                    '해외에서 사용한 금액은 국제 브랜드사(Visa, Mastercard 등)의 환율 및 해외서비스 수수료가 적용됩니다. 결제일 기준 환율이 적용되어 실제 청구 금액이 달라질 수 있습니다.',
+                    "해외에서 사용한 금액은 국제 브랜드사(Visa, Mastercard 등)의 환율 및 해외서비스 수수료가 적용됩니다. 결제일 기준 환율이 적용되어 실제 청구 금액이 달라질 수 있습니다.",
                 },
                 {
-                  title: '일부결제금액이월약정(리볼빙) 안내',
+                  title: "일부결제금액이월약정(리볼빙) 안내",
                   content:
-                    '리볼빙 이용 시 일정 금액만 결제하고 나머지는 다음 달로 이월됩니다. 이월된 금액에는 수수료가 부과되며, 장기 이용 시 이자 부담이 증가할 수 있습니다.',
+                    "리볼빙 이용 시 일정 금액만 결제하고 나머지는 다음 달로 이월됩니다. 이월된 금액에는 수수료가 부과되며, 장기 이용 시 이자 부담이 증가할 수 있습니다.",
                 },
                 {
-                  title: '마이너스대출 안내',
+                  title: "마이너스대출 안내",
                   content:
-                    '마이너스대출(한도대출)은 승인된 한도 내에서 자유롭게 이용 가능합니다. 이용 금액에 대해 일별 이자가 발생하며, 약정된 이율이 적용됩니다.',
+                    "마이너스대출(한도대출)은 승인된 한도 내에서 자유롭게 이용 가능합니다. 이용 금액에 대해 일별 이자가 발생하며, 약정된 이율이 적용됩니다.",
                 },
               ].map(({ title, content }) => (
                 <CollapsibleSection
                   key={title}
                   header={
-                    <Typography variant="body-sm" weight="medium" color="heading">
+                    <Typography
+                      variant="body-sm"
+                      weight="medium"
+                      color="heading"
+                    >
                       {title}
                     </Typography>
                   }

--- a/demo/front/src/pages/card/PaymentStatementPage/index.tsx
+++ b/demo/front/src/pages/card/PaymentStatementPage/index.tsx
@@ -38,6 +38,7 @@ import { BottomSheet } from "@cl/modules/common/BottomSheet";
 import { SelectableListItem } from "@cl/modules/common/SelectableListItem";
 import { CollapsibleSection } from "@cl/modules/common/CollapsibleSection";
 import { Typography } from "@cl/core/Typography";
+import { EmptyState } from "@cl/modules/common/EmptyState";
 import { CardPaymentSummary } from "@cl/biz/card/CardPaymentSummary";
 import { CardInfoPanel } from "@cl/biz/card/CardInfoPanel";
 import { CardPaymentItem } from "@cl/biz/card/CardPaymentItem";
@@ -197,31 +198,39 @@ export function PaymentStatementPage({
             {/* 결제정보 · 카드 이용기간 안내 */}
             <CardInfoPanel sections={paymentData.infoSections} />
 
-            {/* 카드별 금액 목록 */}
-            <div className="flex flex-col">
-              <Typography
-                variant="body-sm"
-                weight="bold"
-                color="heading"
-                className="mb-xs"
-              >
-                카드별 금액
-              </Typography>
-              <div className="flex flex-col divide-y divide-border-subtle">
-                {paymentData.paymentItems.map((item) => (
-                  <CardPaymentItem
-                    key={item.id}
-                    icon={item.icon}
-                    iconBgClassName={item.iconBgClassName}
-                    cardEnName={item.cardEnName}
-                    cardName={item.cardName}
-                    amount={item.amount}
-                    onDetailClick={item.onDetailClick}
-                    onClick={item.onClick}
-                  />
-                ))}
+            {/* 카드별 금액 목록 — items가 없으면 빈 상태 메시지 표시 */}
+            {paymentData.paymentItems.length > 0 ? (
+              <div className="flex flex-col">
+                <Typography
+                  variant="body-sm"
+                  weight="bold"
+                  color="heading"
+                  className="mb-xs"
+                >
+                  카드별 금액
+                </Typography>
+                <div className="flex flex-col divide-y divide-border-subtle">
+                  {paymentData.paymentItems.map((item) => (
+                    <CardPaymentItem
+                      key={item.id}
+                      icon={item.icon}
+                      iconBgClassName={item.iconBgClassName}
+                      cardEnName={item.cardEnName}
+                      cardName={item.cardName}
+                      amount={item.amount}
+                      onDetailClick={item.onDetailClick}
+                      onClick={item.onClick}
+                    />
+                  ))}
+                </div>
               </div>
-            </div>
+            ) : (
+              /* 선택 청구월에 결제 예정 내역이 없는 경우 */
+              <EmptyState
+                title="결제 예정 내역이 없습니다"
+                description="선택한 청구월에 청구된 금액이 없습니다."
+              />
+            )}
           </div>
         )}
 
@@ -240,31 +249,39 @@ export function PaymentStatementPage({
 
             <Divider />
 
-            {/* 카드별 금액 목록 */}
-            <div className="flex flex-col">
-              <Typography
-                variant="body-sm"
-                weight="bold"
-                color="heading"
-                className="mb-xs"
-              >
-                카드별 금액
-              </Typography>
-              <div className="flex flex-col divide-y divide-border-subtle">
-                {statementData.paymentItems.map((item) => (
-                  <CardPaymentItem
-                    key={item.id}
-                    icon={item.icon}
-                    iconBgClassName={item.iconBgClassName}
-                    cardEnName={item.cardEnName}
-                    cardName={item.cardName}
-                    amount={item.amount}
-                    onDetailClick={item.onDetailClick}
-                    onClick={item.onClick}
-                  />
-                ))}
+            {/* 카드별 금액 목록 — items가 없으면 빈 상태 메시지 표시 */}
+            {statementData.paymentItems.length > 0 ? (
+              <div className="flex flex-col">
+                <Typography
+                  variant="body-sm"
+                  weight="bold"
+                  color="heading"
+                  className="mb-xs"
+                >
+                  카드별 금액
+                </Typography>
+                <div className="flex flex-col divide-y divide-border-subtle">
+                  {statementData.paymentItems.map((item) => (
+                    <CardPaymentItem
+                      key={item.id}
+                      icon={item.icon}
+                      iconBgClassName={item.iconBgClassName}
+                      cardEnName={item.cardEnName}
+                      cardName={item.cardName}
+                      amount={item.amount}
+                      onDetailClick={item.onDetailClick}
+                      onClick={item.onClick}
+                    />
+                  ))}
+                </div>
               </div>
-            </div>
+            ) : (
+              /* 선택 청구월에 이용 내역이 없는 경우 */
+              <EmptyState
+                title="이용 내역이 없습니다"
+                description="선택한 청구월에 이용한 내역이 없습니다."
+              />
+            )}
 
             {/* 결제정보 안내 */}
             <CardInfoPanel sections={statementData.infoSections} />

--- a/demo/front/src/pages/card/PaymentStatementPage/types.ts
+++ b/demo/front/src/pages/card/PaymentStatementPage/types.ts
@@ -12,14 +12,6 @@ export type { CardInfoSection };
 /** 탭 식별자 */
 export type StatementTab = 'payment' | 'statement';
 
-/** 카드 선택 드롭다운 옵션 */
-export interface CardOption {
-  /** select value. 예: 'card-1' */
-  value: string;
-  /** select 표시 레이블. 예: '하나 머니 체크카드' */
-  label: string;
-}
-
 /** 카드별 결제 항목 — CardPaymentItem 1행에 대응 */
 export interface CardPaymentEntry {
   id: string;
@@ -76,18 +68,17 @@ export interface StatementTabData {
 export interface PaymentStatementPageProps {
   /** 초기 활성 탭 (기본: 'payment') */
   initialTab?: StatementTab;
-  /** 카드 선택 드롭다운 목록 */
-  cardOptions: CardOption[];
-  /** 초기 선택 카드 value */
-  initialCardValue?: string;
+  /**
+   * 월 선택 피커의 초기 선택 값 ('YYYY-MM').
+   * 미전달 시 오늘 날짜 기준 월로 초기화된다.
+   */
+  initialMonth?: string;
   /** 결제예정금액 탭 데이터 */
   paymentData: PaymentTabData;
   /** 이용대금명세서 탭 데이터 */
   statementData: StatementTabData;
-  /** 카드 변경 핸들러 */
-  onCardChange?: (value: string) => void;
-  /** 날짜(년월) 클릭 핸들러 */
-  onDateClick?: () => void;
+  /** 날짜(년월) 클릭 핸들러. 선택된 월을 'YYYY-MM' 형식으로 전달 */
+  onDateClick?: (yearMonth: string) => void;
   /** 리볼빙 버튼 클릭 */
   onRevolving?: () => void;
   /** 카드론 버튼 클릭 */

--- a/demo/front/src/pages/card/UsageHistoryPage/index.tsx
+++ b/demo/front/src/pages/card/UsageHistoryPage/index.tsx
@@ -23,19 +23,19 @@
  * @param onBack             - 뒤로가기
  * @param onClose            - 닫기(X)
  */
-import React, { useState } from 'react';
-import { X, Search } from 'lucide-react';
+import React, { useState } from "react";
+import { X, Search } from "lucide-react";
 
-import { PageLayout } from '@cl/layout/PageLayout';
-import { Button } from '@cl/core/Button';
-import { Typography } from '@cl/core/Typography';
-import { BillingPeriodLabel } from '@cl/biz/card/BillingPeriodLabel';
-import { CardPaymentActions } from '@cl/biz/card/CardPaymentActions';
+import { PageLayout } from "@cl/layout/PageLayout";
+import { Button } from "@cl/core/Button";
+import { Typography } from "@cl/core/Typography";
+import { BillingPeriodLabel } from "@cl/biz/card/BillingPeriodLabel";
+import { CardPaymentActions } from "@cl/biz/card/CardPaymentActions";
 
-import { UsageTransactionItem } from '@cl/biz/card/UsageTransactionItem';
-import { UsageHistoryFilterSheet } from '@cl/biz/card/UsageHistoryFilterSheet';
+import { UsageTransactionItem } from "@cl/biz/card/UsageTransactionItem";
+import { UsageHistoryFilterSheet } from "@cl/biz/card/UsageHistoryFilterSheet";
 
-import type { UsageHistoryPageProps, SearchFilter } from './types';
+import type { UsageHistoryPageProps, SearchFilter } from "./types";
 
 // ── 상수 ────────────────────────────────────────────────────
 
@@ -47,46 +47,57 @@ const PAGE_SIZE = 10;
  * 적용된 필터의 조회기간을 기반으로 BillingPeriodLabel의 시작/종료일을 계산한다.
  * @param filter - 적용된 검색 필터 (filter.customMonth 포함)
  */
-function computeBillingPeriod(filter: SearchFilter): { startDate: string; endDate: string } {
+function computeBillingPeriod(filter: SearchFilter): {
+  startDate: string;
+  endDate: string;
+} {
   const today = new Date();
   let start: Date;
   let end: Date;
 
-  if (filter.period === 'thisMonth') {
+  if (filter.period === "thisMonth") {
     start = new Date(today.getFullYear(), today.getMonth(), 1);
     end = new Date(today.getFullYear(), today.getMonth() + 1, 0);
-  } else if (filter.period === '1month') {
-    start = new Date(today.getFullYear(), today.getMonth() - 1, today.getDate());
+  } else if (filter.period === "1month") {
+    start = new Date(
+      today.getFullYear(),
+      today.getMonth() - 1,
+      today.getDate(),
+    );
     end = today;
-  } else if (filter.period === '3months') {
-    start = new Date(today.getFullYear(), today.getMonth() - 3, today.getDate());
+  } else if (filter.period === "3months") {
+    start = new Date(
+      today.getFullYear(),
+      today.getMonth() - 3,
+      today.getDate(),
+    );
     end = today;
   } else {
     /* custom: SearchFilter.customMonth 기준 월 1일 ~ 말일 */
-    const [year, month] = (filter.customMonth ?? '').split('-').map(Number);
+    const [year, month] = (filter.customMonth ?? "").split("-").map(Number);
     start = new Date(year, month - 1, 1);
     end = new Date(year, month, 0);
   }
 
   const fmt = (d: Date) =>
-    `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')}`;
+    `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, "0")}.${String(d.getDate()).padStart(2, "0")}`;
   return { startDate: fmt(start), endDate: fmt(end) };
 }
 
 /** 금액 포맷 */
 function formatAmount(n: number) {
-  return `${Math.abs(n).toLocaleString('ko-KR')}원`;
+  return `${Math.abs(n).toLocaleString("ko-KR")}원`;
 }
 
 // ── 메인 페이지 ───────────────────────────────────────────
 
 const DEFAULT_FILTER: SearchFilter = {
-  approval: 'approved',
-  cardType: 'all',
-  selectedCard: 'all',
-  region: 'all',
-  usageType: 'all',
-  period: 'thisMonth',
+  approval: "approved",
+  cardType: "all",
+  selectedCard: "all",
+  region: "all",
+  usageType: "all",
+  period: "thisMonth",
 };
 
 export function UsageHistoryPage({
@@ -104,7 +115,8 @@ export function UsageHistoryPage({
 }: UsageHistoryPageProps) {
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
   const [searchOpen, setSearchOpen] = useState(false);
-  const [appliedFilter, setAppliedFilter] = useState<SearchFilter>(DEFAULT_FILTER);
+  const [appliedFilter, setAppliedFilter] =
+    useState<SearchFilter>(DEFAULT_FILTER);
 
   const visibleTx = transactions.slice(0, visibleCount);
   const hasMore = visibleCount < transactions.length;
@@ -138,13 +150,20 @@ export function UsageHistoryPage({
         }
       >
         {/* ── 결제 요약 카드 ─────────────────────────────── */}
-        <div className="px-standard pt-md pb-lg">
-          <div className="flex flex-col gap-md bg-surface rounded-2xl shadow-card px-md py-lg">
+        <div className="px-standard pt-md">
+          <div className="flex flex-col gap-md bg-surface rounded-2xl shadow-card px-md">
             <div className="flex flex-col gap-xs">
-              <Typography variant="caption" color="muted">
-                {paymentSummary.date ? `${paymentSummary.date} 출금예정` : '출금예정일 정보 없음'}
+              <Typography variant="body-sm" color="muted">
+                {paymentSummary.date
+                  ? `${paymentSummary.date} 출금예정`
+                  : "출금예정일 정보 없음"}
               </Typography>
-              <Typography variant="subheading" weight="bold" color="heading" numeric>
+              <Typography
+                variant="heading"
+                weight="bold"
+                color="heading"
+                numeric
+              >
                 {formatAmount(paymentSummary.totalAmount)}
               </Typography>
             </div>
@@ -191,7 +210,11 @@ export function UsageHistoryPage({
               <div className="flex flex-col divide-y divide-border-subtle">
                 {visibleTx.map((tx) => (
                   /* onClick 전달 → 항목 클릭 시 상세 BottomSheet 노출 */
-                  <UsageTransactionItem key={tx.id} tx={tx} onClick={() => {}} />
+                  <UsageTransactionItem
+                    key={tx.id}
+                    tx={tx}
+                    onClick={() => {}}
+                  />
                 ))}
               </div>
               {hasMore && (

--- a/demo/front/src/pages/common/LoginPage/index.tsx
+++ b/demo/front/src/pages/common/LoginPage/index.tsx
@@ -29,8 +29,8 @@ import type { LoginPageProps } from "./types";
 export type { LoginPageProps } from "./types";
 
 export function LoginPage({
-  userId = '',
-  password = '',
+  userId = "",
+  password = "",
   onUserIdChange,
   onPasswordChange,
   hasError = false,
@@ -98,15 +98,17 @@ export function LoginPage({
             helperText={
               hasError ? "아이디 또는 비밀번호가 틀렸습니다" : undefined
             }
+            // iconOnly 모드에서는 children이 숨겨지므로 leftIcon으로 아이콘을 전달한다
             rightElement={
-              <button
-                type="button"
-                onClick={onTogglePassword}
+              <Button
+                variant="ghost"
+                size="sm"
+                iconOnly
                 aria-label={showPassword ? "비밀번호 숨김" : "비밀번호 표시"}
+                onClick={onTogglePassword}
                 className="text-text-muted"
-              >
-                {showPassword ? <Eye size={20} /> : <EyeOff size={20} />}
-              </button>
+                leftIcon={showPassword ? <Eye size={20} /> : <EyeOff size={20} />}
+              />
             }
           />
         </Stack>

--- a/demo/front/src/routes/RouteWrappers.tsx
+++ b/demo/front/src/routes/RouteWrappers.tsx
@@ -11,9 +11,10 @@
  * - 일반 페이지: XxxRoute (예: LoginRoute)
  * - 모달 오버레이: XxxModal (예: HanaCardMenuModal)
  */
-import { useState, useEffect }             from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { useNavigate, useLocation }        from 'react-router-dom';
 import { useAuth }                         from '@/contexts/AuthContext';
+import { axiosInstance }                   from '@/api/axiosInstance';
 import { Landmark, Building, Receipt, FileText, Wallet, Settings, Gift, CreditCard, Headphones } from 'lucide-react';
 
 import { LoginPage }                from '@/pages/common/LoginPage';
@@ -39,9 +40,6 @@ import type { Transaction, SearchFilter }              from '@/pages/card/UsageH
 import type { PaymentTabData, StatementTabData, CardPaymentEntry } from '@/pages/card/PaymentStatementPage/types';
 import { PATHS }          from '@/constants/paths';
 import {
-  MOCK_CARD_OPTIONS,
-  MOCK_CARDS_VISUAL,
-  MOCK_CARDS_SIMPLE,
   MOCK_USERS,
   MOCK_MANAGEMENT_ROWS,
   MOCK_CAUTIONS,
@@ -62,12 +60,8 @@ export function LoginRoute() {
   const handleLogin = async () => {
     setHasError(false);
     try {
-      const res  = await fetch('http://localhost:3001/api/auth/login', {
-        method:  'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body:    JSON.stringify({ userId, password }),
-      });
-      const data = await res.json();
+      // withCredentials: true 이므로 백엔드가 Set-Cookie로 httpOnly Refresh Token을 심는다
+      const { data } = await axiosInstance.post('/auth/login', { userId, password });
       if (data.success) {
         login({ userId: data.userId, userName: data.userName, userGrade: data.userGrade, token: data.token });
         navigate(PATHS.CARD.DASHBOARD);
@@ -97,15 +91,53 @@ export function LoginRoute() {
 /* 카드 대시보드                                                         */
 /* ------------------------------------------------------------------ */
 
+/**
+ * "YYYY.MM.DD" 또는 "YYMMDD" / "YYYYMMDD" → "M월 D일" 형식 변환.
+ * billingPeriod.dueDate(YYYY.MM.DD) 또는 dueDate(YYMMDD) 모두 처리한다.
+ */
+function parseDueDateKo(raw: string): string {
+  if (!raw) return '';
+  // YYYY.MM.DD
+  const dots = raw.split('.');
+  if (dots.length === 3 && dots[0].length === 4) {
+    return `${Number(dots[1])}월 ${Number(dots[2])}일`;
+  }
+  // YYMMDD (결제예정일 DB 형식)
+  if (raw.length === 6) return `${Number(raw.slice(2, 4))}월 ${Number(raw.slice(4, 6))}일`;
+  // YYYYMMDD
+  if (raw.length === 8) return `${Number(raw.slice(4, 6))}월 ${Number(raw.slice(6, 8))}일`;
+  return '';
+}
+
 /** 햄버거 메뉴 클릭 시 background location 패턴으로 /card/menu 를 모달로 열기 */
 export function CardDashboardRoute() {
-  const navigate  = useNavigate();
-  const location  = useLocation();
-  const { user }  = useAuth();
+  const navigate      = useNavigate();
+  const location      = useLocation();
+  const { user }      = useAuth();
+
+  /** StatementHeroCard: 공여기간 기준 이번 달 결제 예정 금액 */
+  const [statementAmount,  setStatementAmount]  = useState(0);
+  /** StatementHeroCard: 결제일 레이블 (예: "1월 25일") */
+  const [statementDueDate, setStatementDueDate] = useState('');
+
+  useEffect(() => {
+    if (!user?.userId) return;
+    axiosInstance.get('/payment-statement')
+      .then((r) => {
+        const data = r.data;
+        setStatementAmount(data.totalAmount ?? 0);
+        // billingPeriod.dueDate(YYYY.MM.DD) 우선 사용, 없으면 raw dueDate(YYMMDD) 파싱
+        const rawDue = data.billingPeriod?.dueDate ?? data.dueDate ?? '';
+        setStatementDueDate(parseDueDateKo(rawDue));
+      })
+      .catch(console.error);
+  }, [user?.userId]);
 
   return (
     <CardDashboardPage
       userName={user?.userName}
+      statementAmount={statementAmount}
+      statementDueDate={statementDueDate}
       onMenu={()             => navigate(PATHS.CARD.MENU, { state: { background: location } })}
       onNotification={()     => {}}
       onStatementDetail={()  => navigate(PATHS.CARD.PAYMENT_STATEMENT)}
@@ -129,12 +161,12 @@ export function CardDashboardRoute() {
 
 /** 분할납부·즉시결제 클릭 시 즉시결제 안내로 이동 */
 export function UsageHistoryRoute() {
-  const navigate                = useNavigate();
-  const { user, fetchWithAuth } = useAuth();
+  const navigate   = useNavigate();
+  const { user }   = useAuth();
   const [transactions,   setTransactions]   = useState<Transaction[]>([]);
   const [totalCount,     setTotalCount]     = useState(0);
   const [paymentSummary, setPaymentSummary] = useState({ date: '', totalAmount: 0 });
-  const [cardOptions,    setCardOptions]    = useState(MOCK_CARD_OPTIONS);
+  const [cardOptions,    setCardOptions]    = useState<{ value: string; label: string }[]>([]);
   const [loading,        setLoading]        = useState(true);
 
   /** SearchFilter → query string 변환 후 이용내역 재조회 */
@@ -149,9 +181,9 @@ export function UsageHistoryRoute() {
         params.set('usageType', filter.usageType);
     }
     const qs = params.toString() ? `?${params}` : '';
-    fetchWithAuth(`http://localhost:3001/api/transactions${qs}`)
-      .then((r) => r.json())
-      .then((data) => {
+    axiosInstance.get(`/transactions${qs}`)
+      .then((r) => {
+        const data = r.data;
         setTransactions(data.transactions ?? []);
         setTotalCount(data.totalCount ?? 0);
         setPaymentSummary(data.paymentSummary ?? { date: '', totalAmount: 0 });
@@ -160,10 +192,18 @@ export function UsageHistoryRoute() {
   };
 
   useEffect(() => {
-    if (!user?.token) return;
+    if (!user?.userId) return;
+    /* 이번 달 첫째 날 ~ 마지막 날을 YYYYMMDD 형식으로 계산 */
+    const now      = new Date();
+    const year     = now.getFullYear();
+    const month    = String(now.getMonth() + 1).padStart(2, '0');
+    const lastDay  = new Date(year, now.getMonth() + 1, 0).getDate(); // 월의 실제 마지막 날
+    const fromDate = `${year}${month}01`;
+    const toDate   = `${year}${month}${String(lastDay).padStart(2, '0')}`;
+
     Promise.all([
-      fetchWithAuth('http://localhost:3001/api/transactions').then((r) => r.json()),
-      fetchWithAuth('http://localhost:3001/api/cards').then((r) => r.json()),
+      axiosInstance.get(`/transactions?fromDate=${fromDate}&toDate=${toDate}`).then((r) => r.data),
+      axiosInstance.get('/cards').then((r) => r.data),
     ])
       .then(([txData, cardData]) => {
         setTransactions(txData.transactions ?? []);
@@ -178,7 +218,7 @@ export function UsageHistoryRoute() {
       })
       .catch(console.error)
       .finally(() => setLoading(false));
-  }, [user?.token]);
+  }, [user?.userId]);
 
   if (loading) return null;
 
@@ -203,126 +243,187 @@ export function UsageHistoryRoute() {
 /* 결제예정금액 / 명세서                                                  */
 /* ------------------------------------------------------------------ */
 
+/** /api/payment-statement 응답 items 단건 타입 */
+interface StmtApiItem { cardNo: string; cardName: string; amount: number; dueDate: string }
+/** /api/payment-statement 응답 billingPeriod 타입 */
+interface StmtBillingPeriod { usageStart: string; usageEnd: string; dueDate: string }
+/** /api/payment-statement 전체 응답 타입 */
+interface StmtApiResponse { dueDate: string; totalAmount: number; items: StmtApiItem[]; cardInfo: { paymentBank: string; paymentAccount: string; paymentDay: string } | null; billingPeriod: StmtBillingPeriod | null }
+
+/** YYMMDD or YYYYMMDD → "M월 D일 결제" 레이블 */
+function fmtDueDateLabel(raw: string): string {
+  if (raw.length === 6) return `${Number(raw.slice(2, 4))}월 ${Number(raw.slice(4, 6))}일 결제`;
+  if (raw.length === 8) return `${Number(raw.slice(4, 6))}월 ${Number(raw.slice(6, 8))}일 결제`;
+  return '';
+}
+
+
+/** YYMMDD or YYYYMMDD → { dateFull, dateYM, dateMD } */
+function parseDueDate(raw: string) {
+  if (raw.length === 6) {
+    const y = `20${raw.slice(0, 2)}`, m = raw.slice(2, 4), d = raw.slice(4, 6);
+    return { dateFull: `${y}.${m}.${d}`, dateYM: `${raw.slice(0, 2)}년 ${Number(m)}월`, dateMD: `${m}.${d}` };
+  }
+  if (raw.length === 8) {
+    const y = raw.slice(0, 4), m = raw.slice(4, 6), d = raw.slice(6, 8);
+    return { dateFull: `${y}.${m}.${d}`, dateYM: `${y.slice(2)}년 ${Number(m)}월`, dateMD: `${m}.${d}` };
+  }
+  return { dateFull: '', dateYM: '', dateMD: '' };
+}
+
+/**
+ * 오늘 날짜 기준으로 화면 진입 시 보여줄 초기 청구월을 결정한다.
+ *
+ *   1 ~ 14일 → 이번 달(M)
+ *     이유: 주요 결제일(25일 등)이 아직 도래하지 않아 이번 달 결제 예정 금액이
+ *           사용자에게 가장 유의미한 정보다.
+ *
+ *   15일 ~   → 다음 달(M+1)
+ *     이유: 이번 달 결제일이 이미 지났거나 며칠 내 완료될 예정이므로
+ *           다음 달 청구분을 미리 확인하는 흐름이 자연스럽다.
+ *
+ * 월 이동 시 new Date(year, month, 1) 생성자를 사용해
+ * setMonth의 월말 오버플로우를 원천 차단한다.
+ * (e.g. 1월 31일에 setMonth(month+1) → 3월 2일로 밀리는 오류 방지)
+ */
+function getInitialBillingMonth(): string {
+  const today = new Date();
+  const day   = today.getDate();
+  /* 1일로 고정한 뒤 월 이동 — setDate 후 setMonth 방식의 오버플로우 없음 */
+  const base  = new Date(today.getFullYear(), today.getMonth(), 1);
+  if (day >= 15) {
+    // 15일 이후: 다음 달로 이동
+    base.setMonth(base.getMonth() + 1);
+  }
+  // 1~14일: base 그대로(이번 달)
+  return `${base.getFullYear()}-${String(base.getMonth() + 1).padStart(2, '0')}`;
+}
+
 /** 즉시결제·분할납부 클릭 시 즉시결제 안내로 이동 */
 export function PaymentStatementRoute() {
-  const navigate                = useNavigate();
-  const { user, fetchWithAuth } = useAuth();
-  const [paymentData,   setPaymentData]   = useState<PaymentTabData | null>(null);
-  const [statementData, setStatementData] = useState<StatementTabData | null>(null);
-  const [cardOptions,   setCardOptions]   = useState(MOCK_CARD_OPTIONS);
-  const [loading,       setLoading]       = useState(true);
+  const navigate   = useNavigate();
+  const { user }   = useAuth();
+
+  /** 전체 카드 이용내역 items */
+  const [allItems,    setAllItems]    = useState<StmtApiItem[]>([]);
+  /** /api/cards 에서 가져온 카드 상세 (결제은행·계좌·결제일 표시용) */
+  const [rawCards,    setRawCards]    = useState<ApiCardFull[]>([]);
+  /** /api/payment-statement 응답의 cardInfo — rawCards 없을 때 fallback */
+  const [stmtCardInfo, setStmtCardInfo] = useState<StmtApiResponse['cardInfo']>(null);
+  /** API 응답의 공여기간 정보 — infoSections 표시에 사용 */
+  const [billingPeriod, setBillingPeriod] = useState<StmtBillingPeriod | null>(null);
+  const [loading,     setLoading]     = useState(true);
+  /**
+   * 현재 적용된 날짜 필터 — 날짜 변경 시 재조회에 사용.
+   * getInitialBillingMonth()로 오늘 날짜 기준 최적 청구월을 초기값으로 설정한다.
+   * (1~14일: 이번 달 / 15일~: 다음 달)
+   */
+  const yearMonthRef = useRef(getInitialBillingMonth());
+
+  /**
+   * items 재조회.
+   * yearMonth 전달 시: 결제예정일(YYMMDD) LIKE 필터 (공여기간 미적용)
+   */
+  function fetchItems(yearMonth = yearMonthRef.current) {
+    yearMonthRef.current = yearMonth;
+    const params = new URLSearchParams();
+    if (yearMonth) params.set('yearMonth', yearMonth);
+    const qs = params.toString() ? `?${params}` : '';
+    axiosInstance.get<StmtApiResponse>(`/payment-statement${qs}`)
+      .then((r) => {
+        const data = r.data;
+        setAllItems(data.items ?? []);
+        setBillingPeriod(data.billingPeriod ?? null);
+        setStmtCardInfo(data.cardInfo ?? null);
+      })
+      .catch(console.error);
+  }
 
   useEffect(() => {
-    if (!user?.token) return;
+    if (!user?.userId) return;
+    /* 초기 조회: getInitialBillingMonth() 기준 청구월 */
+    const initQs = `?yearMonth=${yearMonthRef.current}`;
     Promise.all([
-      fetchWithAuth('http://localhost:3001/api/payment-statement').then((r) => r.json()),
-      fetchWithAuth('http://localhost:3001/api/cards').then((r) => r.json()),
+      axiosInstance.get<StmtApiResponse>(`/payment-statement${initQs}`).then((r) => r.data),
+      axiosInstance.get<{ cards: ApiCardFull[] }>('/cards').then((r) => r.data),
     ])
       .then(([stmtData, cardData]) => {
-        // ── dueDate(YYMMDD 또는 YYYYMMDD) → dateFull / dateYM / dateMD ──
-        const raw = String(stmtData.dueDate ?? '');
-        let dateFull = '';
-        let dateYM   = '';
-        let dateMD   = '';
-        if (raw.length === 6) {
-          /* YYMMDD: DB 결제예정일 형식 */
-          const y = `20${raw.slice(0, 2)}`;
-          const m = raw.slice(2, 4);
-          const d = raw.slice(4, 6);
-          dateFull = `${y}.${m}.${d}`;
-          dateYM   = `${raw.slice(0, 2)}년 ${Number(m)}월`;
-          dateMD   = `${m}.${d}`;
-        } else if (raw.length === 8) {
-          /* YYYYMMDD */
-          const y = raw.slice(0, 4);
-          const m = raw.slice(4, 6);
-          const d = raw.slice(6, 8);
-          dateFull = `${y}.${m}.${d}`;
-          dateYM   = `${y.slice(2)}년 ${Number(m)}월`;
-          dateMD   = `${m}.${d}`;
-        }
-
-        // ── items → CardPaymentEntry[] ─────────────────────────────
-        const paymentItems: CardPaymentEntry[] = (stmtData.items ?? []).map(
-          (item: { cardNo: string; cardName: string; amount: number; dueDate: string }) => {
-            /* dueDate(YYMMDD or YYYYMMDD) → "M월 D일 결제" */
-            const raw = String(item.dueDate ?? '');
-            let dueDateLabel = '';
-            if (raw.length === 6) {
-              dueDateLabel = `${Number(raw.slice(2, 4))}월 ${Number(raw.slice(4, 6))}일 결제`;
-            } else if (raw.length === 8) {
-              dueDateLabel = `${Number(raw.slice(4, 6))}월 ${Number(raw.slice(6, 8))}일 결제`;
-            }
-            return {
-              id:         `${item.cardNo}_${item.dueDate}`,
-              icon:       <CreditCard className="size-5" />,
-              cardEnName: dueDateLabel,
-              cardName:   item.cardName,
-              amount:     item.amount,
-            };
-          },
-        );
-
-        // ── cardInfo → CardInfoSection[] ──────────────────────────
-        const ci = stmtData.cardInfo;
-        const infoSections = ci
-          ? [
-              {
-                title: '결제정보',
-                rows: [
-                  { label: '결제은행명', value: ci.paymentBank },
-                  { label: '결제계좌',   value: ci.paymentAccount },
-                  { label: '결제일',     value: `${ci.paymentDay}일` },
-                ],
-              },
-            ]
-          : [];
-
-        setPaymentData({
-          dateFull,
-          dateYM,
-          dateMD,
-          totalAmount:  stmtData.totalAmount ?? 0,
-          revolving:    0,
-          cardLoan:     0,
-          cashAdvance:  0,
-          infoSections,
-          paymentItems,
-        });
-        setStatementData({
-          totalAmount:  stmtData.totalAmount ?? 0,
-          badge:        '예정',
-          paymentItems,
-          infoSections,
-        });
-        setCardOptions(
-          (cardData.cards ?? []).map((c: { id: string; name: string }) => ({
-            value: c.id,
-            label: c.name,
-          })),
-        );
+        setAllItems(stmtData.items ?? []);
+        setBillingPeriod(stmtData.billingPeriod ?? null);
+        setStmtCardInfo(stmtData.cardInfo ?? null);
+        setRawCards(cardData.cards ?? []);
       })
       .catch(console.error)
       .finally(() => setLoading(false));
-  }, [user?.token, fetchWithAuth]);
+  }, [user?.userId]);
 
-  if (loading || !paymentData || !statementData) return null;
+  /**
+   * 전체 카드 합산 데이터 계산.
+   * - 백엔드가 카드별 공여기간 규칙을 적용해 선택 청구월 항목만 반환하므로
+   *   프론트는 allItems를 그대로 두 탭에 공통 사용한다.
+   * - infoSections: 첫 번째 카드의 결제정보 + 공여기간
+   */
+  const { paymentData, statementData } = useMemo<{
+    paymentData:   PaymentTabData;
+    statementData: StatementTabData;
+  }>(() => {
+    /* 결제예정금액 탭 — 백엔드가 청구월 기준으로 필터링한 allItems 사용 */
+    const paymentTotalAmt = allItems.reduce((s, i) => s + i.amount, 0);
+    const firstDue = allItems[0]?.dueDate ?? '';
+    const { dateFull, dateYM, dateMD } = parseDueDate(firstDue);
+    const paymentItems: CardPaymentEntry[] = allItems.map((item) => ({
+      id:         `${item.cardNo}_${item.dueDate}`,
+      icon:       <CreditCard className="size-5" />,
+      cardEnName: fmtDueDateLabel(item.dueDate),
+      cardName:   item.cardName,
+      amount:     item.amount,
+    }));
+
+    /* 이용대금명세서 탭 — 동일 항목 재사용 */
+    const statementTotalAmt = paymentTotalAmt;
+    const allPaymentItems   = paymentItems;
+
+    /* 결제정보: stmtCardInfo(payment-statement API) 우선, 없으면 rawCards[0] fallback */
+    const cardInfoSrc = stmtCardInfo ?? (rawCards[0] ? {
+      paymentBank:    rawCards[0].paymentBank,
+      paymentAccount: rawCards[0].paymentAccount,
+      paymentDay:     rawCards[0].paymentDay,
+    } : null);
+    const paymentInfoRows = cardInfoSrc ? [
+      { label: '결제은행명', value: cardInfoSrc.paymentBank },
+      { label: '결제계좌',   value: cardInfoSrc.paymentAccount },
+      { label: '결제일',     value: `${cardInfoSrc.paymentDay}일` },
+    ] : [];
+    const billingRows = billingPeriod ? [
+      { label: '이용 시작', value: billingPeriod.usageStart },
+      { label: '이용 종료', value: billingPeriod.usageEnd },
+    ] : [];
+    const infoSections = cardInfoSrc ? [
+      { title: '결제정보', rows: [...paymentInfoRows, ...billingRows] },
+    ] : [];
+
+    return {
+      paymentData:   { dateFull, dateYM, dateMD, totalAmount: paymentTotalAmt, revolving: 0, cardLoan: 0, cashAdvance: 0, infoSections, paymentItems: paymentItems },
+      statementData: { totalAmount: statementTotalAmt, badge: '예정', paymentItems: allPaymentItems, infoSections },
+    };
+  }, [allItems, rawCards, stmtCardInfo, billingPeriod]);
+
+  if (loading) return null;
 
   return (
     <PaymentStatementPage
-      cardOptions={cardOptions}
+      initialMonth={yearMonthRef.current}
       paymentData={paymentData}
       statementData={statementData}
-      onBack={()              => navigate(-1)}
-      onClose={()             => navigate(PATHS.CARD.DASHBOARD, { replace: true })}
-      onCardChange={()        => {}}
-      onDateClick={()         => {}}
-      onRevolving={()         => {}}
-      onCardLoan={()          => {}}
-      onCashAdvance={()       => {}}
-      onStatementDetail={()   => navigate(PATHS.CARD.USAGE_HISTORY)}
-      onInstallment={()       => navigate(PATHS.CARD.IMMEDIATE_PAYMENT)}
-      onImmediatePayment={()  => navigate(PATHS.CARD.IMMEDIATE_PAYMENT)}
+      onBack={()               => navigate(-1)}
+      onClose={()              => navigate(PATHS.CARD.DASHBOARD, { replace: true })}
+      onDateClick={(yearMonth) => fetchItems(yearMonth)}
+      onRevolving={()          => {}}
+      onCardLoan={()           => {}}
+      onCashAdvance={()        => {}}
+      onStatementDetail={()    => navigate(PATHS.CARD.USAGE_HISTORY)}
+      onInstallment={()        => navigate(PATHS.CARD.IMMEDIATE_PAYMENT)}
+      onImmediatePayment={()   => navigate(PATHS.CARD.IMMEDIATE_PAYMENT)}
     />
   );
 }
@@ -358,11 +459,32 @@ export function ImmediatePaymentRoute() {
 
 /** STEP 1 — 카드·결제유형 선택, 다음 클릭 시 STEP 2 로 이동 */
 export function ImmediatePayRoute() {
-  const navigate = useNavigate();
+  const navigate            = useNavigate();
+  const { user }            = useAuth();
+  const [cards, setCards]   = useState<CardInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!user?.userId) return;
+    axiosInstance.get<{ cards: ApiCardFull[] }>('/cards')
+      .then((r) => {
+        // ApiCardFull → CardInfo (id, name, maskedNumber만 사용)
+        setCards(r.data.cards.map((c) => ({
+          id:           c.id,
+          name:         c.name,
+          maskedNumber: c.maskedNumber,
+        })));
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, [user?.userId]);
+
+  if (loading) return null;
+
   return (
     <ImmediatePayPage
-      cards={MOCK_CARDS_SIMPLE}
-      initialCardId="card-1"
+      cards={cards}
+      initialCardId={cards[0]?.id}
       initialPaymentType="total"
       onPaymentTypeChange={() => {}}
       onCardChange={()        => {}}
@@ -475,9 +597,9 @@ interface ApiCardFull {
 }
 
 export function MyCardManagementRoute() {
-  const navigate              = useNavigate();
-  const { user, fetchWithAuth } = useAuth();
-  const [cards, setCards]     = useState<CardItem[]>(MOCK_CARDS_VISUAL);
+  const navigate    = useNavigate();
+  const { user }    = useAuth();
+  const [cards, setCards]     = useState<CardItem[]>([]);
   const [rawCards, setRawCards] = useState<ApiCardFull[]>([]);
   const [loading, setLoading] = useState(true);
   /** 칩 탭에서 선택된 카드 ID — onCardSelect 콜백으로 동기화 */
@@ -485,10 +607,10 @@ export function MyCardManagementRoute() {
   const [modalOpen, setModalOpen] = useState(false);
 
   useEffect(() => {
-    if (!user?.token) return;
-    fetchWithAuth('http://localhost:3001/api/cards')
-      .then((r) => r.json())
-      .then(({ cards: raw }: { cards: ApiCardFull[] }) => {
+    if (!user?.userId) return;
+    axiosInstance.get<{ cards: ApiCardFull[] }>('/cards')
+      .then((r) => {
+        const { cards: raw } = r.data;
         setRawCards(raw);
         setCards(
           raw.map((c) => ({
@@ -507,7 +629,7 @@ export function MyCardManagementRoute() {
       })
       .catch(console.error)
       .finally(() => setLoading(false));
-  }, [user?.token]);
+  }, [user?.userId]);
 
   if (loading) return null;
 

--- a/demo/front/src/routes/RouteWrappers.tsx
+++ b/demo/front/src/routes/RouteWrappers.tsx
@@ -24,6 +24,7 @@ import { UsageHistoryPage }         from '@/pages/card/UsageHistoryPage';
 import { PaymentStatementPage }     from '@/pages/card/PaymentStatementPage';
 import { ImmediatePaymentPage }     from '@/pages/card/ImmediatePaymentPage';
 import { ImmediatePayPage }         from '@/pages/card/ImmediatePayPage';
+import type { CardInfo }            from '@/pages/card/ImmediatePayPage/types';
 import { ImmediatePayRequestPage }  from '@/pages/card/ImmediatePayRequestPage';
 import { ImmediatePayMethodPage }   from '@/pages/card/ImmediatePayMethodPage';
 import { ImmediatePayCompletePage } from '@/pages/card/ImmediatePayCompletePage';
@@ -119,16 +120,30 @@ export function CardDashboardRoute() {
   const [statementAmount,  setStatementAmount]  = useState(0);
   /** StatementHeroCard: 결제일 레이블 (예: "1월 25일") */
   const [statementDueDate, setStatementDueDate] = useState('');
+  /** SummaryCard(spending): 당월 이용내역 합산 금액 */
+  const [spendingAmount,   setSpendingAmount]   = useState(0);
 
   useEffect(() => {
     if (!user?.userId) return;
-    axiosInstance.get('/payment-statement')
-      .then((r) => {
-        const data = r.data;
-        setStatementAmount(data.totalAmount ?? 0);
+
+    /* 당월 범위 계산 (YYYYMMDD 형식) */
+    const now     = new Date();
+    const year    = now.getFullYear();
+    const month   = String(now.getMonth() + 1).padStart(2, '0');
+    const lastDay = new Date(year, now.getMonth() + 1, 0).getDate();
+    const fromDate = `${year}${month}01`;
+    const toDate   = `${year}${month}${String(lastDay).padStart(2, '0')}`;
+
+    Promise.all([
+      axiosInstance.get('/payment-statement').then((r) => r.data),
+      axiosInstance.get(`/transactions?fromDate=${fromDate}&toDate=${toDate}`).then((r) => r.data),
+    ])
+      .then(([stmtData, txData]) => {
+        setStatementAmount(stmtData.totalAmount ?? 0);
         // billingPeriod.dueDate(YYYY.MM.DD) 우선 사용, 없으면 raw dueDate(YYMMDD) 파싱
-        const rawDue = data.billingPeriod?.dueDate ?? data.dueDate ?? '';
+        const rawDue = stmtData.billingPeriod?.dueDate ?? stmtData.dueDate ?? '';
         setStatementDueDate(parseDueDateKo(rawDue));
+        setSpendingAmount(txData.paymentSummary?.totalAmount ?? 0);
       })
       .catch(console.error);
   }, [user?.userId]);
@@ -138,6 +153,7 @@ export function CardDashboardRoute() {
       userName={user?.userName}
       statementAmount={statementAmount}
       statementDueDate={statementDueDate}
+      spendingAmount={spendingAmount}
       onMenu={()             => navigate(PATHS.CARD.MENU, { state: { background: location } })}
       onNotification={()     => {}}
       onStatementDetail={()  => navigate(PATHS.CARD.PAYMENT_STATEMENT)}
@@ -257,6 +273,55 @@ function fmtDueDateLabel(raw: string): string {
   return '';
 }
 
+
+/**
+ * 결제일이 오늘 이후인지 판단해 '예정' 배지 표시 여부를 결정한다.
+ *
+ * 판단 우선순위:
+ *   1. billingPeriod.dueDate(YYYY.MM.DD) — API가 계산한 정확한 결제예정일
+ *   2. billingPeriod 없을 때 — yearMonth + paymentDay로 결제일 직접 구성
+ */
+function isPaymentUpcoming(
+  billingPeriod: StmtBillingPeriod | null,
+  yearMonth: string,
+  paymentDay?: string | null,
+): boolean {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0); // 시간 무시, 날짜 단위 비교
+
+  if (billingPeriod?.dueDate) {
+    /* YYYY.MM.DD 형식 파싱 */
+    const [y, m, d] = billingPeriod.dueDate.split('.').map(Number);
+    return new Date(y, m - 1, d) >= today;
+  }
+
+  /* billingPeriod 없을 때: yearMonth + paymentDay로 결제일 구성해 비교 */
+  const [y, m] = yearMonth.split('-').map(Number);
+  const day = paymentDay ? Number(paymentDay) : 1; // paymentDay 없으면 1일로 보수적 처리
+  return new Date(y, m - 1, day) >= today;
+}
+
+/**
+ * 계좌번호 마스킹 — 하이픈 구조는 유지하고 중간 구간을 * 로 치환한다.
+ *
+ *   하이픈 있는 경우: 첫·마지막 세그먼트 유지, 중간 세그먼트 전부 마스킹
+ *     e.g. "123-456789-01234" → "123-******-01234"
+ *   하이픈 없는 경우: 앞 3자리·뒤 4자리 유지, 나머지 마스킹
+ *     e.g. "1234567890" → "123***7890"
+ */
+function maskAccountNumber(account: string): string {
+  if (!account) return '';
+  const parts = account.split('-');
+  if (parts.length >= 3) {
+    /* 중간 세그먼트(들)를 같은 길이의 * 로 교체 */
+    const masked = parts.slice(1, -1).map((p) => '*'.repeat(p.length));
+    return [parts[0], ...masked, parts[parts.length - 1]].join('-');
+  }
+  /* 하이픈 없는 숫자열: 앞 3 + * + 뒤 4 */
+  const digits = account.replace(/\D/g, '');
+  if (digits.length <= 7) return account; // 너무 짧으면 마스킹 생략
+  return digits.slice(0, 3) + '*'.repeat(digits.length - 7) + digits.slice(-4);
+}
 
 /** YYMMDD or YYYYMMDD → { dateFull, dateYM, dateMD } */
 function parseDueDate(raw: string) {
@@ -391,7 +456,7 @@ export function PaymentStatementRoute() {
     } : null);
     const paymentInfoRows = cardInfoSrc ? [
       { label: '결제은행명', value: cardInfoSrc.paymentBank },
-      { label: '결제계좌',   value: cardInfoSrc.paymentAccount },
+      { label: '결제계좌',   value: maskAccountNumber(cardInfoSrc.paymentAccount) },
       { label: '결제일',     value: `${cardInfoSrc.paymentDay}일` },
     ] : [];
     const billingRows = billingPeriod ? [
@@ -404,7 +469,7 @@ export function PaymentStatementRoute() {
 
     return {
       paymentData:   { dateFull, dateYM, dateMD, totalAmount: paymentTotalAmt, revolving: 0, cardLoan: 0, cashAdvance: 0, infoSections, paymentItems: paymentItems },
-      statementData: { totalAmount: statementTotalAmt, badge: '예정', paymentItems: allPaymentItems, infoSections },
+      statementData: { totalAmount: statementTotalAmt, badge: isPaymentUpcoming(billingPeriod, yearMonthRef.current, cardInfoSrc?.paymentDay) ? '예정' : undefined, paymentItems: allPaymentItems, infoSections },
     };
   }, [allItems, rawCards, stmtCardInfo, billingPeriod]);
 

--- a/reactive-springware/component-library/biz/card/CardPaymentSummary/index.tsx
+++ b/reactive-springware/component-library/biz/card/CardPaymentSummary/index.tsx
@@ -92,6 +92,7 @@ export function CardPaymentSummary({
   onCardLoan,
   onCashAdvance,
   onDateClick,
+  hideDateButton = false,
   className,
 }: CardPaymentSummaryProps) {
   return (
@@ -104,17 +105,19 @@ export function CardPaymentSummary({
       )}
     >
       {/* 상단: 총 청구금액 */}
-      <div className="flex flex-col items-center gap-xs pt-lg px-md">
-        {/* 날짜 영역 — onDateClick 전달 시 버튼으로 렌더링해 날짜 선택 모달 진입 */}
-        <button
-          type="button"
-          onClick={onDateClick}
-          disabled={!onDateClick}
-          className="flex items-center gap-xs text-lg text-text-muted disabled:cursor-default"
-        >
-          {dateYM}
-          <ChevronDown className="size-4" />
-        </button>
+      <div className="flex flex-col items-center gap-xs px-md">
+        {/* 날짜 영역 — hideDateButton=true이면 숨김. onDateClick 전달 시 클릭 가능 */}
+        {!hideDateButton && (
+          <button
+            type="button"
+            onClick={onDateClick}
+            disabled={!onDateClick}
+            className="flex items-center gap-xs text-lg text-text-muted disabled:cursor-default"
+          >
+            {dateYM}
+            <ChevronDown className="size-4" />
+          </button>
+        )}
         <span className="text-sm text-text-muted">
           {dateFull} 출금예정 ({dateMD}기준)
         </span>

--- a/reactive-springware/component-library/biz/card/CardPaymentSummary/index.tsx
+++ b/reactive-springware/component-library/biz/card/CardPaymentSummary/index.tsx
@@ -118,9 +118,14 @@ export function CardPaymentSummary({
             <ChevronDown className="size-4" />
           </button>
         )}
-        <span className="text-sm text-text-muted">
-          {dateFull} 출금예정 ({dateMD}기준)
-        </span>
+        {/* dateFull이 있을 때만 출금예정일 표시 — items가 없으면 비어있음 */}
+        {dateFull ? (
+          <span className="text-sm text-text-muted">
+            {dateFull} 출금예정 ({dateMD}기준)
+          </span>
+        ) : (
+          <span className="text-sm text-text-muted">결제 예정일 정보 없음</span>
+        )}
         <span className="text-3xl font-bold text-brand pt-lg">{formatAmount(totalAmount)}</span>
       </div>
 

--- a/reactive-springware/component-library/biz/card/CardPaymentSummary/types.ts
+++ b/reactive-springware/component-library/biz/card/CardPaymentSummary/types.ts
@@ -29,5 +29,7 @@ export interface CardPaymentSummaryProps {
   onCashAdvance?: () => void;
   /** 날짜(년월) 영역 클릭 핸들러. 전달 시 날짜 선택 모달 등을 열 수 있음 */
   onDateClick?: () => void;
+  /** true이면 년월 선택 버튼(dateYM + ChevronDown)을 숨김. 기본: false */
+  hideDateButton?: boolean;
   className?: string;
 }

--- a/reactive-springware/component-library/biz/card/StatementTotalCard/index.tsx
+++ b/reactive-springware/component-library/biz/card/StatementTotalCard/index.tsx
@@ -48,7 +48,7 @@ export function StatementTotalCard({
       className={cn(
         'flex flex-col gap-md',
         'bg-surface rounded-2xl overflow-hidden shadow-card',
-        'px-md pt-md pb-lg',
+        'px-md',
         className,
       )}
     >

--- a/reactive-springware/component-library/layout/PageLayout/index.tsx
+++ b/reactive-springware/component-library/layout/PageLayout/index.tsx
@@ -40,7 +40,10 @@ export function PageLayout({
   ...props
 }: PageLayoutProps) {
   return (
-    <div className={cn('flex flex-col min-h-dvh', className)} {...props}>
+    /* h-dvh: 컨테이너를 정확히 뷰포트 높이로 고정해 스크롤이 body가 아닌
+       하위 main 영역 내부에서만 발생하도록 한다. min-h-dvh 사용 시 body가
+       스크롤되어 sticky 헤더와 z-index 충돌이 발생할 수 있음. */
+    <div className={cn('flex flex-col h-dvh', className)} {...props}>
       {/* ── 상단 고정 헤더 ────────────────────────────── */}
       <header className="sticky top-0 z-sticky bg-surface border-b border-border-subtle">
         {/* relative: 타이틀 absolute 포지셔닝의 기준점 */}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
- #15 JWT Access/Refresh Token 분리 및 Axios 자동 갱신 인터셉터 구현
- #16 하나카드 공여기간 계산 유틸리티 및 결제예정금액 API 청구월 필터링 구현
- #17 결제예정금액 화면 청구월 선택 및 전체 화면 실데이터 연동
- #18 세션 비활성 타임아웃 및 클라이언트 사이드 JWT 만료 감지 훅 구현

## ✨ 변경 사항 (Changes)

### #15 — JWT Access/Refresh Token 분리 및 Axios 자동 갱신 인터셉터
- **백엔드**: 단일 JWT → Access Token(15분) + Refresh Token(7일) 분리
  - `POST /api/auth/login`: Refresh Token을 `httpOnly`, `sameSite=lax` 쿠키로 발급
  - `POST /api/auth/refresh`: 쿠키 검증 후 새 Access Token 발급, 탈취 감지 시 즉시 무효화
  - `POST /api/auth/logout`: 인메모리 저장소 삭제 + 쿠키 만료
  - `cookie-parser` 의존성 추가
- **프론트엔드**: `src/api/axiosInstance.ts` 신규 생성
  - Axios 싱글톤, 요청 인터셉터(Authorization 헤더 자동 삽입), 응답 인터셉터(401 시 자동 refresh + 재시도)
  - 동시 401 처리: `isRefreshing` 플래그 + 대기열로 중복 refresh 방지
  - `AuthContext` 리팩터링: `fetchWithAuth` 제거 → Axios 인터셉터로 대체
  - `RouteWrappers.tsx` 전체를 `axiosInstance`로 교체

### #16 — 하나카드 공여기간 계산 유틸리티 및 API 청구월 필터링
- `demo/backend/utils/billingPeriod.js` 신규: 결제일별 공여기간 Forward/Reverse 계산, 말일 클램프 처리
- `demo/backend/utils/billingByMonth.js` 신규: 청구월 기준 항목 필터링·집계, 결제일별 기간 캐싱
- `GET /api/payment-statement`에 `yearMonth` 쿼리 파라미터 추가, 응답에 `billingPeriod` 필드 추가

### #17 — 결제예정금액 화면 청구월 선택 및 실데이터 연동
- `PaymentStatementPage`: 카드 선택 드롭다운 제거, 청구월 변경 시 API 재조회
- `CardDashboardRoute`: 실제 API로 `StatementHeroCard` 금액·결제일 표시
- `ImmediatePayRoute`, `UsageHistoryRoute`: `MOCK_*` 데이터 완전 제거 → `/api/cards` 실데이터로 교체

### #18 — 세션 비활성 타임아웃 및 JWT 만료 감지 훅
- `src/hooks/useSessionActivity.ts` 신규: 1분 인터벌로 비활성 30분 체크, 클릭 이벤트 기반 JWT `exp` 파싱(1분 쓰로틀)
- `App.tsx`에 `useSessionActivity()` 적용

## ⚠️ 고려 및 주의 사항 (선택)
- Refresh Token은 POC 환경 기준 인메모리 `Map` 저장 — 프로덕션 전환 시 Redis/DB 교체 필요
- `secure: false` 설정은 POC HTTP 환경 허용 용도 — 프로덕션에서는 `true` + HTTPS 필수
- `SESSION_TIMEOUT_MS = 30분`, `THROTTLE_MS = 1분` 상수로 분리해 필요 시 조정 가능

## 💬 리뷰 포인트 (선택)
- `axiosInstance.ts`의 동시 401 처리 (isRefreshing + 대기열) 로직
- `billingPeriod.js`의 하나카드 공식 결제일별 공여기간 규칙 구현 정확성
- `useSessionActivity.ts`의 비로그인 상태 이벤트·인터벌 정리 로직