### PR TITLE
feat: 자동 로그인 / 아이디 저장 기능 구현 및 최근 접속 일시 실데이터 연동

### DIFF
--- a/demo/backend/server.js
+++ b/demo/backend/server.js
@@ -17,25 +17,30 @@
 
 require("dotenv").config();
 
-const express      = require("express");
-const cors         = require("cors");
+const express = require("express");
+const cors = require("cors");
 const cookieParser = require("cookie-parser");
 const { apiLogger } = require("./utils/logger");
 const jwt = require("jsonwebtoken");
 const { initPool, withConnection, closePool } = require("./db");
 const { detectBrand, maskCardNumber } = require("./utils/cardBrand");
-const { addClient, broadcastNotice, clientCount } = require("./utils/sseManager");
-const { getBillingPeriod }            = require("./utils/billingPeriod");
-const { getBillingSummaryByMonth }    = require("./utils/billingByMonth");
+const {
+  addClient,
+  broadcastNotice,
+  clientCount,
+} = require("./utils/sseManager");
+const { getBillingPeriod } = require("./utils/billingPeriod");
+const { getBillingSummaryByMonth } = require("./utils/billingByMonth");
 
-const JWT_SECRET          = process.env.JWT_SECRET          || "dev-secret";
+const JWT_SECRET = process.env.JWT_SECRET || "dev-secret";
 // Access Token: 짧은 TTL — 만료 시 Refresh Token으로 재발급
-const JWT_ACCESS_EXPIRES_IN  = process.env.JWT_ACCESS_EXPIRES_IN  || "30m";
+const JWT_ACCESS_EXPIRES_IN = process.env.JWT_ACCESS_EXPIRES_IN || "30m";
 // Refresh Token: 긴 TTL — httpOnly 쿠키로 관리 (JS 접근 불가)
-const JWT_REFRESH_SECRET     = process.env.JWT_REFRESH_SECRET     || "dev-refresh-secret";
+const JWT_REFRESH_SECRET =
+  process.env.JWT_REFRESH_SECRET || "dev-refresh-secret";
 const JWT_REFRESH_EXPIRES_IN = process.env.JWT_REFRESH_EXPIRES_IN || "7d";
 /** Admin → Demo Backend 호출 시 사용하는 공유 비밀 키 */
