### PR TITLE
feat: React 코드 생성 이력 조회 화면 구현 (#12)

### DIFF
--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/ai/client/ClaudeApiClient.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/ai/client/ClaudeApiClient.java
@@ -106,7 +106,14 @@ public class ClaudeApiClient {
         }
         try {
             List<Map<String, Object>> content = (List<Map<String, Object>>) body.get("content");
+            // content 리스트가 null이거나 비어있으면 응답 구조 이상으로 판단
+            if (content == null || content.isEmpty()) {
+                log.error("Claude API 응답 content가 비어있습니다: {}", body);
+                throw new InternalException("Claude API 응답을 파싱할 수 없습니다.");
+            }
             return (String) content.get(0).get("text");
+        } catch (InternalException e) {
+            throw e;
         } catch (Exception e) {
             log.error("Claude API 응답 파싱 실패: {}", body);
             throw new InternalException("Claude API 응답을 파싱할 수 없습니다.");

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/controller/ReactGenerateController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/controller/ReactGenerateController.java
@@ -3,14 +3,21 @@ package com.example.admin_demo.domain.reactgenerate.controller;
 import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateApprovalResponse;
 import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateRequest;
 import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateResponse;
+import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateSearchRequest;
 import com.example.admin_demo.domain.reactgenerate.dto.RenderErrorRequest;
 import com.example.admin_demo.domain.reactgenerate.service.ReactGenerateService;
 import com.example.admin_demo.global.dto.ApiResponse;
+import com.example.admin_demo.global.util.ExcelExportUtil;
 import com.example.admin_demo.global.util.SecurityUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -43,6 +50,46 @@ public class ReactGenerateController {
     public ResponseEntity<ApiResponse<ReactGenerateApprovalResponse>> approve(@PathVariable String id) {
         String currentUserId = SecurityUtil.getCurrentUserId();
         return ResponseEntity.ok(ApiResponse.success(reactGenerateService.approve(id, currentUserId)));
+    }
+
+    /**
+     * 검색 조건에 맞는 React 코드 생성 이력 목록을 페이지네이션 형태로 조회한다.
+     *
+     * @param req 검색 조건 (status, createUserId, fromDate, toDate, page, size)
+     * @return list, totalCount, page, size
+     */
+    @GetMapping("/history")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> getHistory(ReactGenerateSearchRequest req) {
+        return ResponseEntity.ok(ApiResponse.success(reactGenerateService.getHistory(req)));
+    }
+
+    /**
+     * 검색 조건에 맞는 이력 전체를 엑셀 파일로 내보낸다.
+     *
+     * @param req 검색 조건 (status, createUserId, fromDate, toDate)
+     * @return xlsx 파일
+     */
+    @GetMapping("/history/export")
+    public ResponseEntity<byte[]> exportHistory(ReactGenerateSearchRequest req) {
+        byte[] excelBytes = reactGenerateService.exportHistory(req);
+        String fileName = ExcelExportUtil.generateFileName("ReactGenerateHistory", LocalDate.now());
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentDisposition(ContentDisposition.attachment().filename(fileName).build());
+        headers.setContentType(
+                MediaType.parseMediaType(
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
+        return ResponseEntity.ok().headers(headers).body(excelBytes);
+    }
+
+    /**
+     * CODE_ID로 React 코드 생성 이력 상세를 조회한다.
+     *
+     * @param id 조회할 CODE_ID
+     * @return 코드·미리보기 등 상세 정보
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<ReactGenerateResponse>> getById(@PathVariable String id) {
+        return ResponseEntity.ok(ApiResponse.success(reactGenerateService.getById(id)));
     }
 
     /**

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/controller/ReactGenerateController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/controller/ReactGenerateController.java
@@ -42,7 +42,8 @@ public class ReactGenerateController {
     @PostMapping("/{id}/request-approval")
     @PreAuthorize("hasAuthority('REACT_GENERATE:W')")
     public ResponseEntity<ApiResponse<ReactGenerateApprovalResponse>> requestApproval(@PathVariable String id) {
-        return ResponseEntity.ok(ApiResponse.success(reactGenerateService.requestApproval(id)));
+        String currentUserId = SecurityUtil.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(reactGenerateService.requestApproval(id, currentUserId)));
     }
 
     @PostMapping("/{id}/approve")
@@ -74,10 +75,10 @@ public class ReactGenerateController {
         byte[] excelBytes = reactGenerateService.exportHistory(req);
         String fileName = ExcelExportUtil.generateFileName("ReactGenerateHistory", LocalDate.now());
         HttpHeaders headers = new HttpHeaders();
-        headers.setContentDisposition(ContentDisposition.attachment().filename(fileName).build());
+        headers.setContentDisposition(
+                ContentDisposition.attachment().filename(fileName).build());
         headers.setContentType(
-                MediaType.parseMediaType(
-                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
+                MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
         return ResponseEntity.ok().headers(headers).body(excelBytes);
     }
 

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactGenerateHistoryResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactGenerateHistoryResponse.java
@@ -1,0 +1,38 @@
+package com.example.admin_demo.domain.reactgenerate.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * React 코드 생성 이력 목록 조회 응답 DTO.
+ *
+ * <p>목록 화면에서 행 1건을 표현한다. CLOB 컬럼(REACT_CODE, REQUIREMENTS 등)은
+ * 크기가 클 수 있으므로 목록 쿼리에서 제외하고 단건 조회({@link ReactGenerateResponse})
+ * 시에만 가져온다.
+ *
+ * <p>MyBatis resultType 매핑을 위해 Setter가 필요하다.
+ */
+@Getter
+@Setter
+public class ReactGenerateHistoryResponse {
+
+    private String codeId;
+
+    /** 코드 생성 시 입력한 Figma URL. 목록에서는 말줄임 처리된다. */
+    private String figmaUrl;
+
+    /** 현재 처리 상태 (GENERATED / PENDING_APPROVAL / APPROVED / FAILED). */
+    private String status;
+
+    /** 코드 생성 요청자 ID. */
+    private String createUserId;
+
+    /** 생성 일시 (yyyyMMddHHmmss). 화면 표시 시 yyyy-MM-dd HH:mm으로 변환한다. */
+    private String createDtime;
+
+    /** 승인자 ID. 미승인 상태이면 null. */
+    private String approvalUserId;
+
+    /** 승인 일시 (yyyyMMddHHmmss). 미승인 상태이면 null. */
+    private String approvalDtime;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactGenerateResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactGenerateResponse.java
@@ -17,7 +17,10 @@ public class ReactGenerateResponse {
     private String reactCode;
     private String failReason;
     private String status;
+    private String createUserId;
     private String createDtime;
+    private String approvalUserId;
+    private String approvalDtime;
 
     /** WARN 레벨 보안 패턴 탐지 목록 — 코드는 통과하되 프론트엔드에 경고로 표시 */
     private List<String> validationWarnings;

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactGenerateSearchRequest.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactGenerateSearchRequest.java
@@ -6,9 +6,8 @@ import lombok.Setter;
 /**
  * React 코드 생성 이력 목록 검색 조건 DTO.
  *
- * <p>날짜 범위는 yyyyMMdd 형식으로 입력받으며, MyBatis XML에서
- * {@code fromDate || '000000'}, {@code toDate || '235959'} 로 확장되어
- * DB 저장 형식(yyyyMMddHHmmss)과 비교된다.
+ * <p>날짜 범위는 yyyyMMdd 형식으로 입력받으며, {@link #getFromDtime()}/{@link #getToDtime()}을 통해
+ * DB 저장 형식(yyyyMMddHHmmss)으로 변환되어 MyBatis XML에서 사용된다.
  */
 @Getter
 @Setter
@@ -25,6 +24,26 @@ public class ReactGenerateSearchRequest {
 
     /** 검색 종료일 (yyyyMMdd). null이면 제한 없음. */
     private String toDate;
+
+    /**
+     * DB 비교용 시작 일시를 반환한다 (yyyyMMddHHmmss).
+     * fromDate가 null이면 null을 반환하여 XML 조건에서 제외된다.
+     *
+     * @return yyyyMMdd000000 형식, fromDate가 null이면 null
+     */
+    public String getFromDtime() {
+        return fromDate != null && !fromDate.isBlank() ? fromDate + "000000" : null;
+    }
+
+    /**
+     * DB 비교용 종료 일시를 반환한다 (yyyyMMddHHmmss).
+     * toDate가 null이면 null을 반환하여 XML 조건에서 제외된다.
+     *
+     * @return yyyyMMdd235959 형식, toDate가 null이면 null
+     */
+    public String getToDtime() {
+        return toDate != null && !toDate.isBlank() ? toDate + "235959" : null;
+    }
 
     /** 현재 페이지 번호 (1-based). */
     private int page = 1;

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactGenerateSearchRequest.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactGenerateSearchRequest.java
@@ -29,7 +29,7 @@ public class ReactGenerateSearchRequest {
     /** 현재 페이지 번호 (1-based). */
     private int page = 1;
 
-    /** 페이지당 표시 건수. 기본값 20. */
+    /** 페이지당 표시 건수. 기본값 10. */
     private int size = 10;
 
     /**

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactGenerateSearchRequest.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactGenerateSearchRequest.java
@@ -1,0 +1,54 @@
+package com.example.admin_demo.domain.reactgenerate.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * React 코드 생성 이력 목록 검색 조건 DTO.
+ *
+ * <p>날짜 범위는 yyyyMMdd 형식으로 입력받으며, MyBatis XML에서
+ * {@code fromDate || '000000'}, {@code toDate || '235959'} 로 확장되어
+ * DB 저장 형식(yyyyMMddHHmmss)과 비교된다.
+ */
+@Getter
+@Setter
+public class ReactGenerateSearchRequest {
+
+    /** 상태 필터 (GENERATED / PENDING_APPROVAL / APPROVED / FAILED). null이면 전체 조회. */
+    private String status;
+
+    /** 생성자 ID 부분 일치 검색. null이면 전체 조회. */
+    private String createUserId;
+
+    /** 검색 시작일 (yyyyMMdd). null이면 제한 없음. */
+    private String fromDate;
+
+    /** 검색 종료일 (yyyyMMdd). null이면 제한 없음. */
+    private String toDate;
+
+    /** 현재 페이지 번호 (1-based). */
+    private int page = 1;
+
+    /** 페이지당 표시 건수. 기본값 20. */
+    private int size = 10;
+
+    /**
+     * Oracle ROWNUM 페이지네이션에서 시작 행 번호(0-based)를 반환한다.
+     * 외부 쿼리의 {@code WHERE RNUM > offset} 조건에 사용한다.
+     *
+     * @return (page - 1) * size
+     */
+    public int getOffset() {
+        return (page - 1) * size;
+    }
+
+    /**
+     * Oracle ROWNUM 페이지네이션에서 끝 행 번호를 반환한다.
+     * 내부 쿼리의 {@code WHERE ROWNUM <= endRow} 조건에 사용한다.
+     *
+     * @return page * size
+     */
+    public int getEndRow() {
+        return page * size;
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/figma/FigmaDesignExtractor.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/figma/FigmaDesignExtractor.java
@@ -29,6 +29,9 @@ public class FigmaDesignExtractor {
     /** 노드 트리 탐색 최대 깊이. 루트는 0, 직계 자식은 1 */
     private static final int MAX_DEPTH = 4;
 
+    /** 깊이 레벨당 처리할 최대 노드 수. 복잡한 Figma 파일의 메모리 폭발 방지 */
+    private static final int MAX_NODES_PER_LEVEL = 50;
+
     /**
      * Figma API 응답에서 디자인 컨텍스트를 추출한다.
      *
@@ -94,6 +97,9 @@ public class FigmaDesignExtractor {
     /**
      * 하위 노드 목록을 재귀적으로 탐색하여 {@link FigmaNodeSummary} 목록으로 변환한다.
      *
+     * <p>깊이 제한({@code MAX_DEPTH})과 레벨당 노드 수 제한({@code MAX_NODES_PER_LEVEL})을 모두 적용하여
+     * 복잡한 Figma 파일에서 메모리 과다 사용을 방지한다.
+     *
      * @param nodes 변환할 노드 목록
      * @param depth 현재 탐색 깊이 (MAX_DEPTH 초과 시 빈 목록 반환)
      */
@@ -101,7 +107,17 @@ public class FigmaDesignExtractor {
         if (nodes == null || nodes.isEmpty() || depth > MAX_DEPTH) {
             return Collections.emptyList();
         }
-        return nodes.stream().map(node -> toSummary(node, depth)).collect(Collectors.toList());
+        List<FigmaNode> targets = nodes;
+        if (nodes.size() > MAX_NODES_PER_LEVEL) {
+            log.warn(
+                    "depth={} 노드 수({})가 제한({})을 초과하여 앞 {}개만 처리합니다.",
+                    depth,
+                    nodes.size(),
+                    MAX_NODES_PER_LEVEL,
+                    MAX_NODES_PER_LEVEL);
+            targets = nodes.subList(0, MAX_NODES_PER_LEVEL);
+        }
+        return targets.stream().map(node -> toSummary(node, depth)).collect(Collectors.toList());
     }
 
     /** 단일 {@link FigmaNode}를 {@link FigmaNodeSummary}로 변환한다. */

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/figma/client/FigmaApiClient.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/figma/client/FigmaApiClient.java
@@ -82,8 +82,9 @@ public class FigmaApiClient {
         } catch (HttpClientErrorException e) {
             int status = e.getStatusCode().value();
             if (status == 401 || status == 403) {
-                log.error("Figma API 인증 실패 — status: {}", status);
-                throw new InternalException("Figma API 인증에 실패했습니다. FIGMA_ACCESS_TOKEN을 확인하세요.");
+                // 에러 메시지에 환경변수명 등 내부 설정 정보를 노출하지 않는다
+                log.error("Figma API 인증 실패 — status: {}. FIGMA_ACCESS_TOKEN 설정을 확인하세요.", status);
+                throw new InternalException("Figma API 인증에 실패했습니다. 토큰 설정을 확인하세요.");
             }
             if (status == 404) {
                 log.warn("Figma 파일·노드 없음 — fileKey: {}, nodeId: {}", fileKey, nodeId);

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/mapper/ReactGenerateMapper.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/mapper/ReactGenerateMapper.java
@@ -1,6 +1,9 @@
 package com.example.admin_demo.domain.reactgenerate.mapper;
 
+import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateHistoryResponse;
 import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateResponse;
+import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateSearchRequest;
+import java.util.List;
 import org.apache.ibatis.annotations.Param;
 
 /**
@@ -37,4 +40,16 @@ public interface ReactGenerateMapper {
 
     /** 렌더링 실패 또는 코드 생성 실패 시 STATUS를 FAILED로, FAIL_REASON을 기록한다. */
     void updateToFailed(@Param("codeId") String codeId, @Param("failReason") String failReason);
+
+    /**
+     * 검색 조건에 맞는 이력 목록을 생성일시 내림차순으로 조회한다.
+     * CLOB 컬럼(REACT_CODE 등)은 제외하고 목록 표시에 필요한 컬럼만 반환한다.
+     */
+    List<ReactGenerateHistoryResponse> selectList(@Param("req") ReactGenerateSearchRequest req);
+
+    /** 검색 조건에 맞는 전체 건수를 반환한다 (페이지네이션용). */
+    int selectCount(@Param("req") ReactGenerateSearchRequest req);
+
+    /** 검색 조건에 맞는 전체 목록을 페이지네이션 없이 조회한다 (엑셀 내보내기용). */
+    List<ReactGenerateHistoryResponse> selectAllForExport(@Param("req") ReactGenerateSearchRequest req);
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactGenerateService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactGenerateService.java
@@ -385,8 +385,6 @@ public class ReactGenerateService {
      * @return list(목록), totalCount(전체 건수), page, size
      */
     public Map<String, Object> getHistory(ReactGenerateSearchRequest req) {
-        // LIKE 검색 시 SQL 와일드카드(%, _)를 이스케이프하여 의도치 않은 전체 매칭을 방지
-        req.setCreateUserId(escapeLike(req.getCreateUserId()));
         List<ReactGenerateHistoryResponse> list = reactGenerateMapper.selectList(req);
         int totalCount = reactGenerateMapper.selectCount(req);
         return Map.of("list", list, "totalCount", totalCount, "page", req.getPage(), "size", req.getSize());
@@ -459,15 +457,6 @@ public class ReactGenerateService {
             log.warn("날짜 형식 변환 실패 — dtime: {}", dtime);
             return dtime;
         }
-    }
-
-    /**
-     * LIKE 검색 시 SQL 와일드카드 문자(%, _)를 이스케이프한다.
-     * Oracle ESCAPE '\' 절과 함께 사용되며, null이면 그대로 반환한다.
-     */
-    private String escapeLike(String value) {
-        if (value == null) return null;
-        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
     }
 
     /** 영문 상태 코드를 한글 레이블로 변환한다. */

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactGenerateService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactGenerateService.java
@@ -16,14 +16,14 @@ import com.example.admin_demo.domain.reactgenerate.figma.client.FigmaNodeRespons
 import com.example.admin_demo.domain.reactgenerate.mapper.ReactGenerateMapper;
 import com.example.admin_demo.domain.reactgenerate.validator.CodeValidationResult;
 import com.example.admin_demo.domain.reactgenerate.validator.CodeValidator;
+import com.example.admin_demo.global.exception.InternalException;
 import com.example.admin_demo.global.exception.InvalidInputException;
 import com.example.admin_demo.global.exception.NotFoundException;
 import com.example.admin_demo.global.exception.base.BaseException;
 import com.example.admin_demo.global.log.event.ErrorLogEvent;
-import com.example.admin_demo.global.util.TraceIdUtil;
-import com.example.admin_demo.global.exception.InternalException;
 import com.example.admin_demo.global.util.ExcelColumnDefinition;
 import com.example.admin_demo.global.util.ExcelExportUtil;
+import com.example.admin_demo.global.util.TraceIdUtil;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -293,13 +293,27 @@ public class ReactGenerateService {
     }
 
     /**
-     * 생성된 코드를 관리자 승인 요청 상태로 변경한다.
+     * 생성된 코드를 승인 요청 상태로 변경한다.
+     *
+     * <p>클라이언트 측 버튼 노출 조건(작성자 여부)과 별개로,
+     * 서버에서도 요청자가 코드 작성자인지 검증하여 API 직접 호출 우회를 방지한다.
+     *
+     * @param id            승인 요청할 코드 ID
+     * @param requestUserId 요청자 ID (로그인 사용자)
+     * @throws InvalidInputException 요청자가 코드 작성자가 아닐 때
      */
-    public ReactGenerateApprovalResponse requestApproval(String id) {
-        requireExists(id);
+    public ReactGenerateApprovalResponse requestApproval(String id, String requestUserId) {
+        ReactGenerateResponse existing = reactGenerateMapper.selectById(id);
+        if (existing == null) {
+            throw new NotFoundException("생성 결과를 찾을 수 없습니다. codeId=" + id);
+        }
+        // 작성자 본인만 승인 요청 가능 — 클라이언트 우회 방지
+        if (!requestUserId.equals(existing.getCreateUserId())) {
+            throw new InvalidInputException("코드 작성자만 승인 요청할 수 있습니다.");
+        }
 
         reactGenerateMapper.updateStatus(id, ReactGenerateStatus.PENDING_APPROVAL.name(), null, null);
-        log.info("승인 요청 — codeId: {}", id);
+        log.info("승인 요청 — codeId: {}, requestUserId: {}", id, requestUserId);
 
         return ReactGenerateApprovalResponse.builder()
                 .codeId(id)
@@ -311,7 +325,7 @@ public class ReactGenerateService {
      * 관리자가 생성 코드를 승인한다.
      */
     public ReactGenerateApprovalResponse approve(String id, String approvedBy) {
-        requireExists(id);
+        requireExists(id); // 존재 여부 검증
 
         String now = LocalDateTime.now().format(FORMATTER);
         reactGenerateMapper.updateStatus(id, ReactGenerateStatus.APPROVED.name(), approvedBy, now);
@@ -371,6 +385,8 @@ public class ReactGenerateService {
      * @return list(목록), totalCount(전체 건수), page, size
      */
     public Map<String, Object> getHistory(ReactGenerateSearchRequest req) {
+        // LIKE 검색 시 SQL 와일드카드(%, _)를 이스케이프하여 의도치 않은 전체 매칭을 방지
+        req.setCreateUserId(escapeLike(req.getCreateUserId()));
         List<ReactGenerateHistoryResponse> list = reactGenerateMapper.selectList(req);
         int totalCount = reactGenerateMapper.selectCount(req);
         return Map.of("list", list, "totalCount", totalCount, "page", req.getPage(), "size", req.getSize());
@@ -399,11 +415,13 @@ public class ReactGenerateService {
      * @throws InvalidInputException 결과 건수가 최대 행 수를 초과할 때
      */
     public byte[] exportHistory(ReactGenerateSearchRequest req) {
-        List<ReactGenerateHistoryResponse> data = reactGenerateMapper.selectAllForExport(req);
-        if (!ExcelExportUtil.isWithinLimit(data.size())) {
+        // 전체 데이터 로드 전 건수 먼저 확인 → 초과 시 즉시 예외로 OOM 방지
+        int totalCount = reactGenerateMapper.selectCount(req);
+        if (!ExcelExportUtil.isWithinLimit(totalCount)) {
             throw new InvalidInputException(
-                    "엑셀 다운로드 최대 행 수(" + ExcelExportUtil.MAX_ROW_LIMIT + ")를 초과했습니다: " + data.size());
+                    "엑셀 다운로드 최대 행 수(" + ExcelExportUtil.MAX_ROW_LIMIT + ")를 초과했습니다: " + totalCount);
         }
+        List<ReactGenerateHistoryResponse> data = reactGenerateMapper.selectAllForExport(req);
 
         List<ExcelColumnDefinition> columns = List.of(
                 new ExcelColumnDefinition("Figma URL", 50, "figmaUrl"),
@@ -434,9 +452,22 @@ public class ReactGenerateService {
 
     /** DB 저장 형식(yyyyMMddHHmmss)을 사람이 읽기 쉬운 형식(yyyy-MM-dd HH:mm)으로 변환한다. */
     private String formatDtimeForExcel(String dtime) {
-        if (dtime == null || dtime.length() < 12) return dtime != null ? dtime : "";
-        return dtime.substring(0, 4) + "-" + dtime.substring(4, 6) + "-" + dtime.substring(6, 8)
-                + " " + dtime.substring(8, 10) + ":" + dtime.substring(10, 12);
+        if (dtime == null || dtime.length() != 14) return dtime != null ? dtime : "";
+        try {
+            return LocalDateTime.parse(dtime, FORMATTER).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+        } catch (Exception e) {
+            log.warn("날짜 형식 변환 실패 — dtime: {}", dtime);
+            return dtime;
+        }
+    }
+
+    /**
+     * LIKE 검색 시 SQL 와일드카드 문자(%, _)를 이스케이프한다.
+     * Oracle ESCAPE '\' 절과 함께 사용되며, null이면 그대로 반환한다.
+     */
+    private String escapeLike(String value) {
+        if (value == null) return null;
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
     }
 
     /** 영문 상태 코드를 한글 레이블로 변환한다. */
@@ -452,9 +483,11 @@ public class ReactGenerateService {
     }
 
     /** CODE_ID로 이력을 조회하고, 없으면 NotFoundException을 던진다. */
-    private void requireExists(String id) {
-        if (reactGenerateMapper.selectById(id) == null) {
+    private ReactGenerateResponse requireExists(String id) {
+        ReactGenerateResponse response = reactGenerateMapper.selectById(id);
+        if (response == null) {
             throw new NotFoundException("생성 결과를 찾을 수 없습니다. codeId=" + id);
         }
+        return response;
     }
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactGenerateService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactGenerateService.java
@@ -3,8 +3,10 @@ package com.example.admin_demo.domain.reactgenerate.service;
 import com.example.admin_demo.domain.reactgenerate.ai.client.ClaudeApiClient;
 import com.example.admin_demo.domain.reactgenerate.ai.prompt.PromptBuilder;
 import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateApprovalResponse;
+import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateHistoryResponse;
 import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateRequest;
 import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateResponse;
+import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateSearchRequest;
 import com.example.admin_demo.domain.reactgenerate.enums.ReactGenerateStatus;
 import com.example.admin_demo.domain.reactgenerate.figma.FigmaDesignContext;
 import com.example.admin_demo.domain.reactgenerate.figma.FigmaDesignExtractor;
@@ -19,8 +21,16 @@ import com.example.admin_demo.global.exception.NotFoundException;
 import com.example.admin_demo.global.exception.base.BaseException;
 import com.example.admin_demo.global.log.event.ErrorLogEvent;
 import com.example.admin_demo.global.util.TraceIdUtil;
+import com.example.admin_demo.global.exception.InternalException;
+import com.example.admin_demo.global.util.ExcelColumnDefinition;
+import com.example.admin_demo.global.util.ExcelExportUtil;
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -352,6 +362,93 @@ public class ReactGenerateService {
             log.warn("렌더링 오류로 코드 실패 처리 — codeId: {}, error: {}", codeId, errorMessage);
             reactGenerateMapper.updateToFailed(codeId, errorMessage);
         }
+    }
+
+    /**
+     * 검색 조건에 맞는 이력 목록과 전체 건수를 조회한다.
+     *
+     * @param req 검색 조건 (상태·생성자·날짜 범위·페이지)
+     * @return list(목록), totalCount(전체 건수), page, size
+     */
+    public Map<String, Object> getHistory(ReactGenerateSearchRequest req) {
+        List<ReactGenerateHistoryResponse> list = reactGenerateMapper.selectList(req);
+        int totalCount = reactGenerateMapper.selectCount(req);
+        return Map.of("list", list, "totalCount", totalCount, "page", req.getPage(), "size", req.getSize());
+    }
+
+    /**
+     * CODE_ID로 생성 이력 상세를 조회한다.
+     *
+     * @param codeId 조회할 코드 ID
+     * @return 코드·메타 정보 (reactCode, approvalUserId 등 포함)
+     * @throws NotFoundException 해당 codeId 레코드가 없을 때
+     */
+    public ReactGenerateResponse getById(String codeId) {
+        ReactGenerateResponse response = reactGenerateMapper.selectById(codeId);
+        if (response == null) {
+            throw new NotFoundException("이력을 찾을 수 없습니다. codeId=" + codeId);
+        }
+        return response;
+    }
+
+    /**
+     * 검색 조건에 맞는 전체 이력을 엑셀 파일로 변환하여 반환한다.
+     *
+     * @param req 검색 조건 (페이지네이션 무시, 전체 조회)
+     * @return xlsx 파일의 byte 배열
+     * @throws InvalidInputException 결과 건수가 최대 행 수를 초과할 때
+     */
+    public byte[] exportHistory(ReactGenerateSearchRequest req) {
+        List<ReactGenerateHistoryResponse> data = reactGenerateMapper.selectAllForExport(req);
+        if (!ExcelExportUtil.isWithinLimit(data.size())) {
+            throw new InvalidInputException(
+                    "엑셀 다운로드 최대 행 수(" + ExcelExportUtil.MAX_ROW_LIMIT + ")를 초과했습니다: " + data.size());
+        }
+
+        List<ExcelColumnDefinition> columns = List.of(
+                new ExcelColumnDefinition("Figma URL", 50, "figmaUrl"),
+                new ExcelColumnDefinition("상태", 15, "status"),
+                new ExcelColumnDefinition("생성자", 15, "createUserId"),
+                new ExcelColumnDefinition("생성일시", 20, "createDtime"),
+                new ExcelColumnDefinition("승인자", 15, "approvalUserId"),
+                new ExcelColumnDefinition("승인일시", 20, "approvalDtime"));
+
+        List<Map<String, Object>> rows = new ArrayList<>();
+        for (ReactGenerateHistoryResponse item : data) {
+            Map<String, Object> row = new HashMap<>();
+            row.put("figmaUrl", item.getFigmaUrl());
+            row.put("status", translateStatus(item.getStatus()));
+            row.put("createUserId", item.getCreateUserId());
+            row.put("createDtime", formatDtimeForExcel(item.getCreateDtime()));
+            row.put("approvalUserId", item.getApprovalUserId());
+            row.put("approvalDtime", formatDtimeForExcel(item.getApprovalDtime()));
+            rows.add(row);
+        }
+
+        try {
+            return ExcelExportUtil.createWorkbook("React 코드 생성 이력", columns, rows);
+        } catch (IOException e) {
+            throw new InternalException("엑셀 파일 생성 중 오류가 발생했습니다", e);
+        }
+    }
+
+    /** DB 저장 형식(yyyyMMddHHmmss)을 사람이 읽기 쉬운 형식(yyyy-MM-dd HH:mm)으로 변환한다. */
+    private String formatDtimeForExcel(String dtime) {
+        if (dtime == null || dtime.length() < 12) return dtime != null ? dtime : "";
+        return dtime.substring(0, 4) + "-" + dtime.substring(4, 6) + "-" + dtime.substring(6, 8)
+                + " " + dtime.substring(8, 10) + ":" + dtime.substring(10, 12);
+    }
+
+    /** 영문 상태 코드를 한글 레이블로 변환한다. */
+    private String translateStatus(String status) {
+        if (status == null) return "";
+        return switch (status) {
+            case "GENERATED" -> "생성 완료";
+            case "PENDING_APPROVAL" -> "승인 대기";
+            case "APPROVED" -> "승인 완료";
+            case "FAILED" -> "실패";
+            default -> status;
+        };
     }
 
     /** CODE_ID로 이력을 조회하고, 없으면 NotFoundException을 던진다. */

--- a/admin/src/main/java/com/example/admin_demo/global/page/controller/PageController.java
+++ b/admin/src/main/java/com/example/admin_demo/global/page/controller/PageController.java
@@ -326,11 +326,16 @@ public class PageController {
         return resolveView(request, "pages/message-parsing-json/message-parsing-json :: content", model);
     }
 
-    // ── React 플랫폼 ── react_generate
+    // ── React 플랫폼 ── react_generate, react_generate_his
 
     @GetMapping("/react-generate")
     public String reactGenerate(HttpServletRequest request, Model model) {
         return resolveView(request, "pages/react-generate/react-generate :: content", model);
+    }
+
+    @GetMapping("/react-generate-his")
+    public String reactGenerateHis(HttpServletRequest request, Model model) {
+        return resolveView(request, "pages/react-generate-his/react-generate-his :: content", model);
     }
 
     // ── 서비스 관리 ── v3_neb_service_base_info, v3_neb_biz_component, v3_validator_component,

--- a/admin/src/main/resources/mapper/oracle/reactgenerate/ReactGenerateMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/reactgenerate/ReactGenerateMapper.xml
@@ -57,8 +57,8 @@
                 AND STATUS = #{req.status}
             </if>
             <if test="req.createUserId != null and req.createUserId != ''">
-                <!-- 부분 일치 검색 -->
-                AND CREATE_USER_ID LIKE '%' || #{req.createUserId} || '%'
+                <!-- 부분 일치 검색. 서비스에서 %, _ 이스케이프 처리 후 전달됨 -->
+                AND CREATE_USER_ID LIKE '%' || #{req.createUserId} || '%' ESCAPE '\'
             </if>
             <if test="req.fromDate != null and req.fromDate != ''">
                 <!-- DB 저장 형식이 yyyyMMddHHmmss이므로 시작일의 00:00:00부터 포함 -->

--- a/admin/src/main/resources/mapper/oracle/reactgenerate/ReactGenerateMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/reactgenerate/ReactGenerateMapper.xml
@@ -57,16 +57,16 @@
                 AND STATUS = #{req.status}
             </if>
             <if test="req.createUserId != null and req.createUserId != ''">
-                <!-- 부분 일치 검색. 서비스에서 %, _ 이스케이프 처리 후 전달됨 -->
+                <!-- 부분 일치 검색. ESCAPE '\' 절로 와일드카드(%, _) 문자를 리터럴로 처리 -->
                 AND CREATE_USER_ID LIKE '%' || #{req.createUserId} || '%' ESCAPE '\'
             </if>
-            <if test="req.fromDate != null and req.fromDate != ''">
-                <!-- DB 저장 형식이 yyyyMMddHHmmss이므로 시작일의 00:00:00부터 포함 -->
-                AND CREATE_DTIME &gt;= #{req.fromDate} || '000000'
+            <if test="req.fromDtime != null">
+                <!-- Java에서 yyyyMMdd → yyyyMMddHHmmss 변환 후 전달 (fromDate + '000000') -->
+                AND CREATE_DTIME &gt;= #{req.fromDtime}
             </if>
-            <if test="req.toDate != null and req.toDate != ''">
-                <!-- 종료일의 23:59:59까지 포함 -->
-                AND CREATE_DTIME &lt;= #{req.toDate} || '235959'
+            <if test="req.toDtime != null">
+                <!-- Java에서 yyyyMMdd → yyyyMMddHHmmss 변환 후 전달 (toDate + '235959') -->
+                AND CREATE_DTIME &lt;= #{req.toDtime}
             </if>
         </where>
     </sql>

--- a/admin/src/main/resources/mapper/oracle/reactgenerate/ReactGenerateMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/reactgenerate/ReactGenerateMapper.xml
@@ -39,12 +39,36 @@
     <!-- ==================== SELECT ==================== -->
 
     <sql id="selectColumns">
-        CODE_ID        AS codeId,
-        FIGMA_URL      AS figmaUrl,
-        REACT_CODE     AS reactCode,
-        FAIL_REASON    AS failReason,
-        STATUS         AS status,
-        CREATE_DTIME   AS createDtime
+        CODE_ID          AS codeId,
+        FIGMA_URL        AS figmaUrl,
+        REACT_CODE       AS reactCode,
+        FAIL_REASON      AS failReason,
+        STATUS           AS status,
+        CREATE_USER_ID   AS createUserId,
+        CREATE_DTIME     AS createDtime,
+        APPROVAL_USER_ID AS approvalUserId,
+        APPROVAL_DTIME   AS approvalDtime
+    </sql>
+
+    <!-- 목록 조회에 사용하는 WHERE 조건 Fragment (selectList/selectCount 공유) -->
+    <sql id="historyWhereConditions">
+        <where>
+            <if test="req.status != null and req.status != ''">
+                AND STATUS = #{req.status}
+            </if>
+            <if test="req.createUserId != null and req.createUserId != ''">
+                <!-- 부분 일치 검색 -->
+                AND CREATE_USER_ID LIKE '%' || #{req.createUserId} || '%'
+            </if>
+            <if test="req.fromDate != null and req.fromDate != ''">
+                <!-- DB 저장 형식이 yyyyMMddHHmmss이므로 시작일의 00:00:00부터 포함 -->
+                AND CREATE_DTIME &gt;= #{req.fromDate} || '000000'
+            </if>
+            <if test="req.toDate != null and req.toDate != ''">
+                <!-- 종료일의 23:59:59까지 포함 -->
+                AND CREATE_DTIME &lt;= #{req.toDate} || '235959'
+            </if>
+        </where>
     </sql>
 
     <select id="selectById" resultType="com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateResponse">
@@ -52,6 +76,56 @@
             <include refid="selectColumns"/>
         FROM FWK_RPS_CODE_HIS
         WHERE CODE_ID = #{codeId,jdbcType=VARCHAR}
+    </select>
+
+    <!-- ==================== SELECT LIST ==================== -->
+
+    <!--
+        ROWNUM 이중 서브쿼리 페이지네이션 (프로젝트 전체 표준 방식).
+        - 내부 INNER_QRY: 정렬 후 endRow까지 ROWNUM 필터링
+        - 외부 쿼리: offset(0-based) 이후 행만 반환
+    -->
+    <select id="selectList" resultType="com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateHistoryResponse">
+        SELECT *
+        FROM (
+            SELECT INNER_QRY.*, ROWNUM AS RNUM
+            FROM (
+                SELECT
+                    CODE_ID          AS codeId,
+                    FIGMA_URL        AS figmaUrl,
+                    STATUS           AS status,
+                    CREATE_USER_ID   AS createUserId,
+                    CREATE_DTIME     AS createDtime,
+                    APPROVAL_USER_ID AS approvalUserId,
+                    APPROVAL_DTIME   AS approvalDtime
+                FROM FWK_RPS_CODE_HIS
+                <include refid="historyWhereConditions"/>
+                ORDER BY CREATE_DTIME DESC
+            ) INNER_QRY
+            WHERE ROWNUM <![CDATA[<=]]> #{req.endRow}
+        )
+        WHERE RNUM <![CDATA[>]]> #{req.offset}
+    </select>
+
+    <select id="selectCount" resultType="int">
+        SELECT COUNT(*)
+        FROM FWK_RPS_CODE_HIS
+        <include refid="historyWhereConditions"/>
+    </select>
+
+    <!-- 엑셀 내보내기용 전체 조회 (페이지네이션 없음) -->
+    <select id="selectAllForExport" resultType="com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateHistoryResponse">
+        SELECT
+            CODE_ID          AS codeId,
+            FIGMA_URL        AS figmaUrl,
+            STATUS           AS status,
+            CREATE_USER_ID   AS createUserId,
+            CREATE_DTIME     AS createDtime,
+            APPROVAL_USER_ID AS approvalUserId,
+            APPROVAL_DTIME   AS approvalDtime
+        FROM FWK_RPS_CODE_HIS
+        <include refid="historyWhereConditions"/>
+        ORDER BY CREATE_DTIME DESC
     </select>
 
     <!-- ==================== UPDATE ==================== -->

--- a/admin/src/main/resources/menu-resource-permissions.yml
+++ b/admin/src/main/resources/menu-resource-permissions.yml
@@ -150,3 +150,6 @@ menu-resource:
     v3_react_generate:
       R: REACT_GENERATE:R
       W: REACT_GENERATE:W
+    v3_react_generate_his:
+      R: REACT_GENERATE:R
+      W: REACT_GENERATE:W

--- a/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-modal.html
+++ b/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-modal.html
@@ -98,7 +98,8 @@
                                     <iframe id="detailPreviewFrame"
                                             src="/preview-app/index.html"
                                             title="화면 미리보기"
-                                            style="width:100%; height:460px; border:none; border-radius: 0 0 4px 4px;">
+                                            style="width:100%; height:460px; border:none; border-radius: 0 0 4px 4px;"
+                                            sandbox="allow-scripts allow-same-origin">
                                     </iframe>
                                 </div>
 

--- a/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-modal.html
+++ b/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-modal.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<!-- React 코드 생성 이력 Detail Modal Fragment -->
+<div th:fragment="modal">
+    <div class="modal fade" id="reactHisDetailModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header py-2">
+                    <h6 class="modal-title">
+                        <i class="bi bi-code-slash text-primary me-1"></i>
+                        React 코드 생성 이력 상세
+                    </h6>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+
+                    <!-- 로딩 인디케이터 -->
+                    <div id="detailLoading" class="text-center py-4">
+                        <div class="spinner-border spinner-border-sm text-primary me-2" role="status"
+                             aria-hidden="true"></div>
+                        <span class="text-muted">불러오는 중...</span>
+                    </div>
+
+                    <!-- 상세 내용 (로딩 완료 후 표시) -->
+                    <div id="detailContent" class="d-none">
+
+                        <!-- ── 상세 정보 섹션 ── -->
+                        <h6 class="fw-semibold small text-uppercase text-muted mb-2">
+                            <i class="bi bi-info-circle me-1"></i>상세 정보
+                        </h6>
+                        <div class="table-responsive mb-3">
+                            <table class="table table-sm table-bordered small mb-0">
+                                <tbody>
+                                    <tr>
+                                        <th class="table-light text-nowrap" style="width:110px;">Figma URL</th>
+                                        <td colspan="3">
+                                            <a id="detailFigmaUrl" href="#" target="_blank" class="text-break">—</a>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="table-light text-nowrap">상태</th>
+                                        <td colspan="3"><span id="detailStatusBadge" class="badge"></span></td>
+                                    </tr>
+                                    <tr>
+                                        <th class="table-light text-nowrap">생성자</th>
+                                        <td id="detailCreateUserId"></td>
+                                        <th class="table-light text-nowrap" style="width:110px;">생성일시</th>
+                                        <td id="detailCreateDtime"></td>
+                                    </tr>
+                                    <tr>
+                                        <th class="table-light text-nowrap">승인자</th>
+                                        <td id="detailApprovalUserId"></td>
+                                        <th class="table-light text-nowrap">승인일시</th>
+                                        <td id="detailApprovalDtime"></td>
+                                    </tr>
+                                    <!-- 실패 사유: status가 FAILED인 경우에만 노출 -->
+                                    <tr id="detailFailReasonRow" class="d-none">
+                                        <th class="table-light text-nowrap text-danger">실패 사유</th>
+                                        <td colspan="3" class="text-danger" id="detailFailReason"></td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+
+                        <!-- ── 미리보기 섹션: reactCode가 있을 때만 노출 ── -->
+                        <div id="detailPreviewSection">
+                            <h6 class="fw-semibold small text-uppercase text-muted mb-2">
+                                <i class="bi bi-display me-1"></i>미리보기
+                            </h6>
+
+                            <ul class="nav nav-tabs" id="detailTabs" role="tablist">
+                                <li class="nav-item" role="presentation">
+                                    <button class="nav-link active"
+                                            id="detailTab-screen"
+                                            data-bs-toggle="tab"
+                                            data-bs-target="#detailScreenPreview"
+                                            type="button"
+                                            role="tab">
+                                        <i class="bi bi-display me-1"></i>화면 미리보기
+                                    </button>
+                                </li>
+                                <li class="nav-item" role="presentation">
+                                    <button class="nav-link"
+                                            id="detailTab-code"
+                                            data-bs-toggle="tab"
+                                            data-bs-target="#detailCodePreview"
+                                            type="button"
+                                            role="tab">
+                                        <i class="bi bi-file-code me-1"></i>코드 미리보기
+                                    </button>
+                                </li>
+                            </ul>
+
+                            <div class="tab-content border border-top-0 rounded-bottom">
+                                <!-- 화면 미리보기 탭 -->
+                                <div class="tab-pane fade show active p-0" id="detailScreenPreview" role="tabpanel">
+                                    <iframe id="detailPreviewFrame"
+                                            src="/preview-app/index.html"
+                                            title="화면 미리보기"
+                                            style="width:100%; height:460px; border:none; border-radius: 0 0 4px 4px;">
+                                    </iframe>
+                                </div>
+
+                                <!-- 코드 미리보기 탭 -->
+                                <div class="tab-pane fade" id="detailCodePreview" role="tabpanel">
+                                    <div class="position-relative">
+                                        <button class="btn btn-sm btn-outline-secondary position-absolute top-0 end-0 m-2"
+                                                id="detailBtnCopyCode" title="코드 복사">
+                                            <i class="bi bi-clipboard"></i>
+                                        </button>
+                                        <pre id="detailCodeDisplay"
+                                             class="bg-dark text-light p-4 m-0 rounded-bottom"
+                                             style="overflow-x:auto; max-height:460px; font-size:0.85rem; white-space:pre-wrap;"></pre>
+                                    </div>
+                                </div>
+                            </div>
+                        </div><!-- /detailPreviewSection -->
+
+                    </div><!-- /detailContent -->
+                </div>
+
+                <div class="modal-footer py-2">
+                    <!-- 승인 요청 버튼: 쓰기 권한이 있고 로그인 사용자가 작성자인 경우에만 JS에서 노출 (기본 hidden) -->
+                    <button type="button" class="btn btn-outline-warning btn-sm d-none" id="detailBtnRequestApproval">
+                        <i class="bi bi-send me-1"></i>승인 요청
+                    </button>
+                    <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">닫기</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-script.html
+++ b/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-script.html
@@ -1,0 +1,446 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<th:block th:fragment="script">
+<script th:inline="javascript">
+    const HAS_REACT_WRITE = /*[[${userAuthorities != null && userAuthorities.contains('REACT_GENERATE:W')}]]*/ false;
+    // 현재 로그인 사용자 ID — 승인 요청 버튼 노출 여부 판단에 사용
+    const CURRENT_USER_ID = /*[[${currentUserId}]]*/ '';
+
+    // ─── 상태 배지 정의 ────────────────────────────────────────
+    const STATUS_LABEL = {
+        GENERATED:        { text: '생성 완료',  cls: 'bg-secondary' },
+        PENDING_APPROVAL: { text: '승인 대기',  cls: 'bg-warning text-dark' },
+        APPROVED:         { text: '승인 완료',  cls: 'bg-success' },
+        FAILED:           { text: '실패',       cls: 'bg-danger' }
+    };
+
+    /** yyyyMMddHHmmss → yyyy-MM-dd HH:mm 형식으로 변환한다. */
+    function formatDtime(dtime) {
+        if (!dtime || dtime.length < 12) return dtime || '';
+        return dtime.substring(0, 4) + '-' +
+               dtime.substring(4, 6) + '-' +
+               dtime.substring(6, 8) + ' ' +
+               dtime.substring(8, 10) + ':' +
+               dtime.substring(10, 12);
+    }
+
+    /** yyyyMMdd → yyyy-MM-dd 형식으로 변환한다. */
+    function formatDate(d) {
+        if (!d || d.length < 8) return d || '';
+        return d.substring(0, 4) + '-' + d.substring(4, 6) + '-' + d.substring(6, 8);
+    }
+
+    // ─── 이력 목록 모듈 ────────────────────────────────────────
+    const ReactGenerateHis = {
+        currentPage: 1,
+        totalItems: 0,
+        itemsPerPage: 10,
+        appliedSearch: {},
+        currentData: [],  // 현재 페이지 데이터 (출력 기능에 사용)
+
+        /** 검색 조건을 수집하고 1페이지부터 재조회한다. */
+        search: function () {
+            // date input은 yyyy-MM-dd로 오므로 하이픈 제거 후 yyyyMMdd로 전달
+            this.appliedSearch = {
+                status:         $('#searchStatus').val(),
+                createUserId:   $('#searchCreateUserId').val().trim(),
+                fromDate:       ($('#searchFromDate').val() || '').replace(/-/g, ''),
+                toDate:         ($('#searchToDate').val() || '').replace(/-/g, '')
+            };
+            this.currentPage = 1;
+            this.load();
+        },
+
+        /** 현재 검색 조건과 페이지 번호로 API를 호출하고 테이블을 갱신한다. */
+        load: function () {
+            const params = Object.assign({}, this.appliedSearch, {
+                page: this.currentPage,
+                size: this.itemsPerPage
+            });
+
+            $.ajax({
+                url: API_BASE_URL + '/react-generate/history',
+                method: 'GET',
+                data: params,
+                success: (res) => {
+                    if (res.success && res.data) {
+                        this.renderTable(res.data.list || [], res.data.totalCount || 0);
+                        this.totalItems = res.data.totalCount || 0;
+                        this.renderPagination();
+                    } else {
+                        this.renderTable([], 0);
+                    }
+                },
+                error: (xhr) => {
+                    Toast.error(xhr.responseJSON?.message || '이력을 불러오는 중 오류가 발생했습니다.');
+                    this.renderTable([], 0);
+                }
+            });
+        },
+
+        /** 이력 데이터를 받아 tbody를 렌더링한다. */
+        renderTable: function (list, totalCount) {
+            this.currentData = list || [];
+            const tbody = $('#reactHisTableBody');
+            tbody.empty();
+
+            if (!list || list.length === 0) {
+                tbody.append(`
+                    <tr>
+                        <td colspan="6" class="text-center py-4 text-body-secondary">
+                            조회된 데이터가 없습니다.
+                        </td>
+                    </tr>
+                `);
+                return;
+            }
+
+            const offset = (this.currentPage - 1) * this.itemsPerPage;
+            list.forEach((item, idx) => {
+                const statusInfo = STATUS_LABEL[item.status] || { text: item.status, cls: 'bg-secondary' };
+
+                // figmaUrl은 길 수 있으므로 말줄임 처리 (title 속성으로 전체 URL 제공)
+                const safeUrl = HtmlUtils.escape(item.figmaUrl || '');
+                const safeUserId = HtmlUtils.escape(item.createUserId || '');
+                const safeCodeId = HtmlUtils.escape(item.codeId || '');
+
+                const row = $(`
+                    <tr>
+                        <td class="text-center">${offset + idx + 1}</td>
+                        <td class="text-truncate" style="max-width: 300px;" title="${safeUrl}">
+                            <a href="${safeUrl}" target="_blank" rel="noopener noreferrer"
+                               class="text-decoration-none text-reset"
+                               onclick="event.stopPropagation();">${safeUrl}</a>
+                        </td>
+                        <td class="text-center">
+                            <span class="badge ${statusInfo.cls}">${statusInfo.text}</span>
+                        </td>
+                        <td class="text-center">${safeUserId}</td>
+                        <td class="text-center">${formatDtime(item.createDtime)}</td>
+                        <td class="text-center">
+                            <button type="button" class="btn btn-outline-primary btn-sm py-0 px-2"
+                                    onclick="ReactGenerateHis.openDetail('${safeCodeId}')">
+                                보기
+                            </button>
+                        </td>
+                    </tr>
+                `);
+                tbody.append(row);
+            });
+        },
+
+        /** 페이지네이션 UI를 렌더링한다. */
+        renderPagination: function () {
+            const totalPages = Math.ceil(this.totalItems / this.itemsPerPage) || 1;
+            const pagination = $('#pagination');
+            pagination.empty();
+
+            // 처음·이전
+            pagination.append(`
+                <li class="page-item ${this.currentPage === 1 ? 'disabled' : ''}">
+                    <a class="page-link" href="#"
+                       onclick="ReactGenerateHis.changePage(1); return false;">
+                        <i class="bi bi-chevron-double-left"></i>
+                    </a>
+                </li>
+                <li class="page-item ${this.currentPage === 1 ? 'disabled' : ''}">
+                    <a class="page-link" href="#"
+                       onclick="ReactGenerateHis.changePage(${this.currentPage - 1}); return false;">
+                        <i class="bi bi-chevron-left"></i>
+                    </a>
+                </li>
+            `);
+
+            // 페이지 번호 버튼 (최대 5개)
+            const maxButtons = 5;
+            let startPage = Math.max(1, this.currentPage - Math.floor(maxButtons / 2));
+            let endPage = Math.min(totalPages, startPage + maxButtons - 1);
+            if (endPage - startPage + 1 < maxButtons) {
+                startPage = Math.max(1, endPage - maxButtons + 1);
+            }
+            for (let i = startPage; i <= endPage; i++) {
+                pagination.append(`
+                    <li class="page-item ${i === this.currentPage ? 'active' : ''}">
+                        <a class="page-link" href="#"
+                           onclick="ReactGenerateHis.changePage(${i}); return false;">${i}</a>
+                    </li>
+                `);
+            }
+
+            // 다음·마지막
+            const isLast = this.currentPage >= totalPages;
+            pagination.append(`
+                <li class="page-item ${isLast ? 'disabled' : ''}">
+                    <a class="page-link" href="#"
+                       onclick="ReactGenerateHis.changePage(${this.currentPage + 1}); return false;">
+                        <i class="bi bi-chevron-right"></i>
+                    </a>
+                </li>
+                <li class="page-item ${isLast ? 'disabled' : ''}">
+                    <a class="page-link" href="#"
+                       onclick="ReactGenerateHis.changePage(${totalPages}); return false;">
+                        <i class="bi bi-chevron-double-right"></i>
+                    </a>
+                </li>
+            `);
+
+            const start = this.totalItems === 0 ? 0 : (this.currentPage - 1) * this.itemsPerPage + 1;
+            const end   = Math.min(this.currentPage * this.itemsPerPage, this.totalItems);
+            $('#pageInfo').text(`${start} - ${end} of ${this.totalItems} items`);
+        },
+
+        /** 페이지를 변경하고 목록을 다시 불러온다. */
+        changePage: function (page) {
+            const totalPages = Math.ceil(this.totalItems / this.itemsPerPage) || 1;
+            if (page < 1 || page > totalPages) return;
+            this.currentPage = page;
+            this.load();
+        },
+
+        // ─── 상세 모달 ───────────────────────────────────────────
+
+        currentDetailId: null,
+        currentDetailStatus: null,
+
+        /** 상세 모달을 열고 지정된 codeId 데이터를 불러온다. */
+        openDetail: function (codeId) {
+            this.currentDetailId = codeId;
+            this.currentDetailStatus = null;
+
+            // 모달 초기화: 로딩 표시, 내용 숨김
+            $('#detailLoading').removeClass('d-none');
+            $('#detailContent').addClass('d-none');
+
+            const modal = new bootstrap.Modal(document.getElementById('reactHisDetailModal'));
+            modal.show();
+
+            $.ajax({
+                url: API_BASE_URL + '/react-generate/' + codeId,
+                method: 'GET',
+                success: (res) => {
+                    if (res.success && res.data) {
+                        this.renderDetail(res.data);
+                    } else {
+                        Toast.error(res.message || '상세 정보를 불러오지 못했습니다.');
+                        modal.hide();
+                    }
+                },
+                error: (xhr) => {
+                    Toast.error(xhr.responseJSON?.message || '상세 조회 중 오류가 발생했습니다.');
+                    modal.hide();
+                }
+            });
+        },
+
+        /** 상세 데이터를 모달에 렌더링한다. */
+        renderDetail: function (data) {
+            this.currentDetailStatus = data.status;
+
+            // ── 상세 정보 섹션 ──
+            const safeUrl = HtmlUtils.escape(data.figmaUrl || '');
+            $('#detailFigmaUrl').attr('href', safeUrl).text(safeUrl || '—');
+            $('#detailCreateUserId').text(data.createUserId || '—');
+            $('#detailCreateDtime').text(formatDtime(data.createDtime) || '—');
+            $('#detailApprovalUserId').text(data.approvalUserId || '—');
+            $('#detailApprovalDtime').text(formatDtime(data.approvalDtime) || '—');
+
+            // 상태 배지
+            const statusInfo = STATUS_LABEL[data.status] || { text: data.status, cls: 'bg-secondary' };
+            $('#detailStatusBadge')
+                .text(statusInfo.text)
+                .removeClass()
+                .addClass('badge ' + statusInfo.cls);
+
+            // 실패 사유: FAILED 상태일 때만 노출
+            if (data.status === 'FAILED') {
+                $('#detailFailReason').text(data.failReason || '—');
+                $('#detailFailReasonRow').removeClass('d-none');
+            } else {
+                $('#detailFailReasonRow').addClass('d-none');
+            }
+
+            // ── 미리보기 섹션: reactCode가 있을 때만 노출 ──
+            const hasCode = !!(data.reactCode && data.reactCode.trim());
+            if (hasCode) {
+                $('#detailPreviewSection').removeClass('d-none');
+
+                // 화면 미리보기: postMessage로 Preview App에 코드 전달
+                const frame = document.getElementById('detailPreviewFrame');
+                const sendCode = () => {
+                    frame.contentWindow.postMessage(
+                        { type: 'UPDATE_CODE', code: data.reactCode, codeId: data.codeId },
+                        '*'
+                    );
+                };
+                if (frame.contentDocument?.readyState === 'complete') {
+                    sendCode();
+                } else {
+                    frame.onload = sendCode;
+                }
+
+                // 코드 미리보기 (XSS 방어)
+                const escaped = data.reactCode
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;');
+                document.getElementById('detailCodeDisplay').innerHTML = escaped;
+
+                // 화면 미리보기 탭을 기본으로 활성화
+                new bootstrap.Tab(document.getElementById('detailTab-screen')).show();
+            } else {
+                $('#detailPreviewSection').addClass('d-none');
+            }
+
+            // 모달 푸터 버튼 상태 갱신 (작성자 여부 함께 전달)
+            this.updateDetailButtons(data.status, data.createUserId);
+
+            // 로딩 숨기고 내용 표시
+            $('#detailLoading').addClass('d-none');
+            $('#detailContent').removeClass('d-none');
+        },
+
+        /** 상태와 작성자 여부에 따라 모달 내 버튼 노출 여부를 제어한다. */
+        updateDetailButtons: function (status, createUserId) {
+            const $btnReq = $('#detailBtnRequestApproval');
+
+            // 승인 요청 버튼 노출 조건:
+            //   1. 쓰기 권한(REACT_GENERATE:W) 보유
+            //   2. 로그인 사용자가 작성자
+            //   3. 생성 완료(GENERATED) 상태
+            const canRequest = HAS_REACT_WRITE
+                && createUserId && CURRENT_USER_ID && createUserId === CURRENT_USER_ID
+                && status === 'GENERATED';
+            $btnReq.toggleClass('d-none', !canRequest);
+        }
+    };
+
+    // ─── 모달 내 코드 복사 ─────────────────────────────────────
+    $('#detailBtnCopyCode').on('click', function () {
+        const code = document.getElementById('detailCodeDisplay').textContent;
+        navigator.clipboard.writeText(code).then(function () {
+            Toast.success('코드가 클립보드에 복사되었습니다.');
+        }).catch(function () {
+            Toast.error('복사에 실패했습니다.');
+        });
+    });
+
+    // ─── 모달 내 승인 요청 ────────────────────────────────────
+    $('#detailBtnRequestApproval').on('click', function () {
+        if (!ReactGenerateHis.currentDetailId) return;
+        if (!confirm('승인을 요청하시겠습니까?')) return;
+
+        $.ajax({
+            url: API_BASE_URL + '/react-generate/' + ReactGenerateHis.currentDetailId + '/request-approval',
+            method: 'POST',
+            success: function (res) {
+                if (res.success && res.data) {
+                    ReactGenerateHis.currentDetailStatus = res.data.status;
+                    // 상태 변경 후 버튼 재평가 (작성자 정보는 변하지 않으므로 저장된 값 재사용)
+                    const currentCreateUserId = $('#detailCreateUserId').text();
+                    ReactGenerateHis.updateDetailButtons(res.data.status, currentCreateUserId);
+
+                    // 상태 배지 갱신
+                    const info = STATUS_LABEL[res.data.status] || { text: res.data.status, cls: 'bg-secondary' };
+                    $('#detailStatusBadge').text(info.text).removeClass().addClass('badge ' + info.cls);
+
+                    Toast.success('승인 요청이 완료되었습니다.');
+                    // 목록도 갱신하여 상태 변경을 반영
+                    ReactGenerateHis.load();
+                } else {
+                    Toast.error(res.message || '승인 요청에 실패했습니다.');
+                }
+            },
+            error: function (xhr) {
+                Toast.error(xhr.responseJSON?.message || '승인 요청 중 오류가 발생했습니다.');
+            }
+        });
+    });
+
+    // ─── 모달이 닫힐 때 내용 초기화 ─────────────────────────
+    document.getElementById('reactHisDetailModal').addEventListener('hidden.bs.modal', function () {
+        // 미리보기 섹션이 열려 있었으면 Preview App 초기화
+        const frame = document.getElementById('detailPreviewFrame');
+        if (frame.contentDocument?.readyState === 'complete') {
+            frame.contentWindow.postMessage({ type: 'UPDATE_CODE', code: '' }, '*');
+        }
+        document.getElementById('detailCodeDisplay').innerHTML = '';
+        // 다음 열기 시 로딩 상태로 리셋
+        $('#detailContent').addClass('d-none');
+        $('#detailLoading').removeClass('d-none');
+        ReactGenerateHis.currentDetailId = null;
+        ReactGenerateHis.currentDetailStatus = null;
+    });
+
+    // ─── 검색 폼 이벤트 ──────────────────────────────────────
+    $('#btnSearch').on('click', function () {
+        ReactGenerateHis.search();
+    });
+
+    $('#btnSearchReset').on('click', function () {
+        $('#searchStatus').val('');
+        $('#searchCreateUserId').val('');
+        $('#searchFromDate').val('');
+        $('#searchToDate').val('');
+        ReactGenerateHis.search();
+    });
+
+    // 검색 영역 Enter 키 지원
+    $('.card.border').on('keydown', 'input, select', function (e) {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            ReactGenerateHis.search();
+        }
+    });
+
+    // 페이지당 건수 변경
+    $('#limitRows').on('change', function () {
+        ReactGenerateHis.itemsPerPage = parseInt($(this).val()) || 10;
+        ReactGenerateHis.search();
+    });
+
+    // 새로고침 버튼
+    $('#btnRefresh').on('click', function () {
+        ReactGenerateHis.load();
+    });
+
+    // ─── 엑셀 내보내기 ────────────────────────────────────────
+    // 현재 검색 조건 그대로 서버에서 전체 데이터를 xlsx로 다운로드
+    $('#btnExcel').off('click').on('click', function () {
+        const params = Object.assign({}, ReactGenerateHis.appliedSearch);
+        const qs = $.param(params);
+        window.location.href = API_BASE_URL + '/react-generate/history/export' + (qs ? '?' + qs : '');
+    });
+
+    // ─── 출력 ─────────────────────────────────────────────────
+    // 현재 페이지에 표시된 데이터를 PrintUtil로 출력
+    $('#btnPrint').off('click').on('click', function () {
+        const columns = [
+            { key: 'figmaUrl',        label: 'Figma URL' },
+            { key: 'statusLabel',     label: '상태' },
+            { key: 'createUserId',    label: '생성자' },
+            { key: 'createDtimeFmt',  label: '생성일시' },
+            { key: 'approvalUserId',  label: '승인자' },
+            { key: 'approvalDtimeFmt', label: '승인일시' }
+        ];
+        // 출력용 데이터: 상태·일시를 사람이 읽기 쉬운 형태로 변환
+        const printData = ReactGenerateHis.currentData.map(function (item) {
+            const statusInfo = STATUS_LABEL[item.status] || { text: item.status };
+            return {
+                figmaUrl:        item.figmaUrl || '',
+                statusLabel:     statusInfo.text,
+                createUserId:    item.createUserId || '',
+                createDtimeFmt:  formatDtime(item.createDtime),
+                approvalUserId:  item.approvalUserId || '',
+                approvalDtimeFmt: formatDtime(item.approvalDtime)
+            };
+        });
+        PrintUtil.print({ title: 'React 코드 생성 이력', columns: columns, data: printData });
+    });
+
+    // ─── 초기 조회 ─────────────────────────────────────────────
+    ReactGenerateHis.search();
+</script>
+</th:block>
+</body>
+</html>

--- a/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-script.html
+++ b/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-script.html
@@ -268,9 +268,10 @@
                 // 화면 미리보기: postMessage로 Preview App에 코드 전달
                 const frame = document.getElementById('detailPreviewFrame');
                 const sendCode = () => {
+                    // 같은 출처(origin)로만 메시지 전송하여 외부 수신 차단
                     frame.contentWindow.postMessage(
                         { type: 'UPDATE_CODE', code: data.reactCode, codeId: data.codeId },
-                        '*'
+                        window.location.origin
                     );
                 };
                 if (frame.contentDocument?.readyState === 'complete') {
@@ -279,12 +280,8 @@
                     frame.onload = sendCode;
                 }
 
-                // 코드 미리보기 (XSS 방어)
-                const escaped = data.reactCode
-                    .replace(/&/g, '&amp;')
-                    .replace(/</g, '&lt;')
-                    .replace(/>/g, '&gt;');
-                document.getElementById('detailCodeDisplay').innerHTML = escaped;
+                // 코드 미리보기: textContent 할당으로 HTML 파싱을 우회해 XSS를 원천 차단
+                document.getElementById('detailCodeDisplay').textContent = data.reactCode;
 
                 // 화면 미리보기 탭을 기본으로 활성화
                 new bootstrap.Tab(document.getElementById('detailTab-screen')).show();
@@ -362,7 +359,7 @@
         // 미리보기 섹션이 열려 있었으면 Preview App 초기화
         const frame = document.getElementById('detailPreviewFrame');
         if (frame.contentDocument?.readyState === 'complete') {
-            frame.contentWindow.postMessage({ type: 'UPDATE_CODE', code: '' }, '*');
+            frame.contentWindow.postMessage({ type: 'UPDATE_CODE', code: '' }, window.location.origin);
         }
         document.getElementById('detailCodeDisplay').innerHTML = '';
         // 다음 열기 시 로딩 상태로 리셋

--- a/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-search.html
+++ b/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-search.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<!-- React 코드 생성 이력 Search Fragment -->
+<div th:fragment="search" class="card border p-2 mb-3">
+    <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
+        <label class="form-label mb-0 small fw-medium">상태</label>
+        <select id="searchStatus" class="form-select form-select-sm flex-fixed-130">
+            <option value="">전체</option>
+            <option value="GENERATED">생성 완료</option>
+            <option value="PENDING_APPROVAL">승인 대기</option>
+            <option value="APPROVED">승인 완료</option>
+            <option value="FAILED">실패</option>
+        </select>
+
+        <label class="form-label mb-0 small fw-medium ms-2">생성자</label>
+        <input type="text" id="searchCreateUserId" class="form-control form-control-sm flex-fixed-120"
+               placeholder="생성자 ID">
+
+        <label class="form-label mb-0 small fw-medium ms-2">시작일</label>
+        <input type="date" id="searchFromDate" class="form-control form-control-sm flex-fixed-140">
+
+        <label class="form-label mb-0 small fw-medium ms-2">종료일</label>
+        <input type="date" id="searchToDate" class="form-control form-control-sm flex-fixed-140">
+
+        <div class="flex-grow-1"></div>
+
+        <select id="limitRows" class="form-select form-select-sm sp-limit-select">
+            <option value="10" selected>10</option>
+            <option value="20">20</option>
+            <option value="50">50</option>
+        </select>
+        <label class="form-label mb-0 small fw-medium">건씩</label>
+
+        <button class="btn btn-outline-secondary btn-sm" id="btnSearchReset">
+            <i class="bi bi-arrow-counterclockwise"></i> 초기화
+        </button>
+        <button class="btn btn-primary btn-sm" id="btnSearch">
+            <i class="bi bi-search"></i> 조회
+        </button>
+    </div>
+</div>
+</body>
+</html>

--- a/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-table.html
+++ b/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-table.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<!-- React 코드 생성 이력 Table Fragment -->
+<div th:fragment="table" class="table-responsive">
+    <table class="table table-sm table-hover sp-data-grid" id="reactHisTable">
+        <thead class="table-light">
+            <tr>
+                <th class="text-center" style="width: 50px;">No</th>
+                <th>Figma URL</th>
+                <th class="text-center" style="width: 110px;">상태</th>
+                <th class="text-center" style="width: 100px;">생성자</th>
+                <th class="text-center" style="width: 150px;">생성일시</th>
+                <th class="text-center" style="width: 80px;">상세</th>
+            </tr>
+        </thead>
+        <tbody id="reactHisTableBody">
+            <tr>
+                <td colspan="6" class="text-center py-4 text-body-secondary">
+                    조회 버튼을 클릭하여 데이터를 불러오세요.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+</body>
+</html>

--- a/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his.html
+++ b/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<div th:fragment="content">
+
+    <!-- Page Header -->
+    <div class="page-header">
+        <h4 class="page-title">
+            <i class="bi bi-clock-history text-primary"></i>
+            React 코드 생성 이력
+        </h4>
+    </div>
+
+    <!-- Search Box -->
+    <div th:replace="~{pages/react-generate-his/react-generate-his-search :: search}"></div>
+
+    <!-- List Section Header + Toolbar -->
+    <div class="d-flex align-items-center mt-3">
+        <div class="page-header mb-0">
+            <h4 class="page-title mb-0">
+                <i class="bi bi-list-ul text-primary"></i>
+                목록
+            </h4>
+        </div>
+        <div class="flex-grow-1" th:insert="~{fragments/page-content-layout :: toolbar}"></div>
+    </div>
+
+    <!-- Table -->
+    <div th:replace="~{pages/react-generate-his/react-generate-his-table :: table}"></div>
+
+    <!-- Pagination -->
+    <div th:replace="~{fragments/page-content-layout :: pagination}"></div>
+
+    <!-- Detail Modal -->
+    <div th:replace="~{pages/react-generate-his/react-generate-his-modal :: modal}"></div>
+
+    <!-- Script -->
+    <th:block th:replace="~{pages/react-generate-his/react-generate-his-script :: script}" />
+</div>
+</body>
+</html>

--- a/admin/src/main/resources/templates/pages/react-generate/react-generate-script.html
+++ b/admin/src/main/resources/templates/pages/react-generate/react-generate-script.html
@@ -82,9 +82,10 @@
         // iframe이 이미 로드되어 있으면 즉시 전달, 아직 로딩 중이면 onload 후 전달
         const frame = document.getElementById('previewFrame');
         const sendCode = () => {
+            // 같은 출처(origin)로만 메시지 전송하여 외부 수신 차단
             frame.contentWindow.postMessage(
                 { type: 'UPDATE_CODE', code: data.reactCode || '', codeId: data.codeId },
-                '*'
+                window.location.origin
             );
         };
         if (frame.contentDocument?.readyState === 'complete') {
@@ -93,11 +94,8 @@
             frame.onload = sendCode;
         }
 
-        // 코드 미리보기 (escape XSS)
-        const escaped = (data.reactCode || '').replace(/&/g, '&amp;')
-                                               .replace(/</g, '&lt;')
-                                               .replace(/>/g, '&gt;');
-        document.getElementById('codeDisplay').innerHTML = escaped;
+        // 코드 미리보기: textContent 할당으로 HTML 파싱을 우회해 XSS를 원천 차단
+        document.getElementById('codeDisplay').textContent = data.reactCode || '';
 
         updateStatusBadge(data.status);
         $('#resultSection').removeClass('d-none');
@@ -173,14 +171,14 @@
         // 결과 영역 숨김 및 내부 상태 초기화
         $('#resultSection').addClass('d-none');
         $('#resultMeta').text('');
-        document.getElementById('codeDisplay').innerHTML = '';
+        document.getElementById('codeDisplay').textContent = '';
         currentId = null;
         currentStatus = null;
 
         // Preview App에 빈 코드를 전달하여 미리보기 화면 초기화
         const frame = document.getElementById('previewFrame');
         if (frame.contentDocument?.readyState === 'complete') {
-            frame.contentWindow.postMessage({ type: 'UPDATE_CODE', code: '' }, '*');
+            frame.contentWindow.postMessage({ type: 'UPDATE_CODE', code: '' }, window.location.origin);
         }
 
         $('#figmaUrlInput').focus();


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
- #12

## ✨ 변경 사항 (Changes)

### Backend
- **DTO 추가**
  - `ReactGenerateHistoryResponse` — 목록 행 1건 (CLOB 제외)
  - `ReactGenerateSearchRequest` — 검색 조건 + ROWNUM 페이지네이션 파라미터 (`getOffset`, `getEndRow`)
- **`ReactGenerateResponse`** — `createUserId`, `approvalUserId`, `approvalDtime` 필드 추가
- **Mapper/XML**
  - `selectList`: ROWNUM 이중 서브쿼리 페이지네이션 (Oracle 프로젝트 표준)
  - `selectCount`: 동일 WHERE 조건 건수 조회
  - `selectAllForExport`: 엑셀 내보내기용 전체 조회
  - `historyWhereConditions` SQL Fragment 공유
- **Service** — `getHistory`, `getById`, `exportHistory` 구현
- **Controller**
  - `GET /api/react-generate/history` — 페이지네이션 목록 조회
  - `GET /api/react-generate/history/export` — 엑셀 다운로드 (xlsx)
  - `GET /api/react-generate/{id}` — 단건 상세 조회
- **`menu-resource-permissions.yml`** — `v3_react_generate_his` 권한 등록
- **`PageController`** — `/react-generate-his` 라우팅 추가

### Frontend (Thymeleaf)
파일 5개 분리 (`react-generate-his-{main/search/table/modal/script}.html`)

- **검색 영역**: 상태 · 생성자 · 시작일~종료일 · 조회건수(기본 10건)
- **목록**: 생성일시 내림차순, Figma URL 말줄임(title 전체 표시), 상태 배지
- **상세 모달**:
  - 상세 정보 섹션: 4컬럼 테이블 (생성자·생성일시 동행, 승인자·승인일시 동행)
  - FAILED 상태 시 실패 사유 행 노출
  - 미리보기 섹션: reactCode 존재 시만 노출 (화면 미리보기 iframe + 코드 미리보기 탭)
  - 승인 요청 버튼: `REACT_GENERATE:W` 권한 AND 본인 작성자 AND `GENERATED` 상태 모두 충족 시만 노출
- **엑셀 내보내기**: 현재 검색 조건 전체 다운로드
- **출력**: `PrintUtil.print()` 연동

## ⚠️ 고려 및 주의 사항

- DB `FWK_RPS_CODE_HIS` 테이블에 신규 메뉴(`v3_react_generate_his`) 역할 권한 데이터 INSERT 필요
- 페이지네이션은 `OFFSET … ROWS FETCH NEXT … ROWS ONLY` 대신 프로젝트 표준인 **ROWNUM 이중 서브쿼리** 방식으로 구현

## 💬 리뷰 포인트

- `ReactGenerateSearchRequest.getEndRow()` = `page * size` — ROWNUM 상한값 계산 방식
- 승인 요청 버튼 노출 조건 3중 체크 (`updateDetailButtons` 함수)