-const ADMIN_SECRET  = process.env.ADMIN_SECRET  || "admin-secret";
+const ADMIN_SECRET = process.env.ADMIN_SECRET || "admin-secret";
 
 /**
  * 현재 배포 중인 긴급공지 인메모리 상태.
@@ -190,11 +195,11 @@ app.get("/api/dev/usage-stat", localOnly, async (_req, res) => {
     ]);
 
     res.json({
-      totalCount:   countResult.rows[0]?.TOTAL_CNT ?? 0,
+      totalCount: countResult.rows[0]?.TOTAL_CNT ?? 0,
       distribution: (distResult.rows || []).map((r) => ({
-        value:        r.RAW_VAL,       // DB에 실제 저장된 값 (공백 포함 가능)
-        trimmedValue: r.TRIM_VAL,      // 앞뒤 공백 제거 후 값
-        count:        r.CNT,
+        value: r.RAW_VAL, // DB에 실제 저장된 값 (공백 포함 가능)
+        trimmedValue: r.TRIM_VAL, // 앞뒤 공백 제거 후 값
+        count: r.CNT,
       })),
     });
   } catch (err) {
@@ -221,7 +226,80 @@ app.get("/api/dev/columns/:tbl", localOnly, async (req, res) => {
   }
 });
 
+/**
+ * GET /api/dev/user-logins
+ * POC_USER 테이블의 전체 사용자 로그인 현황 진단용 엔드포인트.
+ * 개발 완료 후 이 라우트와 함께 삭제 예정.
+ */
+app.get("/api/dev/user-logins", localOnly, async (_req, res) => {
+  try {
+    const result = await withConnection((conn) =>
+      conn.execute(
+        `SELECT USER_ID, USER_NAME,
+                LAST_LOGIN_DTIME,
+                CASE
+                  WHEN LAST_LOGIN_DTIME IS NULL THEN '(없음)'
+                  ELSE TO_CHAR(
+                    TO_DATE(LAST_LOGIN_DTIME, 'YYYYMMDDHH24MISS'),
+                    'YYYY.MM.DD HH24:MI:SS'
+                  )
+                END AS LAST_LOGIN_FORMATTED
+           FROM D_SPIDERLINK.POC_USER
+          ORDER BY USER_ID`,
+      ),
+    );
+    res.json({
+      users: (result.rows || []).map((r) => ({
+        userId:             r.USER_ID,
+        userName:           r.USER_NAME,
+        lastLoginRaw:       r.LAST_LOGIN_DTIME,
+        lastLoginFormatted: r.LAST_LOGIN_FORMATTED,
+      })),
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // ── 인증 ─────────────────────────────────────────────────────────────────────
+
+/**
+ * GET /api/auth/me
+ * Authorization: Bearer <accessToken>
+ * 현재 로그인 사용자의 프로필과 최근 접속 일시를 반환한다.
+ * 자동 로그인 후 Access Token이 아직 유효해 refresh가 발생하지 않은 경우에도
+ * 프론트엔드가 lastLogin을 즉시 채울 수 있도록 제공한다.
+ */
+app.get("/api/auth/me", verifyToken, async (req, res) => {
+  try {
+    const { userId } = req.user;
+
+    const result = await withConnection((conn) =>
+      conn.execute(
+        `SELECT USER_NAME, USER_GRADE,
+                TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS') AS LAST_LOGIN_DTIME
+           FROM D_SPIDERLINK.POC_USER
+          WHERE USER_ID = :userId`,
+        { userId },
+      ),
+    );
+
+    const row = result.rows?.[0];
+    if (!row) {
+      return res.status(404).json({ error: "사용자를 찾을 수 없습니다." });
+    }
+
+    return res.json({
+      userId,
+      userName:  row.USER_NAME,
+      userGrade: row.USER_GRADE,
+      lastLogin: formatLoginDtime(row.LAST_LOGIN_DTIME),
+    });
+  } catch (err) {
+    console.error("[GET /api/auth/me]", err);
+    return res.status(500).json({ error: "서버 오류가 발생했습니다." });
+  }
+});
 
 /**
  * POST /api/auth/login
@@ -241,7 +319,8 @@ app.post("/api/auth/login", async (req, res) => {
   try {
     const result = await withConnection(async (conn) => {
       return conn.execute(
-        `SELECT USER_ID, USER_NAME, USER_GRADE, LOG_YN
+        `SELECT USER_ID, USER_NAME, USER_GRADE, LOG_YN,
+                TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS') AS LAST_LOGIN_DTIME
            FROM D_SPIDERLINK.POC_USER
           WHERE USER_ID = :userId AND PASSWORD = :password`,
         { userId, password },
@@ -278,8 +357,8 @@ app.post("/api/auth/login", async (req, res) => {
     );
 
     const payload = {
-      userId:    row.USER_ID,
-      userName:  row.USER_NAME,
+      userId: row.USER_ID,
+      userName: row.USER_NAME,
       userGrade: row.USER_GRADE,
     };
 
@@ -299,18 +378,20 @@ app.post("/api/auth/login", async (req, res) => {
     // SameSite=lax: CSRF 방지 / path=/api/auth: 인증 경로에만 쿠키 전송
     res.cookie("refreshToken", refreshToken, {
       httpOnly: true,
-      secure:   false, // POC: HTTP 허용 (프로덕션에서는 true + HTTPS 필수)
+      secure: false, // POC: HTTP 허용 (프로덕션에서는 true + HTTPS 필수)
       sameSite: "lax",
-      maxAge:   7 * 24 * 60 * 60 * 1000, // 7일 (ms)
-      path:     "/api/auth",
+      maxAge: 7 * 24 * 60 * 60 * 1000, // 7일 (ms)
+      path: "/api/auth",
     });
 
     return res.json({
-      success:   true,
-      token:     accessToken, // 기존 키 유지 (프론트 AuthUser.token 호환)
-      userId:    row.USER_ID,
-      userName:  row.USER_NAME,
+      success: true,
+      token: accessToken, // 기존 키 유지 (프론트 AuthUser.token 호환)
+      userId: row.USER_ID,
+      userName: row.USER_NAME,
       userGrade: row.USER_GRADE,
+      // LAST_LOGIN_DTIME 업데이트 전 값 — 이전 접속 시각을 메뉴 화면에 표시하기 위해 반환
+      lastLogin: formatLoginDtime(row.LAST_LOGIN_DTIME),
     });
   } catch (err) {
     console.error("[POST /api/auth/login]", err);
@@ -324,6 +405,7 @@ app.post("/api/auth/login", async (req, res) => {
  * POST /api/auth/refresh
  * Refresh Token(httpOnly 쿠키)으로 새 Access Token 발급.
  * 저장된 토큰과 불일치 시 탈취로 간주하고 해당 유저의 토큰을 무효화한다.
+ * 자동 로그인 등 재진입 시점을 포함해 세션 활동이 감지되므로 LAST_LOGIN_DTIME을 갱신한다.
  */
 app.post("/api/auth/refresh", (req, res) => {
   const refreshToken = req.cookies?.refreshToken;
@@ -334,23 +416,51 @@ app.post("/api/auth/refresh", (req, res) => {
 
   try {
     const decoded = jwt.verify(refreshToken, JWT_REFRESH_SECRET);
-    const stored  = refreshTokenStore.get(decoded.userId);
+    const stored = refreshTokenStore.get(decoded.userId);
 
     // 저장된 토큰과 불일치 → 탈취된 토큰으로 간주, 즉시 무효화
     if (stored !== refreshToken) {
       refreshTokenStore.delete(decoded.userId);
-      return res.status(401).json({ error: "유효하지 않은 Refresh Token입니다." });
+      return res
+        .status(401)
+        .json({ error: "유효하지 않은 Refresh Token입니다." });
     }
 
     const newAccessToken = jwt.sign(
-      { userId: decoded.userId, userName: decoded.userName, userGrade: decoded.userGrade },
+      {
+        userId: decoded.userId,
+        userName: decoded.userName,
+        userGrade: decoded.userGrade,
+      },
       JWT_SECRET,
       { expiresIn: JWT_ACCESS_EXPIRES_IN },
     );
 
-    return res.json({ accessToken: newAccessToken });
+    // LAST_LOGIN_DTIME 갱신 — 실패해도 토큰 발급은 허용
+    withConnection((conn) =>
+      conn.execute(
+        `UPDATE D_SPIDERLINK.POC_USER
+            SET LAST_LOGIN_DTIME = TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS')
+          WHERE USER_ID = :userId`,
+        { userId: decoded.userId },
+        { autoCommit: true },
+      ),
+    ).catch((e) =>
+      console.warn("[refresh] LAST_LOGIN_DTIME 업데이트 실패:", e.message),
+    );
+
+    // 갱신 시각을 프론트에 전달해 '최근 접속 일시' 표시를 즉시 반영한다.
+    // DB 업데이트는 비동기이므로 SYSDATE 대신 JS 현재 시각을 동일 포맷으로 생성한다.
+    const n = new Date();
+    const refreshedAt = formatLoginDtime(
+      `${n.getFullYear()}${String(n.getMonth() + 1).padStart(2, "0")}${String(n.getDate()).padStart(2, "0")}${String(n.getHours()).padStart(2, "0")}${String(n.getMinutes()).padStart(2, "0")}${String(n.getSeconds()).padStart(2, "0")}`,
+    );
+
+    return res.json({ accessToken: newAccessToken, lastLogin: refreshedAt });
   } catch {
-    return res.status(401).json({ error: "Refresh Token이 만료되었거나 유효하지 않습니다." });
+    return res
+      .status(401)
+      .json({ error: "Refresh Token이 만료되었거나 유효하지 않습니다." });
   }
 });
 
@@ -467,6 +577,16 @@ function mapTxStatCode(code) {
 }
 
 /**
+ * LAST_LOGIN_DTIME(YYYYMMDDHH24MISS 14자리) → 'YYYY.MM.DD HH:MM:SS'
+ * @param {string|null} raw
+ */
+function formatLoginDtime(raw) {
+  const s = String(raw ?? "").replace(/\D/g, "");
+  if (s.length !== 14) return raw ?? "";
+  return `${s.slice(0, 4)}.${s.slice(4, 6)}.${s.slice(6, 8)} ${s.slice(8, 10)}:${s.slice(10, 12)}:${s.slice(12, 14)}`;
+}
+
+/**
  * 날짜(YYYYMMDD) + 시각(HHmmss) → 'YYYY.MM.DD HH:mm'
  * @param {string|null} date
  * @param {string|null} time
@@ -476,9 +596,11 @@ function formatDateTime(date, time) {
   const t = String(time ?? "").replace(/\D/g, "");
   // YYYYMMDD(8자리) 또는 YYMMDD(6자리) 모두 처리
   let datePart = d;
-  if (d.length === 8)       // YYYYMMDD
+  if (d.length === 8)
+    // YYYYMMDD
     datePart = `${d.slice(0, 4)}.${d.slice(4, 6)}.${d.slice(6, 8)}`;
-  else if (d.length === 6)  // YYMMDD
+  else if (d.length === 6)
+    // YYMMDD
     datePart = `20${d.slice(0, 2)}.${d.slice(2, 4)}.${d.slice(4, 6)}`;
   const timePart = t.length >= 4 ? `${t.slice(0, 2)}:${t.slice(2, 4)}` : "";
   return timePart ? `${datePart} ${timePart}` : datePart;
@@ -491,9 +613,11 @@ function formatDateTime(date, time) {
 function formatDateKo(raw) {
   if (!raw) return "";
   const s = String(raw).replace(/\D/g, "");
-  if (s.length === 8)  // YYYYMMDD
+  if (s.length === 8)
+    // YYYYMMDD
     return `${Number(s.slice(4, 6))}월 ${Number(s.slice(6, 8))}일`;
-  if (s.length === 6)  // YYMMDD
+  if (s.length === 6)
+    // YYMMDD
     return `${Number(s.slice(2, 4))}월 ${Number(s.slice(4, 6))}일`;
   return String(raw);
 }
@@ -628,13 +752,23 @@ function getDateRange(period, customMonth) {
 app.get("/api/transactions", verifyToken, async (req, res) => {
   try {
     const userId = req.user.userId;
-    const { cardId, period, customMonth, usageType, fromDate: qFromDate, toDate: qToDate } = req.query;
+    const {
+      cardId,
+      period,
+      customMonth,
+      usageType,
+      fromDate: qFromDate,
+      toDate: qToDate,
+    } = req.query;
 
     // ── 날짜 범위 계산 ─────────────────────────────────────────────
     // fromDate/toDate 직접 전달 시 우선 사용, 없으면 period/customMonth로 계산
-    const { fromDate: rangeFrom, toDate: rangeTo } = getDateRange(period, customMonth);
+    const { fromDate: rangeFrom, toDate: rangeTo } = getDateRange(
+      period,
+      customMonth,
+    );
     const fromDate = qFromDate || rangeFrom;
-    const toDate   = qToDate   || rangeTo;
+    const toDate = qToDate || rangeTo;
 
     // ── 동적 WHERE 절 구성 ───────────────────────────────────────
     let sql = `
@@ -735,9 +869,9 @@ app.get("/api/payment-statement", verifyToken, async (req, res) => {
     const ci = cardRows[0] ?? null;
     const cardInfo = ci
       ? {
-          paymentBank:    ci["결제은행명"] ?? "",
+          paymentBank: ci["결제은행명"] ?? "",
           paymentAccount: String(ci["결제계좌"] ?? ""),
-          paymentDay:     String(ci["결제일"] ?? ""),
+          paymentDay: String(ci["결제일"] ?? ""),
         }
       : null;
 
@@ -755,11 +889,15 @@ app.get("/api/payment-statement", verifyToken, async (req, res) => {
        * 보수적 범위(targetMonth-2 ~ targetMonth 말일)로 DB를 조회하고,
        * 정밀 필터링은 getBillingSummaryByMonth가 카드별로 수행한다. */
       const [y, m] = yearMonth.split("-").map(Number);
-      let fromYear = y, fromMonth = m - 2;
-      if (fromMonth <= 0) { fromYear--; fromMonth += 12; }
+      let fromYear = y,
+        fromMonth = m - 2;
+      if (fromMonth <= 0) {
+        fromYear--;
+        fromMonth += 12;
+      }
       const toDay = new Date(y, m, 0).getDate(); // targetMonth 말일
       txBinds.fromDate = `${fromYear}${String(fromMonth).padStart(2, "0")}01`;
-      txBinds.toDate   = `${y}${String(m).padStart(2, "0")}${String(toDay).padStart(2, "0")}`;
+      txBinds.toDate = `${y}${String(m).padStart(2, "0")}${String(toDay).padStart(2, "0")}`;
       txSql += ` AND "이용일자" >= :fromDate AND "이용일자" <= :toDate`;
     } else {
       /* 공여기간 필터: 전달받은 paymentDay 또는 DB 결제일 기준으로 이용일자 범위 산정 */
@@ -769,7 +907,7 @@ app.get("/api/payment-statement", verifyToken, async (req, res) => {
           const bp = getBillingPeriod(new Date(), D);
           txSql += ` AND "이용일자" >= :fromDate AND "이용일자" <= :toDate`;
           txBinds.fromDate = bp.fromDate; // YYYYMMDD
-          txBinds.toDate   = bp.toDate;   // YYYYMMDD
+          txBinds.toDate = bp.toDate; // YYYYMMDD
           billingPeriodFormatted = bp.formatted; // { usageStart, usageEnd, dueDate }
         } catch (e) {
           console.warn("[payment-statement] 공여기간 계산 실패:", e.message);
@@ -778,7 +916,9 @@ app.get("/api/payment-statement", verifyToken, async (req, res) => {
     }
 
     // ── 3. 이용내역 조회 ─────────────────────────────────────────────
-    const txResult = await withConnection((conn) => conn.execute(txSql, txBinds));
+    const txResult = await withConnection((conn) =>
+      conn.execute(txSql, txBinds),
+    );
     const txRows = txResult.rows || [];
 
     // ── 4. 집계 (yearMonth 유무에 따라 분기) ──────────────────────────
@@ -787,42 +927,62 @@ app.get("/api/payment-statement", verifyToken, async (req, res) => {
     if (yearMonth) {
       /* 카드별 결제일 공여기간을 개별 적용해 청구월을 정확히 판단 */
       const rawItems = txRows.map((r) => ({
-        cardNo:   String(r["카드번호"] ?? ""),
+        cardNo: String(r["카드번호"] ?? ""),
         cardName: r["카드명"] ?? "",
-        useDate:  String(r["이용일자"] ?? ""),
-        amount:   Number(r["이용금액"] ?? 0),
-        dueDate:  r["결제예정일"] ?? "",
+        useDate: String(r["이용일자"] ?? ""),
+        amount: Number(r["이용금액"] ?? 0),
+        dueDate: r["결제예정일"] ?? "",
       }));
-      const summary = getBillingSummaryByMonth(rawItems, yearMonth, cardSettings);
+      const summary = getBillingSummaryByMonth(
+        rawItems,
+        yearMonth,
+        cardSettings,
+      );
 
       /* 카드+결제예정일 조합별 재집계 (응답 포맷을 기존과 동일하게 유지) */
       const cardMap = {};
       summary.items.forEach((item) => {
         const key = `${item.cardNo}_${item.dueDate}`;
-        if (!cardMap[key]) cardMap[key] = { cardNo: item.cardNo, cardName: item.cardName, amount: 0, dueDate: item.dueDate };
+        if (!cardMap[key])
+          cardMap[key] = {
+            cardNo: item.cardNo,
+            cardName: item.cardName,
+            amount: 0,
+            dueDate: item.dueDate,
+          };
         cardMap[key].amount += item.amount;
       });
-      items       = Object.values(cardMap);
+      items = Object.values(cardMap);
       totalAmount = summary.totalAmount;
 
       /* 대표 결제예정일 — 가장 많이 등장하는 값 */
       const cnt = {};
-      summary.items.forEach((i) => { if (i.dueDate) cnt[i.dueDate] = (cnt[i.dueDate] || 0) + 1; });
+      summary.items.forEach((i) => {
+        if (i.dueDate) cnt[i.dueDate] = (cnt[i.dueDate] || 0) + 1;
+      });
       dueDate = Object.entries(cnt).sort((a, b) => b[1] - a[1])[0]?.[0] ?? "";
-
     } else {
       /* 공여기간 기반 조회 — 기존 집계 로직 유지 */
       const cardMap = {};
       txRows.forEach((r) => {
         const key = `${r["카드번호"]}_${r["결제예정일"] ?? ""}`;
-        if (!cardMap[key]) cardMap[key] = { cardNo: r["카드번호"], cardName: r["카드명"] ?? "", amount: 0, dueDate: r["결제예정일"] ?? "" };
+        if (!cardMap[key])
+          cardMap[key] = {
+            cardNo: r["카드번호"],
+            cardName: r["카드명"] ?? "",
+            amount: 0,
+            dueDate: r["결제예정일"] ?? "",
+          };
         cardMap[key].amount += Number(r["이용금액"] ?? 0);
       });
-      items       = Object.values(cardMap);
+      items = Object.values(cardMap);
       totalAmount = items.reduce((sum, i) => sum + i.amount, 0);
 
       const cnt = {};
-      txRows.forEach((r) => { const d = r["결제예정일"]; if (d) cnt[d] = (cnt[d] || 0) + 1; });
+      txRows.forEach((r) => {
+        const d = r["결제예정일"];
+        if (d) cnt[d] = (cnt[d] || 0) + 1;
+      });
       dueDate = Object.entries(cnt).sort((a, b) => b[1] - a[1])[0]?.[0] ?? "";
     }
 
@@ -962,8 +1122,8 @@ app.get("/api/cards/:cardId/payable-amount", verifyToken, async (req, res) => {
               AND "카드번호"     = :cardId
               AND "누적결제금액" < "이용금액"
               AND "결제상태코드" <> '9'`,
-              /* 결제상태코드 9(취소건)는 즉시결제 대상에서 제외.
-               * 0:미결제, 1:완납, 2:부분결제, 9:취소 */
+          /* 결제상태코드 9(취소건)는 즉시결제 대상에서 제외.
+           * 0:미결제, 1:완납, 2:부분결제, 9:취소 */
           { userId, cardId },
         ),
         /* 카드 한도금액 조회 */
@@ -978,7 +1138,7 @@ app.get("/api/cards/:cardId/payable-amount", verifyToken, async (req, res) => {
     );
 
     const payableAmount = Number(usageResult.rows?.[0]?.PAYABLE_AMOUNT ?? 0);
-    const creditLimit   = Number(cardResult.rows?.[0]?.CREDIT_LIMIT   ?? 0);
+    const creditLimit = Number(cardResult.rows?.[0]?.CREDIT_LIMIT ?? 0);
     res.json({ payableAmount, creditLimit });
   } catch (err) {
     console.error("[GET /api/cards/:cardId/payable-amount]", err);
@@ -1013,17 +1173,17 @@ app.get("/api/cards/:cardId/payable-amount", verifyToken, async (req, res) => {
  */
 app.post("/api/cards/:cardId/immediate-pay", verifyToken, async (req, res) => {
   try {
-    const userId        = req.user.userId;
-    const { cardId }    = req.params;
+    const userId = req.user.userId;
+    const { cardId } = req.params;
     const { pin, amount } = req.body;
     const requestAmount = Number(amount);
 
     // PIN 검증 — 오늘 날짜의 MMDD (월·일 각 2자리, 예: 4월 15일 → "0415")
-    const now      = new Date();
-    const mm       = String(now.getMonth() + 1).padStart(2, "0");
-    const dd       = String(now.getDate()).padStart(2, "0");
+    const now = new Date();
+    const mm = String(now.getMonth() + 1).padStart(2, "0");
+    const dd = String(now.getDate()).padStart(2, "0");
     const validPin = `${mm}${dd}`;
-    const pinKey   = `${userId}:${cardId}`; // 사용자·카드 조합 단위로 횟수 관리
+    const pinKey = `${userId}:${cardId}`; // 사용자·카드 조합 단위로 횟수 관리
     const attempts = pinAttemptStore.get(pinKey) ?? 0;
 
     if (attempts >= PIN_MAX_ATTEMPTS) {
@@ -1051,7 +1211,9 @@ app.post("/api/cards/:cardId/immediate-pay", verifyToken, async (req, res) => {
     pinAttemptStore.delete(pinKey);
 
     if (!requestAmount || requestAmount <= 0) {
-      return res.status(400).json({ error: "결제요청금액이 유효하지 않습니다." });
+      return res
+        .status(400)
+        .json({ error: "결제요청금액이 유효하지 않습니다." });
     }
 
     const result = await withConnection(async (conn) => {
@@ -1072,28 +1234,28 @@ app.post("/api/cards/:cardId/immediate-pay", verifyToken, async (req, res) => {
           { userId, cardId },
         );
 
-        let remaining      = requestAmount; // 아직 배분하지 못한 결제 잔여금
-        let totalPaid      = 0;             // 이번 결제에서 실제 차감된 총합계
-        let processedCount = 0;             // 업데이트된 내역 건수
+        let remaining = requestAmount; // 아직 배분하지 못한 결제 잔여금
+        let totalPaid = 0; // 이번 결제에서 실제 차감된 총합계
+        let processedCount = 0; // 업데이트된 내역 건수
 
         // ── 2. 이용일자 오래된 순으로 순차 차감 ────────────────────
         for (const row of rows) {
           if (remaining <= 0) break;
 
-          const 결제잔액    = Number(row["결제잔액"]);
+          const 결제잔액 = Number(row["결제잔액"]);
           const 누적결제금액 = Number(row["누적결제금액"]);
 
           let deducted, newBalance, newStatusCode;
 
           if (remaining >= 결제잔액) {
             // 완납: 이 내역의 잔액을 전부 결제하고 남은 금액을 다음 건으로 이월
-            deducted      = 결제잔액;
-            newBalance    = 0;
+            deducted = 결제잔액;
+            newBalance = 0;
             newStatusCode = "1"; // 1: 완납
           } else {
             // 부분결제: 남은 요청금액만큼만 차감하고 루프 종료
-            deducted      = remaining;
-            newBalance    = 결제잔액 - remaining;
+            deducted = remaining;
+            newBalance = 결제잔액 - remaining;
             newStatusCode = "2"; // 2: 부분결제
           }
 
@@ -1142,7 +1304,11 @@ app.post("/api/cards/:cardId/immediate-pay", verifyToken, async (req, res) => {
           )
         ).rows;
 
-        return { paidAmount: totalPaid, processedCount, completedAt: COMPLETED_AT };
+        return {
+          paidAmount: totalPaid,
+          processedCount,
+          completedAt: COMPLETED_AT,
+        };
       } catch (err) {
         // 어느 한 단계라도 실패하면 전체 롤백하여 데이터 무결성 보장
         await conn.rollback();
@@ -1180,9 +1346,9 @@ app.delete("/api/cards/:cardId/pin-attempts", verifyToken, (req, res) => {
  */
 app.get("/api/notices/sse", (req, res) => {
   // SSE 응답 헤더 설정
-  res.setHeader("Content-Type",  "text/event-stream");
+  res.setHeader("Content-Type", "text/event-stream");
   res.setHeader("Cache-Control", "no-cache");
-  res.setHeader("Connection",    "keep-alive");
+  res.setHeader("Connection", "keep-alive");
   res.flushHeaders();
 
   // 연결 즉시 현재 공지 상태 전송 (재접속 시 최신 상태 즉시 반영)
@@ -1212,18 +1378,22 @@ app.post("/api/notices/sync", verifyAdminSecret, (req, res) => {
   const { notices, displayType, closeableYn, hideTodayYn } = req.body;
 
   if (!notices || !Array.isArray(notices) || !displayType) {
-    return res.status(400).json({ error: "notices 배열과 displayType이 필요합니다." });
+    return res
+      .status(400)
+      .json({ error: "notices 배열과 displayType이 필요합니다." });
   }
 
   currentNotice = {
     notices,
     displayType,
-    closeableYn:  closeableYn  ?? "Y",
-    hideTodayYn:  hideTodayYn  ?? "Y",
+    closeableYn: closeableYn ?? "Y",
+    hideTodayYn: hideTodayYn ?? "Y",
   };
   broadcastNotice(currentNotice);
 
-  console.log(`[SSE] 긴급공지 배포 동기화 완료: displayType=${displayType}, 클라이언트=${clientCount()}명`);
+  console.log(
+    `[SSE] 긴급공지 배포 동기화 완료: displayType=${displayType}, 클라이언트=${clientCount()}명`,
+  );
   res.json({ success: true });
 });
 
@@ -1254,7 +1424,7 @@ app.get("/api/notices/preview", async (req, res) => {
         `SELECT DEFAULT_VALUE AS DISPLAY_TYPE
            FROM FWK_PROPERTY
           WHERE PROPERTY_GROUP_ID = 'notice'
-            AND PROPERTY_ID = 'USE_YN'`
+            AND PROPERTY_ID = 'USE_YN'`,
       );
       const row = statusRes.rows?.[0];
 
@@ -1264,13 +1434,13 @@ app.get("/api/notices/preview", async (req, res) => {
            FROM FWK_PROPERTY
           WHERE PROPERTY_GROUP_ID = 'notice'
             AND PROPERTY_ID IN ('EMERGENCY_KO', 'EMERGENCY_EN')
-          ORDER BY PROPERTY_ID`
+          ORDER BY PROPERTY_ID`,
       );
 
       return {
         notices: (noticeRes.rows || []).map((r) => ({
-          lang:    r.LANG,
-          title:   r.TITLE   || "",
+          lang: r.LANG,
+          title: r.TITLE || "",
           content: r.CONTENT || "",
         })),
         displayType: row?.DISPLAY_TYPE || "N",
@@ -1302,7 +1472,7 @@ async function restoreNoticeState() {
         `SELECT DEFAULT_VALUE AS DISPLAY_TYPE, DEPLOY_STATUS
            FROM FWK_PROPERTY
           WHERE PROPERTY_GROUP_ID = 'notice'
-            AND PROPERTY_ID = 'USE_YN'`
+            AND PROPERTY_ID = 'USE_YN'`,
       );
       const row = statusRes.rows?.[0];
       if (!row || row.DEPLOY_STATUS !== "DEPLOYED") return null;
@@ -1313,33 +1483,37 @@ async function restoreNoticeState() {
            FROM FWK_PROPERTY
           WHERE PROPERTY_GROUP_ID = 'notice'
             AND PROPERTY_ID IN ('EMERGENCY_KO', 'EMERGENCY_EN')
-          ORDER BY PROPERTY_ID`
+          ORDER BY PROPERTY_ID`,
       );
       // 노출 설정(닫기 버튼, 오늘 하루 보지 않기) 조회
       const settingsRes = await conn.execute(
         `SELECT PROPERTY_ID, DEFAULT_VALUE
            FROM FWK_PROPERTY
           WHERE PROPERTY_GROUP_ID = 'notice'
-            AND PROPERTY_ID IN ('CLOSEABLE_YN', 'HIDE_TODAY_YN')`
+            AND PROPERTY_ID IN ('CLOSEABLE_YN', 'HIDE_TODAY_YN')`,
       );
       const settingsMap = {};
-      (settingsRes.rows || []).forEach((r) => { settingsMap[r.PROPERTY_ID] = r.DEFAULT_VALUE; });
+      (settingsRes.rows || []).forEach((r) => {
+        settingsMap[r.PROPERTY_ID] = r.DEFAULT_VALUE;
+      });
 
       return {
-        notices:     (noticeRes.rows || []).map((r) => ({
-          lang:    r.LANG,
-          title:   r.TITLE   || "",
+        notices: (noticeRes.rows || []).map((r) => ({
+          lang: r.LANG,
+          title: r.TITLE || "",
           content: r.CONTENT || "",
         })),
-        displayType:  row.DISPLAY_TYPE || "N",
-        closeableYn:  settingsMap["CLOSEABLE_YN"]  ?? "Y",
-        hideTodayYn:  settingsMap["HIDE_TODAY_YN"] ?? "Y",
+        displayType: row.DISPLAY_TYPE || "N",
+        closeableYn: settingsMap["CLOSEABLE_YN"] ?? "Y",
+        hideTodayYn: settingsMap["HIDE_TODAY_YN"] ?? "Y",
       };
     });
 
     if (result) {
       currentNotice = result;
-      console.log(`[Server] 긴급공지 상태 복구 완료: displayType=${result.displayType}`);
+      console.log(
+        `[Server] 긴급공지 상태 복구 완료: displayType=${result.displayType}`,
+      );
     } else {
       console.log("[Server] 배포 중인 긴급공지 없음 — 초기 상태로 기동");
     }
@@ -1350,7 +1524,7 @@ async function restoreNoticeState() {
 
 async function start() {
   try {
-    await initPool();           // ① 커넥션 풀 먼저 생성
+    await initPool(); // ① 커넥션 풀 먼저 생성
     await restoreNoticeState(); // ② 재기동 시 배포 상태 복구
 
     app.listen(PORT, () => {

--- a/demo/front/src/api/axiosInstance.ts
+++ b/demo/front/src/api/axiosInstance.ts
@@ -27,7 +27,7 @@ const        STORAGE_KEY = 'hnc_auth';
 // ── 모듈 레벨 인증 콜백 ─────────────────────────────────────────────────────
 // React 컴포넌트 트리 외부에서 AuthContext 메서드를 호출하기 위한 참조.
 // AuthProvider 마운트 시 registerAuthCallbacks()로 등록된다.
-type TokenRefreshedCb = (newToken: string) => void;
+type TokenRefreshedCb = (newToken: string, lastLogin?: string) => void;
 type AuthFailureCb   = () => void;
 
 let _onTokenRefreshed: TokenRefreshedCb | null = null;
@@ -157,20 +157,25 @@ axiosInstance.interceptors.response.use(
     try {
       // axiosInstance 대신 axios 직접 사용 → 이 인터셉터 재진입 방지
       // withCredentials: true 로 httpOnly 쿠키(Refresh Token) 자동 전송
-      const { data } = await axios.post<{ accessToken: string }>(
+      const { data } = await axios.post<{ accessToken: string; lastLogin?: string }>(
         `${API_BASE}/auth/refresh`,
         {},
         { withCredentials: true },
       );
 
-      const newToken = data.accessToken;
+      const newToken  = data.accessToken;
+      const lastLogin = data.lastLogin;
 
-      // localStorage의 Access Token만 갱신 (Refresh Token은 쿠키로 백엔드 관리)
+      // localStorage의 Access Token과 lastLogin을 함께 갱신한다.
+      // lastLogin이 없는 경우(구버전 서버 호환) 기존 값을 유지한다.
       const raw  = localStorage.getItem(STORAGE_KEY);
       const auth = raw ? JSON.parse(raw) : {};
-      localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...auth, token: newToken }));
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ ...auth, token: newToken, ...(lastLogin ? { lastLogin } : {}) }),
+      );
 
-      _onTokenRefreshed?.(newToken);
+      _onTokenRefreshed?.(newToken, lastLogin);
 
       isRefreshing = false;
       flushQueue(newToken);

--- a/demo/front/src/contexts/AuthContext.tsx
+++ b/demo/front/src/contexts/AuthContext.tsx
@@ -25,15 +25,18 @@ export interface AuthUser {
   userId:    string;
   userName:  string;
   userGrade: string;
-  token:     string; // Access Token (localStorage 저장, 짧은 TTL)
+  token:     string;     // Access Token (localStorage 저장, 짧은 TTL)
+  lastLogin: string;     // 이전 로그인 시각 (로그인 응답 시 업데이트 전 값, 'YYYY.MM.DD HH:MM:SS')
   // Refresh Token은 httpOnly 쿠키로 백엔드 관리 — 이 인터페이스에 포함하지 않음
 }
 
 interface AuthContextValue {
-  user:       AuthUser | null;
-  isLoggedIn: boolean;
-  login:      (user: AuthUser) => void;
-  logout:     () => void;
+  user:             AuthUser | null;
+  isLoggedIn:       boolean;
+  login:            (user: AuthUser) => void;
+  logout:           () => void;
+  /** lastLogin만 갱신한다. 자동 로그인 후 /api/auth/me로 보완할 때 사용. */
+  setLastLogin:     (lastLogin: string) => void;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -57,7 +60,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logout = () => {
     localStorage.removeItem(STORAGE_KEY);
+    // 로그아웃 시 자동 로그인 해제 — 다음 방문에서 로그인 화면을 다시 거치도록 한다
+    localStorage.removeItem('hnc_auto_login');
     setUser(null);
+  };
+
+  const setLastLogin = (lastLogin: string) => {
+    setUser(prev => {
+      if (!prev) return prev;
+      const next = { ...prev, lastLogin };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      return next;
+    });
   };
 
   /**
@@ -68,9 +82,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
    */
   useEffect(() => {
     registerAuthCallbacks(
-      // Access Token 갱신 성공: token 필드만 교체 (나머지 사용자 정보 유지)
-      (newToken: string) => {
-        setUser(prev => (prev ? { ...prev, token: newToken } : prev));
+      // Access Token 갱신 성공: token·lastLogin 교체 (나머지 사용자 정보 유지)
+      // lastLogin이 전달된 경우(자동 로그인 등) '최근 접속 일시'를 즉시 갱신한다.
+      (newToken: string, lastLogin?: string) => {
+        setUser(prev =>
+          prev
+            ? { ...prev, token: newToken, ...(lastLogin ? { lastLogin } : {}) }
+            : prev,
+        );
       },
       // Refresh 실패: 완전 세션 만료 → 로그인 페이지 Modal용 메시지를 세션에 남기고 상태 초기화
       () => {
@@ -82,7 +101,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []); // 마운트 시 한 번만 등록
 
   return (
-    <AuthContext.Provider value={{ user, isLoggedIn: !!user, login, logout }}>
+    <AuthContext.Provider value={{ user, isLoggedIn: !!user, login, logout, setLastLogin }}>
       {children}
     </AuthContext.Provider>
   );

--- a/demo/front/src/pages/common/LoginPage/index.tsx
+++ b/demo/front/src/pages/common/LoginPage/index.tsx
@@ -22,6 +22,7 @@ import { Inline } from "@cl/layout/Inline";
 import { Typography } from "@cl/core/Typography";
 import { Input } from "@cl/core/Input";
 import { Button } from "@cl/core/Button";
+import { Checkbox } from "@cl/modules/common/Checkbox";
 import { DividerWithLabel } from "@cl/modules/common/DividerWithLabel";
 import { QuickMenuGrid } from "@cl/biz/common/QuickMenuGrid";
 import type { LoginPageProps } from "./types";
@@ -37,6 +38,10 @@ export function LoginPage({
   showPassword = false,
   onTogglePassword,
   onLogin,
+  saveId = false,
+  onSaveIdChange,
+  autoLogin = false,
+  onAutoLoginChange,
 }: LoginPageProps) {
   const ALT_LOGIN_ITEMS = [
     {
@@ -93,6 +98,8 @@ export function LoginPage({
             placeholder="비밀번호를 입력하세요"
             value={password}
             onChange={(e) => onPasswordChange?.(e.target.value)}
+            // Enter 키 입력 시 로그인 버튼 클릭과 동일하게 처리
+            onKeyDown={(e) => e.key === "Enter" && onLogin?.()}
             fullWidth
             validationState={hasError ? "error" : "default"}
             helperText={
@@ -107,11 +114,27 @@ export function LoginPage({
                 aria-label={showPassword ? "비밀번호 숨김" : "비밀번호 표시"}
                 onClick={onTogglePassword}
                 className="text-text-muted"
-                leftIcon={showPassword ? <Eye size={20} /> : <EyeOff size={20} />}
+                leftIcon={
+                  showPassword ? <Eye size={20} /> : <EyeOff size={20} />
+                }
               />
             }
           />
         </Stack>
+
+        {/* 아이디 저장 / 자동 로그인 — 각각 독립적으로 체크 가능 */}
+        <Inline gap="lg" className="pt-xs">
+          <Checkbox
+            label="아이디 저장"
+            checked={saveId}
+            onChange={onSaveIdChange ?? (() => {})}
+          />
+          <Checkbox
+            label="자동 로그인"
+            checked={autoLogin}
+            onChange={onAutoLoginChange ?? (() => {})}
+          />
+        </Inline>
 
         <Inline justify="center" gap="sm" className="py-sm">
           <Button variant="ghost" size="sm" onClick={() => {}}>
@@ -133,7 +156,7 @@ export function LoginPage({
           </Button>
         </Inline>
 
-        <div className="pt-md">
+        <div className="pt-md pb-lg">
           <Button variant="primary" size="lg" fullWidth onClick={onLogin}>
             로그인
           </Button>

--- a/demo/front/src/pages/common/LoginPage/types.ts
+++ b/demo/front/src/pages/common/LoginPage/types.ts
@@ -20,4 +20,12 @@ export interface LoginPageProps {
   onTogglePassword?: () => void;
   /** 로그인 버튼 클릭 핸들러 */
   onLogin?: () => void;
+  /** 아이디 저장 체크 여부 — true 시 로그인 성공 후 userId를 localStorage에 보관 */
+  saveId?: boolean;
+  /** 아이디 저장 체크 변경 핸들러 */
+  onSaveIdChange?: (checked: boolean) => void;
+  /** 자동 로그인 체크 여부 — true 시 다음 방문 시 로그인 화면을 건너뜀 */
+  autoLogin?: boolean;
+  /** 자동 로그인 체크 변경 핸들러 */
+  onAutoLoginChange?: (checked: boolean) => void;
 }

--- a/demo/front/src/routes/RouteWrappers.tsx
+++ b/demo/front/src/routes/RouteWrappers.tsx
@@ -73,7 +73,7 @@ import {
 /* ------------------------------------------------------------------ */
 
 /** localStorage 키 상수 */
-const LS_SAVED_ID   = "hnc_saved_id";
+const LS_SAVED_ID = "hnc_saved_id";
 const LS_AUTO_LOGIN = "hnc_auto_login";
 
 export function LoginRoute() {
@@ -81,11 +81,17 @@ export function LoginRoute() {
   const { login, isLoggedIn } = useAuth();
 
   // 이전 방문에서 저장된 값으로 초기화
-  const [saveId,    setSaveId]    = useState(() => !!localStorage.getItem(LS_SAVED_ID));
-  const [autoLogin, setAutoLogin] = useState(() => !!localStorage.getItem(LS_AUTO_LOGIN));
+  const [saveId, setSaveId] = useState(
+    () => !!localStorage.getItem(LS_SAVED_ID),
+  );
+  const [autoLogin, setAutoLogin] = useState(
+    () => !!localStorage.getItem(LS_AUTO_LOGIN),
+  );
 
   // 아이디 저장이 켜져 있으면 저장된 아이디로 초기화, 아니면 빈 문자열
-  const [userId,   setUserId]   = useState(() => localStorage.getItem(LS_SAVED_ID) ?? "");
+  const [userId, setUserId] = useState(
+    () => localStorage.getItem(LS_SAVED_ID) ?? "",
+  );
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [hasError, setHasError] = useState(false);
@@ -96,13 +102,13 @@ export function LoginRoute() {
 
   /**
    * 자동 로그인 처리: 플래그가 있고 이미 로그인 상태이면 대시보드로 이동한다.
-   * - 마운트 시 한 번만 확인하므로 의존성 배열을 비워둔다.
+   * isLoggedIn 또는 navigate가 바뀔 때마다 재평가한다.
    */
   useEffect(() => {
     if (isLoggedIn && localStorage.getItem(LS_AUTO_LOGIN)) {
       navigate(PATHS.CARD.DASHBOARD, { replace: true });
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isLoggedIn, navigate]);
 
   const handleLogin = async () => {
     setHasError(false);
@@ -126,10 +132,10 @@ export function LoginRoute() {
           localStorage.removeItem(LS_AUTO_LOGIN);
         }
         login({
-          userId:    data.userId,
-          userName:  data.userName,
+          userId: data.userId,
+          userName: data.userName,
           userGrade: data.userGrade,
-          token:     data.token,
+          token: data.token,
           lastLogin: data.lastLogin ?? "", // 최초 로그인 시 LAST_LOGIN_DTIME이 null이면 빈 문자열
         });
         navigate(PATHS.CARD.DASHBOARD);
@@ -220,7 +226,7 @@ export function CardDashboardRoute() {
       .get<{ lastLogin: string }>("/auth/me")
       .then(({ data }) => { if (data.lastLogin) setLastLogin(data.lastLogin); })
       .catch(() => {}); // 실패해도 화면 진입은 허용
-  }, [user?.userId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [user?.userId, user?.lastLogin, setLastLogin]);
 
   // 대시보드 진입 시 이전 즉시결제 플로우의 세션 데이터를 일괄 삭제한다.
   // 완료 화면에서 삭제하지 않는 이유: 완료 화면을 건너뛰고 직접 대시보드로 오는 경우에도

--- a/demo/front/src/routes/RouteWrappers.tsx
+++ b/demo/front/src/routes/RouteWrappers.tsx
@@ -72,10 +72,20 @@ import {
 /* 공통 / 인증                                                           */
 /* ------------------------------------------------------------------ */
 
+/** localStorage 키 상수 */
+const LS_SAVED_ID   = "hnc_saved_id";
+const LS_AUTO_LOGIN = "hnc_auto_login";
+
 export function LoginRoute() {
   const navigate = useNavigate();
-  const { login } = useAuth();
-  const [userId, setUserId] = useState("");
+  const { login, isLoggedIn } = useAuth();
+
+  // 이전 방문에서 저장된 값으로 초기화
+  const [saveId,    setSaveId]    = useState(() => !!localStorage.getItem(LS_SAVED_ID));
+  const [autoLogin, setAutoLogin] = useState(() => !!localStorage.getItem(LS_AUTO_LOGIN));
+
+  // 아이디 저장이 켜져 있으면 저장된 아이디로 초기화, 아니면 빈 문자열
+  const [userId,   setUserId]   = useState(() => localStorage.getItem(LS_SAVED_ID) ?? "");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [hasError, setHasError] = useState(false);
@@ -83,6 +93,16 @@ export function LoginRoute() {
   const [sessionMessage, setSessionMessage] = useState(
     () => sessionStorage.getItem("sessionExpiredMessage") ?? "",
   );
+
+  /**
+   * 자동 로그인 처리: 플래그가 있고 이미 로그인 상태이면 대시보드로 이동한다.
+   * - 마운트 시 한 번만 확인하므로 의존성 배열을 비워둔다.
+   */
+  useEffect(() => {
+    if (isLoggedIn && localStorage.getItem(LS_AUTO_LOGIN)) {
+      navigate(PATHS.CARD.DASHBOARD, { replace: true });
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleLogin = async () => {
     setHasError(false);
@@ -93,11 +113,24 @@ export function LoginRoute() {
         password,
       });
       if (data.success) {
+        // 아이디 저장: 체크 시 userId를 localStorage에 보관, 해제 시 삭제
+        if (saveId) {
+          localStorage.setItem(LS_SAVED_ID, userId);
+        } else {
+          localStorage.removeItem(LS_SAVED_ID);
+        }
+        // 자동 로그인: 체크 시 플래그를 저장해 다음 방문 시 대시보드로 자동 이동
+        if (autoLogin) {
+          localStorage.setItem(LS_AUTO_LOGIN, "1");
+        } else {
+          localStorage.removeItem(LS_AUTO_LOGIN);
+        }
         login({
-          userId: data.userId,
-          userName: data.userName,
+          userId:    data.userId,
+          userName:  data.userName,
           userGrade: data.userGrade,
-          token: data.token,
+          token:     data.token,
+          lastLogin: data.lastLogin ?? "", // 최초 로그인 시 LAST_LOGIN_DTIME이 null이면 빈 문자열
         });
         navigate(PATHS.CARD.DASHBOARD);
       } else {
@@ -119,6 +152,10 @@ export function LoginRoute() {
         showPassword={showPassword}
         onTogglePassword={() => setShowPassword((v) => !v)}
         onLogin={handleLogin}
+        saveId={saveId}
+        onSaveIdChange={setSaveId}
+        autoLogin={autoLogin}
+        onAutoLoginChange={setAutoLogin}
       />
       <Modal
         open={!!sessionMessage}
@@ -165,7 +202,7 @@ function parseDueDateKo(raw: string): string {
 export function CardDashboardRoute() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { user } = useAuth();
+  const { user, setLastLogin } = useAuth();
   const { notice } = useEmergencyNotice(); // SSE 긴급공지 구독
 
   /** StatementHeroCard: 공여기간 기준 이번 달 결제 예정 금액 */
@@ -174,6 +211,29 @@ export function CardDashboardRoute() {
   const [statementDueDate, setStatementDueDate] = useState("");
   /** SummaryCard(spending): 당월 이용내역 합산 금액 */
   const [spendingAmount, setSpendingAmount] = useState(0);
+
+  // lastLogin이 없는 경우(변경 전 로그인 세션, 자동 로그인 등) /api/auth/me로 보완한다.
+  // Access Token이 유효한 동안은 refresh가 호출되지 않으므로 대시보드 진입 시점에 한 번 확인한다.
+  useEffect(() => {
+    if (!user?.userId || user.lastLogin) return;
+    axiosInstance
+      .get<{ lastLogin: string }>("/auth/me")
+      .then(({ data }) => { if (data.lastLogin) setLastLogin(data.lastLogin); })
+      .catch(() => {}); // 실패해도 화면 진입은 허용
+  }, [user?.userId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // 대시보드 진입 시 이전 즉시결제 플로우의 세션 데이터를 일괄 삭제한다.
+  // 완료 화면에서 삭제하지 않는 이유: 완료 화면을 건너뛰고 직접 대시보드로 오는 경우에도
+  // 잔여 세션이 남지 않도록 대시보드 진입 시점을 기준으로 정리한다.
+  useEffect(() => {
+    [
+      "immediatePaySelectedCard",
+      "immediatePayAmountInfo",
+      "immediatePayRequestData",
+      "immediatePaySelectedAccount",
+      "immediatePayCompletedAt",
+    ].forEach((key) => sessionStorage.removeItem(key));
+  }, []); // 대시보드 마운트 시 한 번만 실행
 
   useEffect(() => {
     if (!user?.userId) return;
@@ -1003,20 +1063,11 @@ export function ImmediatePayCompleteRoute() {
   const navigate = useNavigate();
 
   // 이전 단계에서 세션에 저장된 카드·결제·계좌·금액·처리일시 정보를 읽는다.
+  // 세션 삭제는 대시보드 진입 시 수행한다 (CardDashboardRoute useEffect 참고).
   const storedCard = sessionStorage.getItem("immediatePaySelectedCard");
   const storedRequest = sessionStorage.getItem("immediatePayRequestData");
   const storedAccount = sessionStorage.getItem("immediatePaySelectedAccount");
   const storedAmountInfo = sessionStorage.getItem("immediatePayAmountInfo");
-  // 화면이 마운트되면(데이터 읽기 완료 후) 즉시결제 플로우 세션을 일괄 삭제한다.
-  useEffect(() => {
-    [
-      "immediatePaySelectedCard",
-      "immediatePayAmountInfo",
-      "immediatePayRequestData",
-      "immediatePaySelectedAccount",
-      "immediatePayCompletedAt",
-    ].forEach((key) => sessionStorage.removeItem(key));
-  }, []);
 
   // 서버 반환 처리일시 사용. 세션 없음·"undefined" 문자열인 경우 클라이언트 현재 시각으로 대체
   const rawCompletedAt = sessionStorage.getItem("immediatePayCompletedAt");
@@ -1336,7 +1387,7 @@ export function NoticePreviewRoute() {
  */
 export function HanaCardMenuModal() {
   const navigate = useNavigate();
-  const { logout } = useAuth();
+  const { user, logout } = useAuth();
 
   const menuItems: MenuItem[] = [
     {
@@ -1393,8 +1444,8 @@ export function HanaCardMenuModal() {
   return (
     <ModalSlideOver onClose={() => navigate(-1)}>
       <HanaCardMenuPage
-        userName="홍길동님"
-        lastLogin="2026.04.09 10:00:00"
+        userName={user ? `${user.userName}님` : ""}
+        lastLogin={user?.lastLogin ?? ""}
         categories={[
           { id: "all", label: "전체" },
           { id: "history", label: "이용내역" },


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
- #34

## ✨ 변경 사항 (Changes)

### Backend (`demo/backend/server.js`)
- `GET /api/auth/me` 엔드포인트 추가 — Access Token 유효 구간에서 `lastLogin` 보완
- `POST /api/auth/login` 응답에 `lastLogin`(이전 접속 시각) 추가
- `POST /api/auth/refresh` 응답에 `lastLogin`(갱신 시각) 추가 + `LAST_LOGIN_DTIME` DB 갱신
- `formatLoginDtime` 유틸 함수 추가 (`YYYYMMDDHH24MISS` → `YYYY.MM.DD HH:MM:SS`)

### Frontend
- **`axiosInstance.ts`**: Refresh 응답에서 `lastLogin` 수신 → localStorage 및 콜백에 전달
- **`AuthContext.tsx`**: `AuthUser.lastLogin` 필드 추가, `setLastLogin` 함수 추가, 로그아웃 시 `hnc_auto_login` 플래그 삭제
- **`LoginPage`**: 아이디 저장 / 자동 로그인 Checkbox UI 추가, 비밀번호 입력 시 Enter 키 로그인 처리
- **`RouteWrappers.tsx`**:
  - `LoginRoute`: 저장된 아이디 초기값 반영, 자동 로그인 플래그 처리
  - `CardDashboardRoute`: `lastLogin` 누락 시 `/api/auth/me` 호출로 보완, 즉시결제 세션 정리를 대시보드 진입 시점으로 이동
  - `HanaCardMenuModal`: 하드코딩 Mock 값(`"홍길동님"`, `"2026.04.09 10:00:00"`) → `user.userName` · `user.lastLogin` 실데이터 교체

## ⚠️ 고려 및 주의 사항 (선택)
- `lastLogin`은 로그인 응답 시 **업데이트 직전 값**을 반환하므로 "이전 접속 시각"이 표시된다. 이는 의도된 동작이다.
- Refresh Token 갱신 시 DB 업데이트는 비동기 처리되며, 응답의 `lastLogin`은 JS 현재 시각으로 생성한다. (실패 시에도 토큰 발급은 허용)
- 자동 로그인은 `hnc_auto_login` localStorage 플래그로 관리하며, Refresh Token 유효 기간(7일) 만료 시 자동 해제된다.

## 💬 리뷰 포인트 (선택)
- `CardDashboardRoute`의 `/api/auth/me` 호출: `user.lastLogin`이 없을 때만 한 번 호출하도록 처리했습니다.
- 즉시결제 세션 정리 위치를 완료 화면 → 대시보드 진입으로 변경했습니다. 완료 화면을 건너뛰고 직접 대시보드로 오는 경우에도 잔여 세션이 남지 않도록 하기 위함입니다.