### PR TITLE
feat: React 코드 승인 관리 메뉴 구현 (#22)

### DIFF
--- a/admin/docs/react-approval-work-plan.md
+++ b/admin/docs/react-approval-work-plan.md
@@ -1,0 +1,387 @@
+# React 코드 승인 관리 — 작업 계획서
+
+- **이슈**: [#22 React 코드 승인 관리 메뉴 구현](https://github.com/neobnsrnd-team/POC_HNC/issues/22)
+- **작성일**: 2026-04-16
+- **선행 조건**: 없음 (현재 코드베이스에서 바로 착수 가능)
+- **후행 이슈**: [#31 React 코드 배포 관리 메뉴 구현](https://github.com/neobnsrnd-team/POC_HNC/issues/31)
+
+---
+
+## 1. 현재 상태 (As-Is)
+
+### 구현된 것
+
+| 항목 | 위치 | 내용 |
+|------|------|------|
+| STATUS enum | `ReactGenerateStatus.java` | `GENERATED`, `FAILED`, `PENDING_APPROVAL`, `APPROVED`, `REJECTED` |
+| 승인 요청 API | `ReactGenerateController` `POST /{id}/request-approval` | 작성자 본인 검증 포함 |
+| 승인 API | `ReactGenerateController` `POST /{id}/approve` | 구현됨, 단 **요청자 != 승인자 검증 없음** |
+| 보안 스캔 | `ReactGenerateService.generate()` Step 6 | `CodeValidator`로 생성 시점에 실행, 실패 시 `FAILED` 저장 |
+| DDL | `FWK_RPS_CODE_HIS` | `SCAN_PASSED`/`SCAN_FAILED` 없이 이미 올바른 상태 |
+
+### 없는 것 (구현 필요)
+
+- 반려(`reject`) API 및 로직
+- 승인자 != 요청자 검증 (서버 사이드)
+- `PENDING_APPROVAL` 전용 목록 조회 쿼리/API
+- **React 코드 승인 관리** 신규 메뉴 (뷰, JS, 권한)
+- `ReactApprovalService` / `ReactApprovalController` 분리
+
+---
+
+## 2. 목표 상태 (To-Be)
+
+### 상태 흐름
+
+```
+[코드 생성 요청]
+      ↓ 품질 검사(CodeValidator) → 보안 스캔 — 자동 실행
+ GENERATED ←──── FAILED  (검사 실패, FAIL_REASON에 상세 기록)
+      ↓  승인 요청 (작성자 본인)
+ PENDING_APPROVAL
+      ↓  승인 (작성자 외 1인)
+   APPROVED  ──→  [이슈 #31 배포 관리로 이어짐]
+      ↑↓ 반려 (어느 단계에서든)
+  REJECTED
+```
+
+### 신규 API 구조
+
+```
+/api/react-approval
+  GET    /              PENDING_APPROVAL 목록 조회 (페이지네이션)
+  POST   /{id}/approve  승인 (요청자 본인 불가)
+  POST   /{id}/reject   반려 (어느 단계에서든 가능)
+```
+
+---
+
+## 3. 작업 단계
+
+### Step 1. DDL 확인 및 수정 (`docs/sql/`)
+
+> 현재 `CHK_REACT_GEN_STATUS` 제약에 `FIRST_APPROVED`가 없으므로 **추가 DDL 변경 불필요**.
+> MySQL DDL도 동일하게 확인만 하면 됨.
+
+- [ ] `docs/sql/oracle/01_create_tables.sql` — CHECK 제약 확인 (이미 올바름)
+- [ ] `docs/sql/mysql/01_create_tables.sql` — 동일 상태 확인
+
+---
+
+### Step 2. 백엔드 — Mapper
+
+**파일**: `ReactGenerateMapper.xml`, `ReactGenerateMapper.java`
+
+#### 2-1. `selectPendingList` 쿼리 추가
+
+`PENDING_APPROVAL` 상태만 조회하는 전용 쿼리. 기존 `selectList`와 별도로 분리하여 승인 관리 메뉴 전용으로 사용한다.
+
+```xml
+<!-- ReactGenerateMapper.xml에 추가 -->
+<select id="selectPendingList"
+        resultType="com.example.admin_demo.domain.reactgenerate.dto.ReactApprovalResponse">
+    SELECT *
+    FROM (
+        SELECT INNER_QRY.*, ROWNUM AS RNUM
+        FROM (
+            SELECT
+                CODE_ID        AS codeId,
+                FIGMA_URL      AS figmaUrl,
+                STATUS         AS status,
+                CREATE_USER_ID AS createUserId,
+                CREATE_DTIME   AS createDtime
+            FROM FWK_RPS_CODE_HIS
+            WHERE STATUS = 'PENDING_APPROVAL'
+            ORDER BY CREATE_DTIME ASC  -- 오래된 요청 먼저
+        ) INNER_QRY
+        WHERE ROWNUM <= #{endRow}
+    )
+    WHERE RNUM > #{offset}
+</select>
+
+<select id="selectPendingCount" resultType="int">
+    SELECT COUNT(*) FROM FWK_RPS_CODE_HIS WHERE STATUS = 'PENDING_APPROVAL'
+</select>
+```
+
+#### 2-2. `ReactGenerateMapper.java`에 인터페이스 추가
+
+```java
+List<ReactApprovalResponse> selectPendingList(
+    @Param("offset") int offset,
+    @Param("endRow") int endRow);
+
+int selectPendingCount();
+```
+
+---
+
+### Step 3. 백엔드 — DTO
+
+**파일 신규 생성**: `dto/ReactApprovalResponse.java`
+
+승인 관리 목록에 필요한 필드만 담는 경량 DTO.
+
+```java
+@Data @NoArgsConstructor @AllArgsConstructor @Builder
+public class ReactApprovalResponse {
+    private String codeId;
+    private String figmaUrl;
+    private String status;
+    private String createUserId;
+    private String createDtime;
+}
+```
+
+> `ReactGenerateApprovalResponse`(승인 요청 응답용)는 기존 그대로 유지.
+
+---
+
+### Step 4. 백엔드 — Service
+
+**파일 신규 생성**: `service/ReactApprovalService.java`
+
+기존 `ReactGenerateService`에 섞여 있는 `approve()` / `requestApproval()`과 분리하여 승인 워크플로우를 전담한다.
+
+#### 4-1. `getPendingList(page, size)`
+
+```java
+public Map<String, Object> getPendingList(int page, int size) {
+    int offset = (page - 1) * size;
+    int endRow = offset + size;
+    List<ReactApprovalResponse> list = reactGenerateMapper.selectPendingList(offset, endRow);
+    int totalCount = reactGenerateMapper.selectPendingCount();
+    return Map.of("list", list, "totalCount", totalCount, "page", page, "size", size);
+}
+```
+
+#### 4-2. `approve(id, approverUserId)`
+
+```java
+public ReactGenerateApprovalResponse approve(String id, String approverUserId) {
+    ReactGenerateResponse existing = requirePendingApproval(id);
+
+    // 요청자 본인 승인 불가 — 클라이언트 우회 방지
+    if (approverUserId.equals(existing.getCreateUserId())) {
+        throw new InvalidInputException("코드 요청자는 승인할 수 없습니다.");
+    }
+
+    String now = LocalDateTime.now().format(FORMATTER);
+    reactGenerateMapper.updateStatus(id, ReactGenerateStatus.APPROVED.name(), approverUserId, now);
+    log.info("승인 완료 — codeId: {}, approver: {}", id, approverUserId);
+
+    return ReactGenerateApprovalResponse.builder()
+            .codeId(id).status(ReactGenerateStatus.APPROVED.name())
+            .approvalUserId(approverUserId).approvalDtime(now).build();
+}
+```
+
+#### 4-3. `reject(id, rejectorUserId)`
+
+```java
+// 어느 단계(PENDING_APPROVAL, GENERATED 등)에서든 반려 가능
+public ReactGenerateApprovalResponse reject(String id, String rejectorUserId) {
+    requireExists(id);
+    String now = LocalDateTime.now().format(FORMATTER);
+    reactGenerateMapper.updateStatus(id, ReactGenerateStatus.REJECTED.name(), rejectorUserId, now);
+    log.info("반려 완료 — codeId: {}, rejector: {}", id, rejectorUserId);
+
+    return ReactGenerateApprovalResponse.builder()
+            .codeId(id).status(ReactGenerateStatus.REJECTED.name())
+            .approvalUserId(rejectorUserId).approvalDtime(now).build();
+}
+```
+
+#### 4-4. 기존 `ReactGenerateService` 정리
+
+- `approve()` 메서드 → `ReactApprovalService`로 이동 후 **요청자 != 승인자 검증 추가**
+- `requestApproval()` 메서드는 생성 도메인 범주이므로 `ReactGenerateService`에 유지
+
+---
+
+### Step 5. 백엔드 — Controller
+
+**파일 신규 생성**: `controller/ReactApprovalController.java`
+
+기존 `ReactGenerateController`의 `approve()` 엔드포인트는 제거하고, 승인 관련 엔드포인트를 이 컨트롤러로 일원화한다.
+
+```java
+@RestController
+@RequestMapping("/api/react-approval")
+@PreAuthorize("hasAuthority('REACT_APPROVAL:R')")
+@RequiredArgsConstructor
+public class ReactApprovalController {
+
+    private final ReactApprovalService reactApprovalService;
+
+    // PENDING_APPROVAL 목록 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<Map<String, Object>>> getPendingList(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size) { ... }
+
+    // 승인
+    @PostMapping("/{id}/approve")
+    @PreAuthorize("hasAuthority('REACT_APPROVAL:W')")
+    public ResponseEntity<ApiResponse<ReactGenerateApprovalResponse>> approve(
+            @PathVariable String id) { ... }
+
+    // 반려
+    @PostMapping("/{id}/reject")
+    @PreAuthorize("hasAuthority('REACT_APPROVAL:W')")
+    public ResponseEntity<ApiResponse<ReactGenerateApprovalResponse>> reject(
+            @PathVariable String id) { ... }
+}
+```
+
+> **레이어 의존성 규칙 준수**: `ReactApprovalController` → `ReactApprovalService` → `ReactGenerateMapper`
+
+---
+
+### Step 6. 권한 등록
+
+**파일**: `src/main/resources/menu-resource-permissions.yml`
+
+```yaml
+v3_react_approval:
+  R: REACT_APPROVAL:R
+  W: REACT_APPROVAL:W
+```
+
+---
+
+### Step 7. 프론트엔드 — 뷰
+
+**파일 신규 생성**: `templates/pages/react-approval/react-approval.html`
+
+긴급공지 배포 관리 뷰 구조를 참고하여 구성.
+
+```
+[React 코드 승인 관리]
+┌─────────────────────────────────────────────────┐
+│  PENDING_APPROVAL 목록 테이블                     │
+│  CODE_ID | Figma URL | 요청자 | 요청일시 | 액션   │
+│  [코드 보기] [승인] [반려]                        │
+├─────────────────────────────────────────────────┤
+│  페이징                                          │
+└─────────────────────────────────────────────────┘
+
+[코드 미리보기 모달]
+  - 생성된 React 코드 표시 (read-only)
+  - 코드 복사 버튼
+```
+
+**권한 분기**:
+- `REACT_APPROVAL:R` — 목록 조회, 코드 보기
+- `REACT_APPROVAL:W` — 승인/반려 버튼 노출
+
+---
+
+### Step 8. 프론트엔드 — JS 스크립트
+
+**파일 신규 생성**: `templates/pages/react-approval/react-approval-script.html`
+
+```javascript
+const ReactApprovalPage = {
+    currentPage: 1,
+    pageSize: 10,
+
+    init()       // load(1) + 버튼 이벤트 바인딩
+    load(page)   // GET /api/react-approval?page=&size= → renderTable() + renderPagination()
+    renderTable(list, total)
+    renderPagination(total)
+    openCodeModal(codeId)  // GET /api/react-generate/{id} → 모달에 코드 표시
+    approve(id)  // confirm → POST /api/react-approval/{id}/approve → load(1) + EventBus.emit
+    reject(id)   // confirm + 반려 사유 입력 → POST /api/react-approval/{id}/reject → load(1)
+}
+```
+
+**EventBus 발행**: 승인/반려 후 생성 이력 탭 갱신
+```javascript
+EventBus.emit('admin:reactApproval:statusChanged');
+```
+
+---
+
+### Step 9. 프론트엔드 — 승인 요청 버튼 연결
+
+**파일**: `templates/pages/react-generate/react-generate-script.html`
+
+현재 승인 요청은 이미 실제 API를 호출하고 있으므로 추가 수정 불필요.
+승인 버튼(`btnApprove`)은 `ReactGenerateController`에 있는 기존 엔드포인트에서
+**신규 `ReactApprovalController`로 URL 변경** 필요:
+
+```javascript
+// 변경 전
+url: API_BASE_URL + '/react-generate/' + currentId + '/approve'
+
+// 변경 후
+url: API_BASE_URL + '/react-approval/' + currentId + '/approve'
+```
+
+---
+
+## 4. 작업 순서 및 의존 관계
+
+```
+Step 1 (DDL 확인)
+    ↓
+Step 2–3 (Mapper + DTO)    ← 병렬 가능
+    ↓
+Step 4 (Service)
+    ↓
+Step 5 (Controller)
+    ↓
+Step 6 (권한 등록)         ← Step 7–8과 병렬 가능
+Step 7–8 (뷰 + JS)
+    ↓
+Step 9 (기존 JS 수정)
+```
+
+---
+
+## 5. 파일 변경 목록
+
+### 신규 생성
+
+| 파일 | 설명 |
+|------|------|
+| `domain/reactgenerate/dto/ReactApprovalResponse.java` | 승인 목록 조회용 DTO |
+| `domain/reactgenerate/service/ReactApprovalService.java` | 승인 워크플로우 서비스 |
+| `domain/reactgenerate/controller/ReactApprovalController.java` | 승인 관리 API 컨트롤러 |
+| `templates/pages/react-approval/react-approval.html` | 승인 관리 뷰 |
+| `templates/pages/react-approval/react-approval-script.html` | 승인 관리 JS |
+
+### 수정
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `mapper/oracle/reactgenerate/ReactGenerateMapper.xml` | `selectPendingList`, `selectPendingCount` 쿼리 추가 |
+| `domain/reactgenerate/mapper/ReactGenerateMapper.java` | `selectPendingList`, `selectPendingCount` 인터페이스 추가 |
+| `domain/reactgenerate/service/ReactGenerateService.java` | `approve()` 메서드 제거 (ReactApprovalService로 이전) |
+| `domain/reactgenerate/controller/ReactGenerateController.java` | `approve()` 엔드포인트 제거 |
+| `resources/menu-resource-permissions.yml` | `v3_react_approval` 권한 추가 |
+| `templates/pages/react-generate/react-generate-script.html` | 승인 API URL을 `/react-approval/{id}/approve`로 변경 |
+
+---
+
+## 6. 인수 기준 체크리스트
+
+- [ ] `PENDING_APPROVAL` 상태 목록만 승인 관리 메뉴에 조회된다
+- [ ] 요청자 본인이 승인 시도하면 400 오류가 반환된다
+- [ ] 승인 시 `STATUS`가 `APPROVED`로 변경된다
+- [ ] 반려 시 `STATUS`가 `REJECTED`로 변경된다
+- [ ] 반려는 `PENDING_APPROVAL` 외 다른 상태에서도 가능하다
+- [ ] 승인/반려 후 생성 이력 탭이 EventBus를 통해 자동 갱신된다
+- [ ] `REACT_APPROVAL:R/W` 권한으로 메뉴 접근이 제어된다
+- [ ] ArchUnit 레이어 의존성 규칙(`Controller → Service → Mapper`)을 위반하지 않는다
+- [ ] Spotless 포맷 검사(`./mvnw spotless:check`)를 통과한다
+
+---
+
+## 7. 참고
+
+- 긴급공지 배포 패턴: `EmergencyNoticeDeployController`, `EmergencyNoticeDeployService`
+- EventBus: `static/js/utils/event-bus.js`
+- 예외 계층: `InvalidInputException` (요청자 본인 승인), `NotFoundException` (존재하지 않는 codeId)
+- 후행 이슈 #31에서 `APPROVED` 이후 배포 흐름(`DRAFT → DEPLOYED → ENDED`) 구현 예정

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/controller/ReactApprovalController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/controller/ReactApprovalController.java
@@ -1,0 +1,101 @@
+/**
+ * @file ReactApprovalController.java
+ * @description React 코드 승인 관리 API 컨트롤러.
+ *     승인 대기 목록 조회, 승인, 반려 엔드포인트를 제공한다.
+ *     읽기는 REACT_APPROVAL:R, 쓰기(승인·반려)는 REACT_APPROVAL:W 권한이 필요하다.
+ */
+package com.example.admin_demo.domain.reactgenerate.controller;
+
+import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateApprovalResponse;
+import com.example.admin_demo.domain.reactgenerate.service.ReactApprovalService;
+import com.example.admin_demo.global.dto.ApiResponse;
+import com.example.admin_demo.global.util.SecurityUtil;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/react-approval")
+@PreAuthorize("hasAuthority('REACT_APPROVAL:R')")
+@RequiredArgsConstructor
+public class ReactApprovalController {
+
+    private final ReactApprovalService reactApprovalService;
+
+    /**
+     * 승인 대기(PENDING_APPROVAL) 목록을 페이지네이션 형태로 조회한다.
+     *
+     * @param page 페이지 번호 (기본값 1)
+     * @param size 페이지당 건수 (기본값 10)
+     * @return list(목록), totalCount, page, size
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<Map<String, Object>>> getPendingList(
+            @RequestParam(defaultValue = "1") int page, @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(ApiResponse.success(reactApprovalService.getPendingList(page, size)));
+    }
+
+    /**
+     * 승인 이력(APPROVED / REJECTED) 목록을 페이지네이션 형태로 조회한다.
+     *
+     * @param page           페이지 번호 (기본값 1)
+     * @param size           페이지당 건수 (기본값 10)
+     * @param status         상태 필터 (APPROVED / REJECTED, 미입력 시 전체)
+     * @param approvalUserId 처리자 ID 부분 일치 검색
+     * @param createUserId   요청자 ID 부분 일치 검색
+     * @param fromDate       처리일시 시작 (yyyyMMdd)
+     * @param toDate         처리일시 종료 (yyyyMMdd)
+     * @return list(목록), totalCount, page, size
+     */
+    @GetMapping("/history")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> getHistory(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "") String status,
+            @RequestParam(defaultValue = "") String approvalUserId,
+            @RequestParam(defaultValue = "") String createUserId,
+            @RequestParam(defaultValue = "") String fromDate,
+            @RequestParam(defaultValue = "") String toDate) {
+        return ResponseEntity.ok(ApiResponse.success(
+                reactApprovalService.getHistory(page, size, status, approvalUserId, createUserId, fromDate, toDate)));
+    }
+
+    /**
+     * 승인 대기 코드를 승인한다.
+     *
+     * <p>요청자 본인은 승인할 수 없으며, PENDING_APPROVAL 상태인 코드만 승인 가능하다.
+     *
+     * @param id 승인할 코드 ID
+     * @return 변경된 상태 및 승인자 정보
+     */
+    @PostMapping("/{id}/approve")
+    @PreAuthorize("hasAuthority('REACT_APPROVAL:W')")
+    public ResponseEntity<ApiResponse<ReactGenerateApprovalResponse>> approve(@PathVariable String id) {
+        String currentUserId = SecurityUtil.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(reactApprovalService.approve(id, currentUserId)));
+    }
+
+    /**
+     * 코드를 반려한다.
+     *
+     * <p>상태에 관계없이 어느 단계에서든 반려 가능하다.
+     *
+     * @param id 반려할 코드 ID
+     * @return 변경된 상태 및 반려자 정보
+     */
+    @PostMapping("/{id}/reject")
+    @PreAuthorize("hasAuthority('REACT_APPROVAL:W')")
+    public ResponseEntity<ApiResponse<ReactGenerateApprovalResponse>> reject(@PathVariable String id) {
+        String currentUserId = SecurityUtil.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(reactApprovalService.reject(id, currentUserId)));
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/controller/ReactApprovalController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/controller/ReactApprovalController.java
@@ -7,6 +7,7 @@
 package com.example.admin_demo.domain.reactgenerate.controller;
 
 import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateApprovalResponse;
+import com.example.admin_demo.domain.reactgenerate.dto.ReactRejectRequest;
 import com.example.admin_demo.domain.reactgenerate.service.ReactApprovalService;
 import com.example.admin_demo.global.dto.ApiResponse;
 import com.example.admin_demo.global.util.SecurityUtil;
@@ -18,6 +19,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -94,8 +96,10 @@ public class ReactApprovalController {
      */
     @PostMapping("/{id}/reject")
     @PreAuthorize("hasAuthority('REACT_APPROVAL:W')")
-    public ResponseEntity<ApiResponse<ReactGenerateApprovalResponse>> reject(@PathVariable String id) {
+    public ResponseEntity<ApiResponse<ReactGenerateApprovalResponse>> reject(
+            @PathVariable String id, @RequestBody(required = false) ReactRejectRequest request) {
         String currentUserId = SecurityUtil.getCurrentUserId();
-        return ResponseEntity.ok(ApiResponse.success(reactApprovalService.reject(id, currentUserId)));
+        String reason = request != null ? request.getReason() : null;
+        return ResponseEntity.ok(ApiResponse.success(reactApprovalService.reject(id, currentUserId, reason)));
     }
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/controller/ReactApprovalController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/controller/ReactApprovalController.java
@@ -11,11 +11,15 @@ import com.example.admin_demo.domain.reactgenerate.dto.ReactRejectRequest;
 import com.example.admin_demo.domain.reactgenerate.service.ReactApprovalService;
 import com.example.admin_demo.global.dto.ApiResponse;
 import com.example.admin_demo.global.util.SecurityUtil;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,9 +29,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
+@Validated // @RequestParam에 적용된 @Min/@Max 검증을 활성화
 @RestController
 @RequestMapping("/api/react-approval")
-@PreAuthorize("hasAuthority('REACT_APPROVAL:R')")
 @RequiredArgsConstructor
 public class ReactApprovalController {
 
@@ -36,21 +40,23 @@ public class ReactApprovalController {
     /**
      * 승인 대기(PENDING_APPROVAL) 목록을 페이지네이션 형태로 조회한다.
      *
-     * @param page 페이지 번호 (기본값 1)
-     * @param size 페이지당 건수 (기본값 10)
+     * @param page 페이지 번호 (기본값 1, 최솟값 1)
+     * @param size 페이지당 건수 (기본값 10, 범위 1~100)
      * @return list(목록), totalCount, page, size
      */
     @GetMapping
+    @PreAuthorize("hasAuthority('REACT_APPROVAL:R')")
     public ResponseEntity<ApiResponse<Map<String, Object>>> getPendingList(
-            @RequestParam(defaultValue = "1") int page, @RequestParam(defaultValue = "10") int size) {
+            @RequestParam(defaultValue = "1") @Min(1) int page,
+            @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size) {
         return ResponseEntity.ok(ApiResponse.success(reactApprovalService.getPendingList(page, size)));
     }
 
     /**
      * 승인 이력(APPROVED / REJECTED) 목록을 페이지네이션 형태로 조회한다.
      *
-     * @param page           페이지 번호 (기본값 1)
-     * @param size           페이지당 건수 (기본값 10)
+     * @param page           페이지 번호 (기본값 1, 최솟값 1)
+     * @param size           페이지당 건수 (기본값 10, 범위 1~100)
      * @param status         상태 필터 (APPROVED / REJECTED, 미입력 시 전체)
      * @param approvalUserId 처리자 ID 부분 일치 검색
      * @param createUserId   요청자 ID 부분 일치 검색
@@ -59,9 +65,10 @@ public class ReactApprovalController {
      * @return list(목록), totalCount, page, size
      */
     @GetMapping("/history")
+    @PreAuthorize("hasAuthority('REACT_APPROVAL:R')")
     public ResponseEntity<ApiResponse<Map<String, Object>>> getHistory(
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "1") @Min(1) int page,
+            @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
             @RequestParam(defaultValue = "") String status,
             @RequestParam(defaultValue = "") String approvalUserId,
             @RequestParam(defaultValue = "") String createUserId,
@@ -91,13 +98,14 @@ public class ReactApprovalController {
      *
      * <p>상태에 관계없이 어느 단계에서든 반려 가능하다.
      *
-     * @param id 반려할 코드 ID
+     * @param id      반려할 코드 ID
+     * @param request 반려 사유 (최대 500자, 선택)
      * @return 변경된 상태 및 반려자 정보
      */
     @PostMapping("/{id}/reject")
     @PreAuthorize("hasAuthority('REACT_APPROVAL:W')")
     public ResponseEntity<ApiResponse<ReactGenerateApprovalResponse>> reject(
-            @PathVariable String id, @RequestBody(required = false) ReactRejectRequest request) {
+            @PathVariable String id, @RequestBody(required = false) @Valid ReactRejectRequest request) {
         String currentUserId = SecurityUtil.getCurrentUserId();
         String reason = request != null ? request.getReason() : null;
         return ResponseEntity.ok(ApiResponse.success(reactApprovalService.reject(id, currentUserId, reason)));

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/controller/ReactGenerateController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/controller/ReactGenerateController.java
@@ -46,13 +46,6 @@ public class ReactGenerateController {
         return ResponseEntity.ok(ApiResponse.success(reactGenerateService.requestApproval(id, currentUserId)));
     }
 
-    @PostMapping("/{id}/approve")
-    @PreAuthorize("hasAuthority('REACT_GENERATE:W')")
-    public ResponseEntity<ApiResponse<ReactGenerateApprovalResponse>> approve(@PathVariable String id) {
-        String currentUserId = SecurityUtil.getCurrentUserId();
-        return ResponseEntity.ok(ApiResponse.success(reactGenerateService.approve(id, currentUserId)));
-    }
-
     /**
      * 검색 조건에 맞는 React 코드 생성 이력 목록을 페이지네이션 형태로 조회한다.
      *

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactApprovalResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactApprovalResponse.java
@@ -1,0 +1,26 @@
+/**
+ * @file ReactApprovalResponse.java
+ * @description 승인 관리 메뉴의 목록 조회용 경량 DTO.
+ *     PENDING_APPROVAL 상태 코드 목록을 반환할 때 사용하며,
+ *     CLOB 컬럼(REACT_CODE 등)은 포함하지 않는다.
+ * @returns codeId, figmaUrl, status, createUserId, createDtime
+ */
+package com.example.admin_demo.domain.reactgenerate.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReactApprovalResponse {
+
+    private String codeId;
+    private String figmaUrl;
+    private String status;
+    private String createUserId;
+    private String createDtime;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactRejectRequest.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactRejectRequest.java
@@ -5,6 +5,7 @@
  */
 package com.example.admin_demo.domain.reactgenerate.dto;
 
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -12,6 +13,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ReactRejectRequest {
 
-    /** 반려 사유 (선택 입력, 최대 500자) */
+    /**
+     * 반려 사유 (선택 입력, 최대 500자).
+     * DB 컬럼(FAIL_REASON CLOB)에 저장되며, 프론트 maxlength 우회 방지를 위해 서버에서 재검증한다.
+     */
+    @Size(max = 500, message = "반려 사유는 500자 이하여야 합니다.")
     private String reason;
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactRejectRequest.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/dto/ReactRejectRequest.java
@@ -1,0 +1,17 @@
+/**
+ * @file ReactRejectRequest.java
+ * @description React 코드 반려 요청 DTO.
+ *     반려 사유(reason)를 클라이언트로부터 수신한다.
+ */
+package com.example.admin_demo.domain.reactgenerate.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class ReactRejectRequest {
+
+    /** 반려 사유 (선택 입력, 최대 500자) */
+    private String reason;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/mapper/ReactGenerateMapper.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/mapper/ReactGenerateMapper.java
@@ -32,12 +32,13 @@ public interface ReactGenerateMapper {
     /** CODE_ID로 생성 이력을 단건 조회한다. 존재하지 않으면 null 반환. */
     ReactGenerateResponse selectById(@Param("codeId") String codeId);
 
-    /** 승인 상태를 변경한다. 승인·반려 시 approvalUserId/approvalDtime 함께 기록. */
+    /** 승인 상태를 변경한다. 승인·반려 시 approvalUserId/approvalDtime 함께 기록. 반려 사유는 failReason에 저장. */
     void updateStatus(
             @Param("codeId") String codeId,
             @Param("status") String status,
             @Param("approvalUserId") String approvalUserId,
-            @Param("approvalDtime") String approvalDtime);
+            @Param("approvalDtime") String approvalDtime,
+            @Param("failReason") String failReason);
 
     /** 렌더링 실패 또는 코드 생성 실패 시 STATUS를 FAILED로, FAIL_REASON을 기록한다. */
     void updateToFailed(@Param("codeId") String codeId, @Param("failReason") String failReason);

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/mapper/ReactGenerateMapper.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/mapper/ReactGenerateMapper.java
@@ -1,5 +1,6 @@
 package com.example.admin_demo.domain.reactgenerate.mapper;
 
+import com.example.admin_demo.domain.reactgenerate.dto.ReactApprovalResponse;
 import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateHistoryResponse;
 import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateResponse;
 import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateSearchRequest;
@@ -52,4 +53,45 @@ public interface ReactGenerateMapper {
 
     /** 검색 조건에 맞는 전체 목록을 페이지네이션 없이 조회한다 (엑셀 내보내기용). */
     List<ReactGenerateHistoryResponse> selectAllForExport(@Param("req") ReactGenerateSearchRequest req);
+
+    /**
+     * 승인 대기(PENDING_APPROVAL) 목록을 생성일시 오름차순으로 조회한다 (승인 관리 메뉴 전용).
+     *
+     * @param offset 시작 오프셋 (0-based)
+     * @param endRow 마지막 행 번호 (inclusive)
+     * @return 승인 대기 목록
+     */
+    List<ReactApprovalResponse> selectPendingList(@Param("offset") int offset, @Param("endRow") int endRow);
+
+    /** 승인 대기(PENDING_APPROVAL) 전체 건수를 반환한다 (페이지네이션용). */
+    int selectPendingCount();
+
+    /**
+     * 승인 이력(APPROVED / REJECTED) 목록을 처리일시 내림차순으로 조회한다.
+     *
+     * @param offset         시작 오프셋 (0-based)
+     * @param endRow         마지막 행 번호 (inclusive)
+     * @param status         상태 필터 (null/빈 문자열이면 APPROVED/REJECTED 전체)
+     * @param approvalUserId 처리자 ID 부분 일치 (null/빈 문자열이면 미적용)
+     * @param createUserId   요청자 ID 부분 일치 (null/빈 문자열이면 미적용)
+     * @param fromDate       처리일시 시작 (yyyyMMdd, null/빈 문자열이면 미적용)
+     * @param toDate         처리일시 종료 (yyyyMMdd, null/빈 문자열이면 미적용)
+     * @return 승인 이력 목록
+     */
+    List<ReactGenerateHistoryResponse> selectApprovalHistory(
+            @Param("offset") int offset,
+            @Param("endRow") int endRow,
+            @Param("status") String status,
+            @Param("approvalUserId") String approvalUserId,
+            @Param("createUserId") String createUserId,
+            @Param("fromDate") String fromDate,
+            @Param("toDate") String toDate);
+
+    /** 승인 이력 전체 건수를 반환한다 (페이지네이션용). */
+    int selectApprovalHistoryCount(
+            @Param("status") String status,
+            @Param("approvalUserId") String approvalUserId,
+            @Param("createUserId") String createUserId,
+            @Param("fromDate") String fromDate,
+            @Param("toDate") String toDate);
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/mapper/ReactGenerateMapper.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/mapper/ReactGenerateMapper.java
@@ -40,6 +40,19 @@ public interface ReactGenerateMapper {
             @Param("approvalDtime") String approvalDtime,
             @Param("failReason") String failReason);
 
+    /**
+     * 현재 STATUS가 requiredStatus인 경우에만 상태를 변경하고 변경된 행 수를 반환한다.
+     * Race Condition 방지를 위해 approve 처리 시 사용한다.
+     * 반환값이 0이면 다른 요청이 이미 상태를 변경했음을 의미한다.
+     */
+    int updateStatusConditional(
+            @Param("codeId") String codeId,
+            @Param("status") String status,
+            @Param("approvalUserId") String approvalUserId,
+            @Param("approvalDtime") String approvalDtime,
+            @Param("failReason") String failReason,
+            @Param("requiredStatus") String requiredStatus);
+
     /** 렌더링 실패 또는 코드 생성 실패 시 STATUS를 FAILED로, FAIL_REASON을 기록한다. */
     void updateToFailed(@Param("codeId") String codeId, @Param("failReason") String failReason);
 

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactApprovalService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactApprovalService.java
@@ -1,0 +1,165 @@
+/**
+ * @file ReactApprovalService.java
+ * @description React 코드 승인 워크플로우를 전담하는 서비스.
+ *     승인 대기 목록 조회, 승인, 반려 세 가지 오퍼레이션을 제공한다.
+ *     승인 시 요청자 본인 여부를 서버에서 검증하여 클라이언트 우회를 방지한다.
+ */
+package com.example.admin_demo.domain.reactgenerate.service;
+
+import com.example.admin_demo.domain.reactgenerate.dto.ReactApprovalResponse;
+import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateApprovalResponse;
+import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateHistoryResponse;
+import com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateResponse;
+import com.example.admin_demo.domain.reactgenerate.enums.ReactGenerateStatus;
+import com.example.admin_demo.domain.reactgenerate.mapper.ReactGenerateMapper;
+import com.example.admin_demo.global.exception.InvalidInputException;
+import com.example.admin_demo.global.exception.NotFoundException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReactApprovalService {
+
+    private final ReactGenerateMapper reactGenerateMapper;
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+    /**
+     * 승인 대기(PENDING_APPROVAL) 목록과 전체 건수를 조회한다.
+     *
+     * @param page 페이지 번호 (1-based)
+     * @param size 페이지당 건수
+     * @return list(목록), totalCount(전체 건수), page, size
+     */
+    public Map<String, Object> getPendingList(int page, int size) {
+        int offset = (page - 1) * size;
+        int endRow = offset + size;
+        List<ReactApprovalResponse> list = reactGenerateMapper.selectPendingList(offset, endRow);
+        int totalCount = reactGenerateMapper.selectPendingCount();
+        return Map.of("list", list, "totalCount", totalCount, "page", page, "size", size);
+    }
+
+    /**
+     * 코드를 승인한다.
+     *
+     * <p>승인 조건:
+     * <ul>
+     *   <li>STATUS가 PENDING_APPROVAL인 코드만 승인 가능</li>
+     *   <li>코드 요청자 본인은 승인 불가 — 클라이언트 우회 방지를 위해 서버에서 재검증</li>
+     * </ul>
+     *
+     * @param id            승인할 코드 ID
+     * @param approverUserId 승인자 ID (로그인 사용자)
+     * @throws NotFoundException      해당 codeId가 존재하지 않을 때
+     * @throws InvalidInputException  PENDING_APPROVAL이 아닌 상태이거나 요청자 본인일 때
+     */
+    public ReactGenerateApprovalResponse approve(String id, String approverUserId) {
+        ReactGenerateResponse existing = requirePendingApproval(id);
+
+        // 코드 요청자와 승인자가 동일한 경우 거부 — 클라이언트 우회 방지
+        if (approverUserId.equals(existing.getCreateUserId())) {
+            throw new InvalidInputException("코드 요청자는 승인할 수 없습니다.");
+        }
+
+        String now = LocalDateTime.now().format(FORMATTER);
+        reactGenerateMapper.updateStatus(id, ReactGenerateStatus.APPROVED.name(), approverUserId, now);
+        log.info("승인 완료 — codeId: {}, approver: {}", id, approverUserId);
+
+        return ReactGenerateApprovalResponse.builder()
+                .codeId(id)
+                .status(ReactGenerateStatus.APPROVED.name())
+                .approvalUserId(approverUserId)
+                .approvalDtime(now)
+                .build();
+    }
+
+    /**
+     * 코드를 반려한다.
+     *
+     * <p>반려는 상태에 관계없이 어느 단계에서든 가능하다.
+     * (PENDING_APPROVAL, GENERATED, APPROVED 모두 반려 가능)
+     *
+     * @param id             반려할 코드 ID
+     * @param rejectorUserId 반려자 ID (로그인 사용자)
+     * @throws NotFoundException 해당 codeId가 존재하지 않을 때
+     */
+    public ReactGenerateApprovalResponse reject(String id, String rejectorUserId) {
+        requireExists(id);
+
+        String now = LocalDateTime.now().format(FORMATTER);
+        reactGenerateMapper.updateStatus(id, ReactGenerateStatus.REJECTED.name(), rejectorUserId, now);
+        log.info("반려 완료 — codeId: {}, rejector: {}", id, rejectorUserId);
+
+        return ReactGenerateApprovalResponse.builder()
+                .codeId(id)
+                .status(ReactGenerateStatus.REJECTED.name())
+                .approvalUserId(rejectorUserId)
+                .approvalDtime(now)
+                .build();
+    }
+
+    /**
+     * 승인 이력(APPROVED / REJECTED) 목록과 전체 건수를 조회한다.
+     *
+     * @param page           페이지 번호 (1-based)
+     * @param size           페이지당 건수
+     * @param status         상태 필터 (null/빈 문자열이면 전체)
+     * @param approvalUserId 처리자 ID 부분 일치 검색
+     * @param createUserId   요청자 ID 부분 일치 검색
+     * @param fromDate       처리일시 시작 (yyyyMMdd)
+     * @param toDate         처리일시 종료 (yyyyMMdd)
+     * @return list(목록), totalCount(전체 건수), page, size
+     */
+    public Map<String, Object> getHistory(
+            int page,
+            int size,
+            String status,
+            String approvalUserId,
+            String createUserId,
+            String fromDate,
+            String toDate) {
+        int offset = (page - 1) * size;
+        int endRow = offset + size;
+        // 빈 문자열은 null로 통일하여 mapper의 전체 조회 분기를 타도록 한다
+        String s = nullIfBlank(status);
+        String au = nullIfBlank(approvalUserId);
+        String cu = nullIfBlank(createUserId);
+        String fd = nullIfBlank(fromDate);
+        String td = nullIfBlank(toDate);
+        List<ReactGenerateHistoryResponse> list =
+                reactGenerateMapper.selectApprovalHistory(offset, endRow, s, au, cu, fd, td);
+        int totalCount = reactGenerateMapper.selectApprovalHistoryCount(s, au, cu, fd, td);
+        return Map.of("list", list, "totalCount", totalCount, "page", page, "size", size);
+    }
+
+    /** null이거나 공백만 있으면 null, 아니면 원본 문자열 반환. */
+    private static String nullIfBlank(String value) {
+        return (value != null && !value.isBlank()) ? value : null;
+    }
+
+    /** CODE_ID로 이력을 조회하고, PENDING_APPROVAL 상태가 아니면 예외를 던진다. */
+    private ReactGenerateResponse requirePendingApproval(String id) {
+        ReactGenerateResponse response = reactGenerateMapper.selectById(id);
+        if (response == null) {
+            throw new NotFoundException("생성 결과를 찾을 수 없습니다. codeId=" + id);
+        }
+        if (!ReactGenerateStatus.PENDING_APPROVAL.name().equals(response.getStatus())) {
+            throw new InvalidInputException("승인 대기 상태인 코드만 승인할 수 있습니다. 현재 상태: " + response.getStatus());
+        }
+        return response;
+    }
+
+    /** CODE_ID로 이력을 조회하고, 없으면 NotFoundException을 던진다. */
+    private void requireExists(String id) {
+        if (reactGenerateMapper.selectById(id) == null) {
+            throw new NotFoundException("생성 결과를 찾을 수 없습니다. codeId=" + id);
+        }
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactApprovalService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactApprovalService.java
@@ -18,6 +18,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +35,9 @@ public class ReactApprovalService {
 
     /** yyyyMMdd 형식 검증 패턴 — 날짜 파라미터를 SQL에 전달하기 전 형식을 검증한다. */
     private static final Pattern YYYYMMDD = Pattern.compile("^\\d{8}$");
+
+    /** 승인 이력 조회에서 허용되는 상태 값 — APPROVED 또는 REJECTED 외의 값은 거부한다. */
+    private static final Set<String> ALLOWED_HISTORY_STATUSES = Set.of("APPROVED", "REJECTED");
 
     /**
      * 승인 대기(PENDING_APPROVAL) 목록과 전체 건수를 조회한다.
@@ -153,11 +157,18 @@ public class ReactApprovalService {
         int offset = (page - 1) * size;
         int endRow = offset + size;
         // 빈 문자열은 null로 통일하여 mapper의 전체 조회 분기를 타도록 한다
-        String s = nullIfBlank(status);
-        String au = nullIfBlank(approvalUserId);
-        String cu = nullIfBlank(createUserId);
+        // status: APPROVED/REJECTED 외의 값이 들어오면 거부 (이력 API 범위 제한)
+        String s = validateAndNormalizeStatus(nullIfBlank(status));
+        // LIKE 검색 파라미터: %, _, \ 를 이스케이프하여 의도치 않은 와일드카드 동작 방지
+        String au = escapeLike(nullIfBlank(approvalUserId));
+        String cu = escapeLike(nullIfBlank(createUserId));
         String fd = nullIfBlank(fromDate);
         String td = nullIfBlank(toDate);
+
+        // 날짜 범위 역전 검증 — fromDate가 toDate보다 이후이면 빈 결과 대신 오류 반환
+        if (fd != null && td != null && fd.compareTo(td) > 0) {
+            throw new InvalidInputException("시작 날짜는 종료 날짜보다 이전이어야 합니다.");
+        }
         List<ReactGenerateHistoryResponse> list =
                 reactGenerateMapper.selectApprovalHistory(offset, endRow, s, au, cu, fd, td);
         int totalCount = reactGenerateMapper.selectApprovalHistoryCount(s, au, cu, fd, td);
@@ -180,6 +191,35 @@ public class ReactApprovalService {
         if (date != null && !date.isBlank() && !YYYYMMDD.matcher(date).matches()) {
             throw new InvalidInputException(fieldName + " 날짜 형식이 올바르지 않습니다. (yyyyMMdd 형식으로 입력하세요)");
         }
+    }
+
+    /**
+     * 승인 이력 status 파라미터를 검증하고 정규화한다.
+     * null이면 null 반환 (전체 조회), APPROVED/REJECTED 외의 값이면 예외를 던진다.
+     *
+     * @param status 검증할 상태 값 (nullIfBlank 처리 후 전달)
+     * @return 유효한 상태 값 또는 null
+     */
+    private static String validateAndNormalizeStatus(String status) {
+        if (status == null) return null;
+        if (!ALLOWED_HISTORY_STATUSES.contains(status)) {
+            throw new InvalidInputException("상태 값이 올바르지 않습니다. APPROVED 또는 REJECTED만 허용됩니다.");
+        }
+        return status;
+    }
+
+    /**
+     * Oracle LIKE 검색의 와일드카드 문자를 이스케이프한다.
+     * SQL에 {@code ESCAPE '\'} 절이 선언된 경우, Java에서 %, _, \ 를 미리 이스케이프해야
+     * 사용자 입력이 의도치 않은 와일드카드로 동작하는 것을 방지할 수 있다.
+     *
+     * @param value 이스케이프할 문자열 (null이면 null 반환)
+     * @return 이스케이프 처리된 문자열
+     */
+    private static String escapeLike(String value) {
+        if (value == null) return null;
+        // 순서 중요: \ 먼저 이스케이프 후 %, _ 순으로 처리
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
     }
 
     /** CODE_ID로 이력을 조회하고, PENDING_APPROVAL 상태가 아니면 예외를 던진다. */

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactApprovalService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactApprovalService.java
@@ -18,6 +18,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,6 +31,9 @@ public class ReactApprovalService {
     private final ReactGenerateMapper reactGenerateMapper;
 
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+    /** yyyyMMdd 형식 검증 패턴 — 날짜 파라미터를 SQL에 전달하기 전 형식을 검증한다. */
+    private static final Pattern YYYYMMDD = Pattern.compile("^\\d{8}$");
 
     /**
      * 승인 대기(PENDING_APPROVAL) 목록과 전체 건수를 조회한다.
@@ -55,10 +59,13 @@ public class ReactApprovalService {
      *   <li>코드 요청자 본인은 승인 불가 — 클라이언트 우회 방지를 위해 서버에서 재검증</li>
      * </ul>
      *
-     * @param id            승인할 코드 ID
+     * <p>Race Condition 방지: WHERE 조건에 STATUS = PENDING_APPROVAL을 포함한 조건부 UPDATE를 사용하여
+     * 동시 요청이 들어와도 DB 레벨에서 단 하나의 요청만 처리되도록 보장한다.
+     *
+     * @param id             승인할 코드 ID
      * @param approverUserId 승인자 ID (로그인 사용자)
-     * @throws NotFoundException      해당 codeId가 존재하지 않을 때
-     * @throws InvalidInputException  PENDING_APPROVAL이 아닌 상태이거나 요청자 본인일 때
+     * @throws NotFoundException     해당 codeId가 존재하지 않을 때
+     * @throws InvalidInputException PENDING_APPROVAL이 아닌 상태이거나, 요청자 본인이거나, 동시 요청으로 선점 실패 시
      */
     public ReactGenerateApprovalResponse approve(String id, String approverUserId) {
         ReactGenerateResponse existing = requirePendingApproval(id);
@@ -69,8 +76,19 @@ public class ReactApprovalService {
         }
 
         String now = LocalDateTime.now().format(FORMATTER);
-        // 승인 시 failReason은 null로 초기화
-        reactGenerateMapper.updateStatus(id, ReactGenerateStatus.APPROVED.name(), approverUserId, now, null);
+        // PENDING_APPROVAL 상태인 경우에만 UPDATE (동시 승인 Race Condition 방지)
+        // 두 요청이 동시에 들어와도 DB가 WHERE 조건으로 하나만 처리하고 나머지는 0행을 반환
+        int updated = reactGenerateMapper.updateStatusConditional(
+                id,
+                ReactGenerateStatus.APPROVED.name(),
+                approverUserId,
+                now,
+                null, // 승인 시 failReason은 null로 초기화
+                ReactGenerateStatus.PENDING_APPROVAL.name());
+        if (updated == 0) {
+            // 선점 실패: 동시 요청이 먼저 상태를 변경함
+            throw new InvalidInputException("이미 처리된 승인 요청입니다.");
+        }
         log.info("승인 완료 — codeId: {}, approver: {}", id, approverUserId);
 
         return ReactGenerateApprovalResponse.builder()
@@ -89,6 +107,7 @@ public class ReactApprovalService {
      *
      * @param id             반려할 코드 ID
      * @param rejectorUserId 반려자 ID (로그인 사용자)
+     * @param reason         반려 사유 (nullable, 최대 500자)
      * @throws NotFoundException 해당 codeId가 존재하지 않을 때
      */
     public ReactGenerateApprovalResponse reject(String id, String rejectorUserId, String reason) {
@@ -127,6 +146,10 @@ public class ReactApprovalService {
             String createUserId,
             String fromDate,
             String toDate) {
+        // 날짜 형식 검증 — SQL DTIME 비교 파라미터이므로 형식 불일치 시 DB 오류 가능
+        validateDateFormat(fromDate, "처리일시 시작");
+        validateDateFormat(toDate, "처리일시 종료");
+
         int offset = (page - 1) * size;
         int endRow = offset + size;
         // 빈 문자열은 null로 통일하여 mapper의 전체 조회 분기를 타도록 한다
@@ -144,6 +167,19 @@ public class ReactApprovalService {
     /** null이거나 공백만 있으면 null, 아니면 원본 문자열 반환. */
     private static String nullIfBlank(String value) {
         return (value != null && !value.isBlank()) ? value : null;
+    }
+
+    /**
+     * 날짜 문자열이 yyyyMMdd 형식인지 검증한다.
+     * 빈 문자열과 null은 허용하며, 형식 불일치 시 {@link InvalidInputException}을 던진다.
+     *
+     * @param date      검증할 날짜 문자열
+     * @param fieldName 오류 메시지에 표시할 필드명
+     */
+    private static void validateDateFormat(String date, String fieldName) {
+        if (date != null && !date.isBlank() && !YYYYMMDD.matcher(date).matches()) {
+            throw new InvalidInputException(fieldName + " 날짜 형식이 올바르지 않습니다. (yyyyMMdd 형식으로 입력하세요)");
+        }
     }
 
     /** CODE_ID로 이력을 조회하고, PENDING_APPROVAL 상태가 아니면 예외를 던진다. */

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactApprovalService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactApprovalService.java
@@ -69,7 +69,8 @@ public class ReactApprovalService {
         }
 
         String now = LocalDateTime.now().format(FORMATTER);
-        reactGenerateMapper.updateStatus(id, ReactGenerateStatus.APPROVED.name(), approverUserId, now);
+        // 승인 시 failReason은 null로 초기화
+        reactGenerateMapper.updateStatus(id, ReactGenerateStatus.APPROVED.name(), approverUserId, now, null);
         log.info("승인 완료 — codeId: {}, approver: {}", id, approverUserId);
 
         return ReactGenerateApprovalResponse.builder()
@@ -90,11 +91,12 @@ public class ReactApprovalService {
      * @param rejectorUserId 반려자 ID (로그인 사용자)
      * @throws NotFoundException 해당 codeId가 존재하지 않을 때
      */
-    public ReactGenerateApprovalResponse reject(String id, String rejectorUserId) {
+    public ReactGenerateApprovalResponse reject(String id, String rejectorUserId, String reason) {
         requireExists(id);
 
         String now = LocalDateTime.now().format(FORMATTER);
-        reactGenerateMapper.updateStatus(id, ReactGenerateStatus.REJECTED.name(), rejectorUserId, now);
+        // 반려 사유를 FAIL_REASON 컬럼에 저장
+        reactGenerateMapper.updateStatus(id, ReactGenerateStatus.REJECTED.name(), rejectorUserId, now, reason);
         log.info("반려 완료 — codeId: {}, rejector: {}", id, rejectorUserId);
 
         return ReactGenerateApprovalResponse.builder()

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactGenerateService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactGenerateService.java
@@ -312,7 +312,7 @@ public class ReactGenerateService {
             throw new InvalidInputException("코드 작성자만 승인 요청할 수 있습니다.");
         }
 
-        reactGenerateMapper.updateStatus(id, ReactGenerateStatus.PENDING_APPROVAL.name(), null, null);
+        reactGenerateMapper.updateStatus(id, ReactGenerateStatus.PENDING_APPROVAL.name(), null, null, null);
         log.info("승인 요청 — codeId: {}, requestUserId: {}", id, requestUserId);
 
         return ReactGenerateApprovalResponse.builder()

--- a/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactGenerateService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactgenerate/service/ReactGenerateService.java
@@ -322,24 +322,6 @@ public class ReactGenerateService {
     }
 
     /**
-     * 관리자가 생성 코드를 승인한다.
-     */
-    public ReactGenerateApprovalResponse approve(String id, String approvedBy) {
-        requireExists(id); // 존재 여부 검증
-
-        String now = LocalDateTime.now().format(FORMATTER);
-        reactGenerateMapper.updateStatus(id, ReactGenerateStatus.APPROVED.name(), approvedBy, now);
-        log.info("승인 완료 — codeId: {}, approvalUserId: {}", id, approvedBy);
-
-        return ReactGenerateApprovalResponse.builder()
-                .codeId(id)
-                .status(ReactGenerateStatus.APPROVED.name())
-                .approvalUserId(approvedBy)
-                .approvalDtime(now)
-                .build();
-    }
-
-    /**
      * Preview App에서 발생한 렌더링 오류를 기록한다.
      *
      * <p>브라우저 side에서 catch된 오류는 서버까지 전달되지 않으므로,

--- a/admin/src/main/java/com/example/admin_demo/global/page/controller/PageController.java
+++ b/admin/src/main/java/com/example/admin_demo/global/page/controller/PageController.java
@@ -349,6 +349,11 @@ public class PageController {
         return resolveView(request, "pages/react-generate-his/react-generate-his :: content", model);
     }
 
+    @GetMapping("/react-approval")
+    public String reactApproval(HttpServletRequest request, Model model) {
+        return resolveView(request, "pages/react-approval/react-approval :: content", model);
+    }
+
     // ── 서비스 관리 ── v3_neb_service_base_info, v3_neb_biz_component, v3_validator_component,
     //                    v3_biz_app, v3_sql_query_manage, v3_sql_dataSource_manage
 

--- a/admin/src/main/resources/mapper/oracle/reactgenerate/ReactGenerateMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/reactgenerate/ReactGenerateMapper.xml
@@ -234,7 +234,9 @@
         SET
             STATUS           = #{status,jdbcType=VARCHAR},
             APPROVAL_USER_ID = #{approvalUserId,jdbcType=VARCHAR},
-            APPROVAL_DTIME   = #{approvalDtime,jdbcType=VARCHAR}
+            APPROVAL_DTIME   = #{approvalDtime,jdbcType=VARCHAR},
+            <!-- 반려 시 사유 저장, 승인 시 null 전달하여 기존 값 초기화 -->
+            FAIL_REASON      = #{failReason,jdbcType=CLOB}
         WHERE CODE_ID = #{codeId,jdbcType=VARCHAR}
     </update>
 

--- a/admin/src/main/resources/mapper/oracle/reactgenerate/ReactGenerateMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/reactgenerate/ReactGenerateMapper.xml
@@ -240,6 +240,22 @@
         WHERE CODE_ID = #{codeId,jdbcType=VARCHAR}
     </update>
 
+    <!--
+        Race condition 방지용 조건부 UPDATE.
+        WHERE 절에 requiredStatus 조건을 추가하여, 현재 STATUS가 예상 상태가 아니면
+        UPDATE가 발생하지 않아 0을 반환한다. 반환값으로 선점 여부를 판단한다.
+    -->
+    <update id="updateStatusConditional">
+        UPDATE FWK_RPS_CODE_HIS
+        SET
+            STATUS           = #{status,jdbcType=VARCHAR},
+            APPROVAL_USER_ID = #{approvalUserId,jdbcType=VARCHAR},
+            APPROVAL_DTIME   = #{approvalDtime,jdbcType=VARCHAR},
+            FAIL_REASON      = #{failReason,jdbcType=CLOB}
+        WHERE CODE_ID = #{codeId,jdbcType=VARCHAR}
+          AND STATUS  = #{requiredStatus,jdbcType=VARCHAR}
+    </update>
+
     <update id="updateToFailed">
         UPDATE FWK_RPS_CODE_HIS
         SET

--- a/admin/src/main/resources/mapper/oracle/reactgenerate/ReactGenerateMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/reactgenerate/ReactGenerateMapper.xml
@@ -128,6 +128,105 @@
         ORDER BY CREATE_DTIME DESC
     </select>
 
+    <!-- ==================== SELECT PENDING ==================== -->
+
+    <!--
+        승인 관리 메뉴 전용: PENDING_APPROVAL 상태 목록 조회.
+        오래된 요청부터 처리할 수 있도록 CREATE_DTIME ASC 정렬.
+        CLOB 컬럼(REACT_CODE 등)은 목록에서 제외.
+    -->
+    <select id="selectPendingList" resultType="com.example.admin_demo.domain.reactgenerate.dto.ReactApprovalResponse">
+        SELECT *
+        FROM (
+            SELECT INNER_QRY.*, ROWNUM AS RNUM
+            FROM (
+                SELECT
+                    CODE_ID        AS codeId,
+                    FIGMA_URL      AS figmaUrl,
+                    STATUS         AS status,
+                    CREATE_USER_ID AS createUserId,
+                    CREATE_DTIME   AS createDtime
+                FROM FWK_RPS_CODE_HIS
+                WHERE STATUS = 'PENDING_APPROVAL'
+                ORDER BY CREATE_DTIME ASC
+            ) INNER_QRY
+            WHERE ROWNUM <![CDATA[<=]]> #{endRow}
+        )
+        WHERE RNUM <![CDATA[>]]> #{offset}
+    </select>
+
+    <!-- 승인 대기(PENDING_APPROVAL) 전체 건수 조회 (페이지네이션용) -->
+    <select id="selectPendingCount" resultType="int">
+        SELECT COUNT(*)
+        FROM FWK_RPS_CODE_HIS
+        WHERE STATUS = 'PENDING_APPROVAL'
+    </select>
+
+    <!-- ==================== SELECT APPROVAL HISTORY ==================== -->
+
+    <!--
+        승인 이력 조회: APPROVED / REJECTED 상태 코드 목록.
+        status, approvalUserId, createUserId, fromDate, toDate 조건으로 필터링 가능.
+        처리일시(APPROVAL_DTIME) 내림차순 정렬.
+    -->
+    <sql id="approvalHistoryWhereConditions">
+        <where>
+            <choose>
+                <!-- 특정 상태 필터가 있으면 해당 상태만, 없으면 APPROVED/REJECTED 전체 조회 -->
+                <when test="status != null and status != ''">
+                    STATUS = #{status}
+                </when>
+                <otherwise>
+                    STATUS IN ('APPROVED', 'REJECTED')
+                </otherwise>
+            </choose>
+            <if test="approvalUserId != null and approvalUserId != ''">
+                AND APPROVAL_USER_ID LIKE '%' || #{approvalUserId} || '%' ESCAPE '\'
+            </if>
+            <if test="createUserId != null and createUserId != ''">
+                AND CREATE_USER_ID LIKE '%' || #{createUserId} || '%' ESCAPE '\'
+            </if>
+            <if test="fromDate != null and fromDate != ''">
+                <!-- fromDate: yyyyMMdd → yyyyMMdd000000 으로 비교 -->
+                AND APPROVAL_DTIME &gt;= #{fromDate} || '000000'
+            </if>
+            <if test="toDate != null and toDate != ''">
+                <!-- toDate: yyyyMMdd → yyyyMMdd235959 으로 비교 -->
+                AND APPROVAL_DTIME &lt;= #{toDate} || '235959'
+            </if>
+        </where>
+    </sql>
+
+    <select id="selectApprovalHistory"
+            resultType="com.example.admin_demo.domain.reactgenerate.dto.ReactGenerateHistoryResponse">
+        SELECT *
+        FROM (
+            SELECT INNER_QRY.*, ROWNUM AS RNUM
+            FROM (
+                SELECT
+                    CODE_ID          AS codeId,
+                    FIGMA_URL        AS figmaUrl,
+                    STATUS           AS status,
+                    CREATE_USER_ID   AS createUserId,
+                    CREATE_DTIME     AS createDtime,
+                    APPROVAL_USER_ID AS approvalUserId,
+                    APPROVAL_DTIME   AS approvalDtime
+                FROM FWK_RPS_CODE_HIS
+                <include refid="approvalHistoryWhereConditions"/>
+                ORDER BY APPROVAL_DTIME DESC
+            ) INNER_QRY
+            WHERE ROWNUM <![CDATA[<=]]> #{endRow}
+        )
+        WHERE RNUM <![CDATA[>]]> #{offset}
+    </select>
+
+    <!-- 승인 이력 전체 건수 조회 (페이지네이션용) -->
+    <select id="selectApprovalHistoryCount" resultType="int">
+        SELECT COUNT(*)
+        FROM FWK_RPS_CODE_HIS
+        <include refid="approvalHistoryWhereConditions"/>
+    </select>
+
     <!-- ==================== UPDATE ==================== -->
 
     <update id="updateStatus">

--- a/admin/src/main/resources/menu-resource-permissions.yml
+++ b/admin/src/main/resources/menu-resource-permissions.yml
@@ -156,3 +156,6 @@ menu-resource:
     v3_react_generate_his:
       R: REACT_GENERATE:R
       W: REACT_GENERATE:W
+    v3_react_approval:
+      R: REACT_APPROVAL:R
+      W: REACT_APPROVAL:W

--- a/admin/src/main/resources/templates/pages/react-approval/react-approval-his-search.html
+++ b/admin/src/main/resources/templates/pages/react-approval/react-approval-his-search.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<!-- 승인 이력 검색 영역 Fragment -->
+<div th:fragment="search" class="card border p-2 mb-3">
+    <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
+
+        <label class="form-label mb-0 small fw-medium">상태</label>
+        <select id="hisSearchStatus" class="form-select form-select-sm flex-fixed-130">
+            <option value="">전체</option>
+            <option value="APPROVED">승인 완료</option>
+            <option value="REJECTED">반려</option>
+        </select>
+
+        <label class="form-label mb-0 small fw-medium ms-2">승인자</label>
+        <input type="text" id="hisSearchApprovalUserId"
+               class="form-control form-control-sm flex-fixed-120"
+               placeholder="승인자 ID">
+
+        <label class="form-label mb-0 small fw-medium ms-2">요청자</label>
+        <input type="text" id="hisSearchCreateUserId"
+               class="form-control form-control-sm flex-fixed-120"
+               placeholder="요청자 ID">
+
+        <label class="form-label mb-0 small fw-medium ms-2">처리일 시작</label>
+        <input type="date" id="hisSearchFromDate"
+               class="form-control form-control-sm flex-fixed-140">
+
+        <label class="form-label mb-0 small fw-medium ms-2">처리일 종료</label>
+        <input type="date" id="hisSearchToDate"
+               class="form-control form-control-sm flex-fixed-140">
+
+        <div class="flex-grow-1"></div>
+
+        <!-- 내 것만 보기: 요청자(createUserId)를 현재 로그인 사용자로 고정 -->
+        <div class="form-check form-check-inline ms-2 mb-0">
+            <input class="form-check-input" type="checkbox" id="chkHisMyOnly">
+            <label class="form-check-label small fw-medium" for="chkHisMyOnly">나의 승인 이력</label>
+        </div>
+
+        <select id="limitRows" class="form-select form-select-sm sp-limit-select">
+            <option value="10" selected>10</option>
+            <option value="20">20</option>
+            <option value="50">50</option>
+        </select>
+        <label class="form-label mb-0 small fw-medium">건씩</label>
+
+        <button class="btn btn-outline-secondary btn-sm" id="btnSearchReset">
+            <i class="bi bi-arrow-counterclockwise"></i> 초기화
+        </button>
+        <button class="btn btn-primary btn-sm" id="btnSearch">
+            <i class="bi bi-search"></i> 조회
+        </button>
+    </div>
+</div>
+</body>
+</html>

--- a/admin/src/main/resources/templates/pages/react-approval/react-approval-his-table.html
+++ b/admin/src/main/resources/templates/pages/react-approval/react-approval-his-table.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<!-- 승인 이력 테이블 Fragment -->
+<div th:fragment="table" class="table-responsive">
+    <table class="table table-sm table-hover sp-data-grid" id="approvalHisTable">
+        <thead class="table-light">
+            <tr>
+                <th class="text-center" style="width:50px;">No</th>
+                <th class="text-center" style="width:110px;">상태</th>
+                <th class="text-center" style="width:100px;">요청자</th>
+                <th class="text-center" style="width:100px;">승인자</th>
+                <th class="text-center" style="width:150px;">승인일시</th>
+                <th class="text-center" style="width:70px;">코드</th>
+            </tr>
+        </thead>
+        <tbody id="approvalHisTableBody">
+            <tr>
+                <td colspan="6" class="text-center py-4 text-body-secondary">
+                    조회 중...
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+</body>
+</html>

--- a/admin/src/main/resources/templates/pages/react-approval/react-approval-modal.html
+++ b/admin/src/main/resources/templates/pages/react-approval/react-approval-modal.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<!-- React 코드 승인 관리 상세 모달 Fragment (승인 대기 목록 + 이력 공용) -->
+<div th:fragment="modal">
+    <div class="modal fade" id="approvalDetailModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header py-2">
+                    <h6 class="modal-title">
+                        <i class="bi bi-code-slash text-primary me-1"></i>
+                        React 코드 상세
+                    </h6>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+
+                    <!-- 로딩 인디케이터 -->
+                    <div id="approvalDetailLoading" class="text-center py-4">
+                        <div class="spinner-border spinner-border-sm text-primary me-2"
+                             role="status" aria-hidden="true"></div>
+                        <span class="text-muted">불러오는 중...</span>
+                    </div>
+
+                    <!-- 상세 내용 (로딩 완료 후 표시) -->
+                    <div id="approvalDetailContent" class="d-none">
+
+                        <!-- 상세 정보 테이블 -->
+                        <h6 class="fw-semibold small text-uppercase text-muted mb-2">
+                            <i class="bi bi-info-circle me-1"></i>상세 정보
+                        </h6>
+                        <div class="table-responsive mb-3">
+                            <table class="table table-sm table-bordered small mb-0">
+                                <tbody>
+                                    <tr>
+                                        <th class="table-light text-nowrap" style="width:110px;">Figma URL</th>
+                                        <td colspan="3">
+                                            <a id="approvalDetailFigmaUrl" href="#"
+                                               target="_blank" class="text-break">—</a>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="table-light text-nowrap">상태</th>
+                                        <td colspan="3">
+                                            <span id="approvalDetailStatusBadge" class="badge"></span>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="table-light text-nowrap">요청자</th>
+                                        <td id="approvalDetailCreateUserId"></td>
+                                        <th class="table-light text-nowrap" style="width:110px;">요청일시</th>
+                                        <td id="approvalDetailCreateDtime"></td>
+                                    </tr>
+                                    <tr>
+                                        <th class="table-light text-nowrap">승인자</th>
+                                        <td id="approvalDetailApprovalUserId"></td>
+                                        <th class="table-light text-nowrap">승인일시</th>
+                                        <td id="approvalDetailApprovalDtime"></td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+
+                        <!-- 미리보기 섹션 -->
+                        <div id="approvalDetailPreviewSection">
+                            <h6 class="fw-semibold small text-uppercase text-muted mb-2">
+                                <i class="bi bi-display me-1"></i>미리보기
+                            </h6>
+                            <ul class="nav nav-tabs" role="tablist">
+                                <li class="nav-item" role="presentation">
+                                    <button class="nav-link active"
+                                            id="approvalDetailTab-screen"
+                                            data-bs-toggle="tab"
+                                            data-bs-target="#approvalDetailScreenPreview"
+                                            type="button" role="tab">
+                                        <i class="bi bi-display me-1"></i>화면 미리보기
+                                    </button>
+                                </li>
+                                <li class="nav-item" role="presentation">
+                                    <button class="nav-link"
+                                            id="approvalDetailTab-code"
+                                            data-bs-toggle="tab"
+                                            data-bs-target="#approvalDetailCodePreview"
+                                            type="button" role="tab">
+                                        <i class="bi bi-file-code me-1"></i>코드 미리보기
+                                    </button>
+                                </li>
+                            </ul>
+                            <div class="tab-content border border-top-0 rounded-bottom">
+                                <div class="tab-pane fade show active p-0"
+                                     id="approvalDetailScreenPreview" role="tabpanel">
+                                    <iframe id="approvalDetailPreviewFrame"
+                                            src="/preview-app/index.html"
+                                            title="화면 미리보기"
+                                            style="width:100%; height:460px; border:none; border-radius:0 0 4px 4px;"
+                                            sandbox="allow-scripts allow-same-origin">
+                                    </iframe>
+                                </div>
+                                <div class="tab-pane fade" id="approvalDetailCodePreview" role="tabpanel">
+                                    <div class="position-relative">
+                                        <button class="btn btn-sm btn-outline-secondary position-absolute top-0 end-0 m-2"
+                                                id="approvalDetailBtnCopyCode" title="코드 복사">
+                                            <i class="bi bi-clipboard"></i>
+                                        </button>
+                                        <pre id="approvalDetailCodeDisplay"
+                                             class="bg-dark text-light p-4 m-0 rounded-bottom"
+                                             style="overflow-x:auto; max-height:460px; font-size:0.85rem; white-space:pre-wrap;"></pre>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                    </div><!-- /approvalDetailContent -->
+                </div>
+
+                <div class="modal-footer py-2"
+                     th:if="${userAuthorities != null and userAuthorities.contains('REACT_APPROVAL:W')}">
+                    <!-- 작성자 본인일 때 노출되는 안내 메시지 (기본 hidden) -->
+                    <span class="text-muted small me-auto d-none" id="approvalDetailAuthorNotice">
+                        <i class="bi bi-info-circle me-1"></i>작성자 본인은 승인할 수 없습니다.
+                    </span>
+                    <!-- PENDING_APPROVAL 상태이고 작성자 본인이 아닐 때만 JS에서 노출 (기본 hidden) -->
+                    <button type="button" class="btn btn-outline-danger btn-sm d-none"
+                            id="approvalDetailBtnReject">
+                        <i class="bi bi-x-circle me-1"></i>반려
+                    </button>
+                    <button type="button" class="btn btn-success btn-sm d-none"
+                            id="approvalDetailBtnApprove">
+                        <i class="bi bi-check-circle me-1"></i>승인
+                    </button>
+                    <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">닫기</button>
+                </div>
+                <div class="modal-footer py-2"
+                     th:unless="${userAuthorities != null and userAuthorities.contains('REACT_APPROVAL:W')}">
+                    <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">닫기</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/admin/src/main/resources/templates/pages/react-approval/react-approval-modal.html
+++ b/admin/src/main/resources/templates/pages/react-approval/react-approval-modal.html
@@ -57,6 +57,11 @@
                                         <th class="table-light text-nowrap">승인일시</th>
                                         <td id="approvalDetailApprovalDtime"></td>
                                     </tr>
+                                    <!-- 반려 사유: REJECTED 상태일 때만 노출 -->
+                                    <tr id="approvalDetailRejectReasonRow" class="d-none">
+                                        <th class="table-light text-nowrap text-danger">반려 사유</th>
+                                        <td colspan="3" class="text-danger" id="approvalDetailRejectReason"></td>
+                                    </tr>
                                 </tbody>
                             </table>
                         </div>

--- a/admin/src/main/resources/templates/pages/react-approval/react-approval-pending.html
+++ b/admin/src/main/resources/templates/pages/react-approval/react-approval-pending.html
@@ -1,8 +1,16 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <body>
-<!-- React 코드 승인 대기 목록 Fragment -->
-<div th:fragment="pending" class="card">
+<!--
+    th:block 으로 카드와 반려 모달을 하나의 fragment로 묶는다.
+    th:replace 는 선택된 fragment 요소만 가져오므로, 카드(div)만 fragment로 지정하면
+    형제 요소인 rejectReasonModal 이 DOM에 포함되지 않는다.
+    th:block 은 실제 HTML 태그를 렌더링하지 않으므로 레이아웃에 영향이 없다.
+-->
+<th:block th:fragment="pending">
+
+<!-- React 코드 승인 대기 목록 -->
+<div class="card">
     <div class="card-header">
         <div class="d-flex align-items-center gap-2">
             <span class="fw-semibold">승인 대기 목록</span>
@@ -26,7 +34,7 @@
                 </thead>
                 <tbody id="pendingTableBody">
                     <tr>
-                        <td colspan="6" class="text-center py-4 text-body-secondary">
+                        <td colspan="5" class="text-center py-4 text-body-secondary">
                             조회 중...
                         </td>
                     </tr>
@@ -49,7 +57,7 @@
     </div>
 </div>
 
-<!-- 반려 사유 입력 모달 -->
+<!-- 반려 사유 입력 모달 — th:block 안에 포함되어야 fragment로 함께 렌더링됨 -->
 <div class="modal fade" id="rejectReasonModal" tabindex="-1"
      aria-labelledby="rejectReasonModalLabel" aria-hidden="true">
     <div class="modal-dialog">
@@ -77,5 +85,7 @@
         </div>
     </div>
 </div>
+
+</th:block>
 </body>
 </html>

--- a/admin/src/main/resources/templates/pages/react-approval/react-approval-pending.html
+++ b/admin/src/main/resources/templates/pages/react-approval/react-approval-pending.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<!-- React 코드 승인 대기 목록 Fragment -->
+<div th:fragment="pending" class="card">
+    <div class="card-header">
+        <div class="d-flex align-items-center gap-2">
+            <span class="fw-semibold">승인 대기 목록</span>
+            <span class="badge bg-secondary" id="pendingCountBadge">0건</span>
+        </div>
+    </div>
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-sm table-hover sp-data-grid mb-0" id="pendingTable">
+                <thead class="table-light">
+                    <tr>
+                        <th class="text-center" style="width:50px;">No</th>
+                        <th class="text-center" style="width:150px;">요청자</th>
+                        <th class="text-center" style="width:150px;">요청일시</th>
+                        <th class="text-center" style="width:120px;"
+                            th:if="${userAuthorities != null and userAuthorities.contains('REACT_APPROVAL:W')}">
+                            액션
+                        </th>
+                        <th class="text-center" style="width:70px;">코드</th>
+                    </tr>
+                </thead>
+                <tbody id="pendingTableBody">
+                    <tr>
+                        <td colspan="6" class="text-center py-4 text-body-secondary">
+                            조회 중...
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <!-- 이력 섹션의 pagination-container 레이아웃과 동일: 왼쪽 페이지 버튼, 오른쪽 건수+새로고침 -->
+    <div class="card-footer pagination-container mb-0">
+        <nav aria-label="승인 대기 페이지네이션">
+            <ul class="pagination pagination-sm mb-0" id="pendingPagination"></ul>
+        </nav>
+        <div class="pagination-info">
+            <span id="pendingPageInfo">0 - 0 of 0 items</span>
+            <button type="button" class="btn btn-outline-secondary btn-sm" id="btnPendingRefresh"
+                    title="새로고침">
+                <i class="bi bi-arrow-clockwise"></i>
+            </button>
+        </div>
+    </div>
+</div>
+
+<!-- 반려 사유 입력 모달 -->
+<div class="modal fade" id="rejectReasonModal" tabindex="-1"
+     aria-labelledby="rejectReasonModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="rejectReasonModalLabel">
+                    <i class="bi bi-x-circle text-danger me-1"></i>반려 사유 입력
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
+            </div>
+            <div class="modal-body">
+                <label for="rejectReasonInput" class="form-label">
+                    반려 사유 <span class="text-danger">*</span>
+                </label>
+                <textarea id="rejectReasonInput" class="form-control" rows="3"
+                          maxlength="500" placeholder="반려 사유를 입력하세요."></textarea>
+                <div class="form-text text-end">
+                    <span id="rejectReasonCount">0</span>/500
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+                <button type="button" class="btn btn-danger" id="btnConfirmReject">반려 확인</button>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/admin/src/main/resources/templates/pages/react-approval/react-approval-script.html
+++ b/admin/src/main/resources/templates/pages/react-approval/react-approval-script.html
@@ -24,6 +24,25 @@ function approvalFormatDtime(dtime) {
            dtime.substring(6, 8) + ' ' + dtime.substring(8, 10) + ':' + dtime.substring(10, 12);
 }
 
+/**
+ * URL이 http/https 프로토콜을 사용하는지 검증한다.
+ * javascript: 등 위험 프로토콜을 가진 URL을 href에 바인딩하지 않기 위해 사용한다.
+ *
+ * @param {string} url - 검증할 URL 문자열
+ * @returns {boolean} http/https 프로토콜이면 true, 그 외 또는 파싱 불가이면 false
+ */
+function isSafeUrl(url) {
+    if (!url) return false;
+    try {
+        const parsed = new URL(url);
+        // http/https 프로토콜만 허용 — javascript:, data: 등 위험 프로토콜 차단
+        return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+    } catch {
+        // URL 파싱 실패 = 유효하지 않은 URL
+        return false;
+    }
+}
+
 // ═══════════════════════════════════════════════════════
 //  승인 대기 목록 모듈
 // ═══════════════════════════════════════════════════════
@@ -367,7 +386,12 @@ const ReactApprovalDetail = {
         const statusInfo = APPROVAL_STATUS_LABEL[data.status] || { text: data.status, cls: 'bg-secondary' };
         const safeUrl    = HtmlUtils.escape(data.figmaUrl || '');
 
-        $('#approvalDetailFigmaUrl').attr('href', safeUrl).text(safeUrl || '—');
+        // 안전한 URL(http/https)만 href 속성을 설정하고, 그 외에는 링크 없이 텍스트만 표시 (XSS 방지)
+        if (isSafeUrl(data.figmaUrl)) {
+            $('#approvalDetailFigmaUrl').attr('href', safeUrl).text(safeUrl || '—');
+        } else {
+            $('#approvalDetailFigmaUrl').removeAttr('href').text(safeUrl || '—');
+        }
         $('#approvalDetailStatusBadge')
             .text(statusInfo.text).removeClass().addClass('badge ' + statusInfo.cls);
         $('#approvalDetailCreateUserId').text(data.createUserId || '—');

--- a/admin/src/main/resources/templates/pages/react-approval/react-approval-script.html
+++ b/admin/src/main/resources/templates/pages/react-approval/react-approval-script.html
@@ -1,0 +1,523 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<th:block th:fragment="script">
+<script th:inline="javascript">
+/*<![CDATA[*/
+const HAS_WRITE = document.getElementById('hasWriteAuth')?.value === 'true';
+// 내 것만 보기 체크박스 — createUserId 필터에 현재 로그인 사용자 ID를 주입할 때 사용
+const CURRENT_USER_ID = /*[[${currentUserId}]]*/ '';
+
+// 상태 배지 정의
+const APPROVAL_STATUS_LABEL = {
+    GENERATED:        { text: '생성 완료',  cls: 'bg-secondary' },
+    FAILED:           { text: '실패',        cls: 'bg-danger' },
+    PENDING_APPROVAL: { text: '승인 대기',   cls: 'bg-warning text-dark' },
+    APPROVED:         { text: '승인 완료',   cls: 'bg-success' },
+    REJECTED:         { text: '반려',        cls: 'bg-secondary' },
+};
+
+/** yyyyMMddHHmmss → yyyy-MM-dd HH:mm 형식으로 변환한다. */
+function approvalFormatDtime(dtime) {
+    if (!dtime || dtime.length < 12) return dtime || '';
+    return dtime.substring(0, 4) + '-' + dtime.substring(4, 6) + '-' +
+           dtime.substring(6, 8) + ' ' + dtime.substring(8, 10) + ':' + dtime.substring(10, 12);
+}
+
+// ═══════════════════════════════════════════════════════
+//  승인 대기 목록 모듈
+// ═══════════════════════════════════════════════════════
+const ReactApprovalPending = {
+    currentPage: 1,
+    totalItems:  0,
+    pageSize:    10,
+
+    // 현재 모달에서 처리 중인 코드 ID (승인·반려 시 참조)
+    activeCodeId: null,
+
+    load: function (page) {
+        this.currentPage = page || 1;
+        $.get(API_BASE_URL + '/react-approval', { page: this.currentPage, size: this.pageSize })
+            .done(res => {
+                if (res.success) {
+                    this.totalItems = res.data.totalCount || 0;
+                    this.renderTable(res.data.list || []);
+                    this.renderPagination();
+                } else {
+                    Toast.error(res.message || '승인 대기 목록 조회에 실패했습니다.');
+                }
+            })
+            .fail(() => Toast.error('승인 대기 목록 조회 중 오류가 발생했습니다.'));
+    },
+
+    renderTable: function (list) {
+        const badge = document.getElementById('pendingCountBadge');
+        badge.textContent = this.totalItems + '건';
+        badge.className   = this.totalItems > 0 ? 'badge bg-warning text-dark' : 'badge bg-secondary';
+
+        const tbody = $('#pendingTableBody');
+        tbody.empty();
+        if (!list || list.length === 0) {
+            const cols = HAS_WRITE ? 5 : 4;
+            tbody.html(`<tr><td colspan="${cols}" class="text-center py-4 text-body-secondary">
+                승인 대기 중인 코드가 없습니다.</td></tr>`);
+            return;
+        }
+
+        const offset = (this.currentPage - 1) * this.pageSize;
+        list.forEach((item, idx) => {
+            const safeId     = HtmlUtils.escape(item.codeId  || '');
+            const safeUserId = HtmlUtils.escape(item.createUserId || '');
+
+            // 쓰기 권한자이면서 코드 작성자 본인이 아닐 때만 승인·반려 버튼 노출
+            const isAuthor   = CURRENT_USER_ID && item.createUserId === CURRENT_USER_ID;
+            const actionCell = !HAS_WRITE ? '' :
+                (isAuthor
+                    ? `<td class="text-center text-muted small">
+                           <i class="bi bi-info-circle me-1"></i>작성자 승인 불가
+                       </td>`
+                    : `<td class="text-center">
+                           <button class="btn btn-sm btn-success me-1"
+                                   onclick="ReactApprovalPending.approve('${safeId}')">
+                               <i class="bi bi-check-circle me-1"></i>승인
+                           </button>
+                           <button class="btn btn-sm btn-outline-danger"
+                                   onclick="ReactApprovalPending.openRejectModal('${safeId}')">
+                               <i class="bi bi-x-circle me-1"></i>반려
+                           </button>
+                       </td>`);
+
+            tbody.append(`
+                <tr>
+                    <td class="text-center">${offset + idx + 1}</td>
+                    <td class="text-center">${safeUserId}</td>
+                    <td class="text-center">${approvalFormatDtime(item.createDtime)}</td>
+                    ${actionCell}
+                    <td class="text-center">
+                        <button type="button" class="btn btn-outline-primary btn-sm py-0 px-2"
+                                onclick="ReactApprovalDetail.open('${safeId}')">
+                            보기
+                        </button>
+                    </td>
+                </tr>`);
+        });
+    },
+
+    renderPagination: function () {
+        const totalPages = Math.ceil(this.totalItems / this.pageSize) || 1;
+        const ul = $('#pendingPagination');
+        ul.empty();
+
+        // 페이지 정보 텍스트 업데이트
+        const s = this.totalItems === 0 ? 0 : (this.currentPage - 1) * this.pageSize + 1;
+        const e = Math.min(this.currentPage * this.pageSize, this.totalItems);
+        $('#pendingPageInfo').text(`${s} - ${e} of ${this.totalItems} items`);
+
+        if (totalPages <= 1) return;
+
+        const maxBtns = 5;
+        let start = Math.max(1, this.currentPage - Math.floor(maxBtns / 2));
+        let end   = Math.min(totalPages, start + maxBtns - 1);
+        if (end - start + 1 < maxBtns) start = Math.max(1, end - maxBtns + 1);
+
+        ul.append(`<li class="page-item ${this.currentPage === 1 ? 'disabled' : ''}">
+            <a class="page-link" href="#"
+               onclick="ReactApprovalPending.load(1); return false;">
+                <i class="bi bi-chevron-double-left"></i></a></li>
+            <li class="page-item ${this.currentPage === 1 ? 'disabled' : ''}">
+            <a class="page-link" href="#"
+               onclick="ReactApprovalPending.load(${this.currentPage - 1}); return false;">
+                <i class="bi bi-chevron-left"></i></a></li>`);
+
+        for (let p = start; p <= end; p++) {
+            ul.append(`<li class="page-item ${p === this.currentPage ? 'active' : ''}">
+                <a class="page-link" href="#"
+                   onclick="ReactApprovalPending.load(${p}); return false;">${p}</a></li>`);
+        }
+
+        const isLast = this.currentPage >= totalPages;
+        ul.append(`<li class="page-item ${isLast ? 'disabled' : ''}">
+            <a class="page-link" href="#"
+               onclick="ReactApprovalPending.load(${this.currentPage + 1}); return false;">
+                <i class="bi bi-chevron-right"></i></a></li>
+            <li class="page-item ${isLast ? 'disabled' : ''}">
+            <a class="page-link" href="#"
+               onclick="ReactApprovalPending.load(${totalPages}); return false;">
+                <i class="bi bi-chevron-double-right"></i></a></li>`);
+    },
+
+    approve: function (codeId) {
+        if (!confirm('해당 코드를 승인하시겠습니까?')) return;
+        $.ajax({ url: API_BASE_URL + '/react-approval/' + codeId + '/approve', type: 'POST' })
+            .done(res => {
+                if (res.success) {
+                    Toast.success('승인이 완료됐습니다.');
+                    this.load(this.currentPage);
+                    ReactApprovalHis.search(); // 이력 갱신
+                    EventBus.emit('admin:reactApproval:statusChanged');
+                } else {
+                    Toast.error(res.message || '승인에 실패했습니다.');
+                }
+            })
+            .fail(xhr => Toast.error(xhr.responseJSON?.message || '승인 처리 중 오류가 발생했습니다.'));
+    },
+
+    openRejectModal: function (codeId) {
+        this.activeCodeId = codeId;
+        $('#rejectReasonInput').val('');
+        $('#rejectReasonCount').text('0');
+        new bootstrap.Modal(document.getElementById('rejectReasonModal')).show();
+    },
+
+    reject: function (codeId, reason) {
+        bootstrap.Modal.getInstance(document.getElementById('rejectReasonModal'))?.hide();
+        $.ajax({
+            url: API_BASE_URL + '/react-approval/' + codeId + '/reject',
+            type: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({ reason }),
+        })
+        .done(res => {
+            if (res.success) {
+                Toast.success('반려 처리됐습니다.');
+                this.load(this.currentPage);
+                ReactApprovalHis.search(); // 이력 갱신
+                EventBus.emit('admin:reactApproval:statusChanged');
+            } else {
+                Toast.error(res.message || '반려에 실패했습니다.');
+            }
+        })
+        .fail(xhr => Toast.error(xhr.responseJSON?.message || '반려 처리 중 오류가 발생했습니다.'));
+    },
+};
+
+// ═══════════════════════════════════════════════════════
+//  승인 이력 모듈
+// ═══════════════════════════════════════════════════════
+const ReactApprovalHis = {
+    currentPage:   1,
+    totalItems:    0,
+    itemsPerPage:  10,
+    appliedSearch: {},
+    currentData:   [],
+
+    /** 검색 조건을 수집하고 1페이지부터 재조회한다. */
+    search: function () {
+        // 나의 승인 이력 체크 시 승인자 ID를 현재 로그인 사용자로 고정
+        const myOnly = $('#chkHisMyOnly').is(':checked');
+        this.appliedSearch = {
+            status:          $('#hisSearchStatus').val(),
+            approvalUserId:  myOnly ? CURRENT_USER_ID : $('#hisSearchApprovalUserId').val().trim(),
+            createUserId:    $('#hisSearchCreateUserId').val().trim(),
+            fromDate:        ($('#hisSearchFromDate').val() || '').replace(/-/g, ''),
+            toDate:          ($('#hisSearchToDate').val()   || '').replace(/-/g, ''),
+        };
+        this.currentPage = 1;
+        this.load();
+    },
+
+    load: function () {
+        const params = Object.assign({}, this.appliedSearch, {
+            page: this.currentPage,
+            size: this.itemsPerPage,
+        });
+        $.ajax({
+            url: API_BASE_URL + '/react-approval/history',
+            method: 'GET',
+            data: params,
+            success: (res) => {
+                if (res.success && res.data) {
+                    this.currentData = res.data.list || [];
+                    this.totalItems  = res.data.totalCount || 0;
+                    this.renderTable(this.currentData);
+                    this.renderPagination();
+                } else {
+                    this.renderTable([]);
+                }
+            },
+            error: (xhr) => {
+                Toast.error(xhr.responseJSON?.message || '이력을 불러오는 중 오류가 발생했습니다.');
+                this.renderTable([]);
+            },
+        });
+    },
+
+    renderTable: function (list) {
+        const tbody = $('#approvalHisTableBody');
+        tbody.empty();
+        if (!list || list.length === 0) {
+            tbody.html(`<tr><td colspan="6" class="text-center py-4 text-body-secondary">
+                조회된 데이터가 없습니다.</td></tr>`);
+            return;
+        }
+
+        const offset = (this.currentPage - 1) * this.itemsPerPage;
+        list.forEach((item, idx) => {
+            const statusInfo = APPROVAL_STATUS_LABEL[item.status] || { text: item.status, cls: 'bg-secondary' };
+            const safeId     = HtmlUtils.escape(item.codeId  || '');
+
+            tbody.append(`
+                <tr>
+                    <td class="text-center">${offset + idx + 1}</td>
+                    <td class="text-center">
+                        <span class="badge ${statusInfo.cls}">${statusInfo.text}</span>
+                    </td>
+                    <td class="text-center">${HtmlUtils.escape(item.createUserId || '')}</td>
+                    <td class="text-center">${HtmlUtils.escape(item.approvalUserId || '')}</td>
+                    <td class="text-center">${approvalFormatDtime(item.approvalDtime)}</td>
+                    <td class="text-center">
+                        <button type="button" class="btn btn-outline-primary btn-sm py-0 px-2"
+                                onclick="ReactApprovalDetail.open('${safeId}')">
+                            보기
+                        </button>
+                    </td>
+                </tr>`);
+        });
+    },
+
+    renderPagination: function () {
+        const totalPages = Math.ceil(this.totalItems / this.itemsPerPage) || 1;
+        const pagination = $('#pagination');
+        pagination.empty();
+
+        pagination.append(`
+            <li class="page-item ${this.currentPage === 1 ? 'disabled' : ''}">
+                <a class="page-link" href="#"
+                   onclick="ReactApprovalHis.changePage(1); return false;">
+                    <i class="bi bi-chevron-double-left"></i></a></li>
+            <li class="page-item ${this.currentPage === 1 ? 'disabled' : ''}">
+                <a class="page-link" href="#"
+                   onclick="ReactApprovalHis.changePage(${this.currentPage - 1}); return false;">
+                    <i class="bi bi-chevron-left"></i></a></li>`);
+
+        const maxBtns = 5;
+        let start = Math.max(1, this.currentPage - Math.floor(maxBtns / 2));
+        let end   = Math.min(totalPages, start + maxBtns - 1);
+        if (end - start + 1 < maxBtns) start = Math.max(1, end - maxBtns + 1);
+        for (let p = start; p <= end; p++) {
+            pagination.append(`
+                <li class="page-item ${p === this.currentPage ? 'active' : ''}">
+                    <a class="page-link" href="#"
+                       onclick="ReactApprovalHis.changePage(${p}); return false;">${p}</a></li>`);
+        }
+
+        const isLast = this.currentPage >= totalPages;
+        pagination.append(`
+            <li class="page-item ${isLast ? 'disabled' : ''}">
+                <a class="page-link" href="#"
+                   onclick="ReactApprovalHis.changePage(${this.currentPage + 1}); return false;">
+                    <i class="bi bi-chevron-right"></i></a></li>
+            <li class="page-item ${isLast ? 'disabled' : ''}">
+                <a class="page-link" href="#"
+                   onclick="ReactApprovalHis.changePage(${totalPages}); return false;">
+                    <i class="bi bi-chevron-double-right"></i></a></li>`);
+
+        const s = this.totalItems === 0 ? 0 : (this.currentPage - 1) * this.itemsPerPage + 1;
+        const e = Math.min(this.currentPage * this.itemsPerPage, this.totalItems);
+        $('#pageInfo').text(`${s} - ${e} of ${this.totalItems} items`);
+    },
+
+    changePage: function (page) {
+        const totalPages = Math.ceil(this.totalItems / this.itemsPerPage) || 1;
+        if (page < 1 || page > totalPages) return;
+        this.currentPage = page;
+        this.load();
+    },
+};
+
+// ═══════════════════════════════════════════════════════
+//  공용 상세 모달 모듈
+// ═══════════════════════════════════════════════════════
+const ReactApprovalDetail = {
+    currentCodeId: null,
+    currentStatus: null,
+
+    open: function (codeId) {
+        this.currentCodeId = codeId;
+        this.currentStatus = null;
+
+        $('#approvalDetailLoading').removeClass('d-none');
+        $('#approvalDetailContent').addClass('d-none');
+        // 모달 내 액션 버튼 초기화
+        $('#approvalDetailBtnApprove, #approvalDetailBtnReject').addClass('d-none');
+
+        const modal = new bootstrap.Modal(document.getElementById('approvalDetailModal'));
+        modal.show();
+
+        $.ajax({
+            url: API_BASE_URL + '/react-generate/' + codeId,
+            method: 'GET',
+            success: (res) => {
+                if (res.success && res.data) {
+                    this.render(res.data);
+                } else {
+                    Toast.error(res.message || '상세 정보를 불러오지 못했습니다.');
+                    modal.hide();
+                }
+            },
+            error: (xhr) => {
+                Toast.error(xhr.responseJSON?.message || '상세 조회 중 오류가 발생했습니다.');
+                modal.hide();
+            },
+        });
+    },
+
+    render: function (data) {
+        this.currentStatus = data.status;
+        const statusInfo = APPROVAL_STATUS_LABEL[data.status] || { text: data.status, cls: 'bg-secondary' };
+        const safeUrl    = HtmlUtils.escape(data.figmaUrl || '');
+
+        $('#approvalDetailFigmaUrl').attr('href', safeUrl).text(safeUrl || '—');
+        $('#approvalDetailStatusBadge')
+            .text(statusInfo.text).removeClass().addClass('badge ' + statusInfo.cls);
+        $('#approvalDetailCreateUserId').text(data.createUserId || '—');
+        $('#approvalDetailCreateDtime').text(approvalFormatDtime(data.createDtime) || '—');
+        $('#approvalDetailApprovalUserId').text(data.approvalUserId || '—');
+        $('#approvalDetailApprovalDtime').text(approvalFormatDtime(data.approvalDtime) || '—');
+
+        // 미리보기 섹션
+        const hasCode = !!(data.reactCode && data.reactCode.trim());
+        if (hasCode) {
+            $('#approvalDetailPreviewSection').removeClass('d-none');
+            const frame    = document.getElementById('approvalDetailPreviewFrame');
+            const sendCode = () => frame.contentWindow.postMessage(
+                { type: 'UPDATE_CODE', code: data.reactCode, codeId: data.codeId },
+                window.location.origin
+            );
+            if (frame.contentDocument?.readyState === 'complete') sendCode();
+            else frame.onload = sendCode;
+            document.getElementById('approvalDetailCodeDisplay').textContent = data.reactCode;
+            new bootstrap.Tab(document.getElementById('approvalDetailTab-screen')).show();
+        } else {
+            $('#approvalDetailPreviewSection').addClass('d-none');
+        }
+
+        // PENDING_APPROVAL 상태이고 쓰기 권한이 있을 때 작성자 여부에 따라 버튼/안내 분기
+        const isAuthor = CURRENT_USER_ID && data.createUserId === CURRENT_USER_ID;
+        if (HAS_WRITE && data.status === 'PENDING_APPROVAL') {
+            if (isAuthor) {
+                // 작성자 본인 — 승인·반려 불가 안내 메시지 노출
+                $('#approvalDetailAuthorNotice').removeClass('d-none');
+            } else {
+                // 제3자 승인자 — 승인·반려 버튼 노출
+                $('#approvalDetailBtnApprove, #approvalDetailBtnReject').removeClass('d-none');
+            }
+        }
+
+        $('#approvalDetailLoading').addClass('d-none');
+        $('#approvalDetailContent').removeClass('d-none');
+    },
+};
+
+// ═══════════════════════════════════════════════════════
+//  이벤트 바인딩
+// ═══════════════════════════════════════════════════════
+$(document).ready(function () {
+
+    // ── 진입 시 승인 대기 목록 + 이력 동시 조회
+    ReactApprovalPending.load(1);
+    ReactApprovalHis.search();
+
+    // ── 반려 사유 글자 수 카운터
+    $('#rejectReasonInput').on('input', function () {
+        $('#rejectReasonCount').text(this.value.length);
+    });
+
+    // ── 반려 확인 버튼
+    $('#btnConfirmReject').on('click', function () {
+        const reason = $('#rejectReasonInput').val().trim();
+        if (!reason) { Toast.error('반려 사유를 입력해주세요.'); return; }
+        ReactApprovalPending.reject(ReactApprovalPending.activeCodeId, reason);
+    });
+
+    // ── 모달 내 승인 버튼
+    $('#approvalDetailBtnApprove').on('click', function () {
+        if (!ReactApprovalDetail.currentCodeId) return;
+        bootstrap.Modal.getInstance(document.getElementById('approvalDetailModal'))?.hide();
+        ReactApprovalPending.approve(ReactApprovalDetail.currentCodeId);
+    });
+
+    // ── 모달 내 반려 버튼
+    $('#approvalDetailBtnReject').on('click', function () {
+        if (!ReactApprovalDetail.currentCodeId) return;
+        bootstrap.Modal.getInstance(document.getElementById('approvalDetailModal'))?.hide();
+        ReactApprovalPending.openRejectModal(ReactApprovalDetail.currentCodeId);
+    });
+
+    // ── 모달 코드 복사
+    $('#approvalDetailBtnCopyCode').on('click', function () {
+        const code = document.getElementById('approvalDetailCodeDisplay').textContent;
+        navigator.clipboard.writeText(code)
+            .then(() => Toast.success('코드가 클립보드에 복사됐습니다.'))
+            .catch(() => Toast.error('복사에 실패했습니다.'));
+    });
+
+    // ── 모달 닫힐 때 Preview App 초기화
+    document.getElementById('approvalDetailModal').addEventListener('hidden.bs.modal', function () {
+        const frame = document.getElementById('approvalDetailPreviewFrame');
+        if (frame.contentDocument?.readyState === 'complete') {
+            frame.contentWindow.postMessage({ type: 'UPDATE_CODE', code: '' }, window.location.origin);
+        }
+        document.getElementById('approvalDetailCodeDisplay').textContent = '';
+        $('#approvalDetailContent').addClass('d-none');
+        $('#approvalDetailLoading').removeClass('d-none');
+        // 버튼·안내 메시지 모두 초기화 (다음 열기 시 조건에 따라 재노출)
+        $('#approvalDetailBtnApprove, #approvalDetailBtnReject').addClass('d-none');
+        $('#approvalDetailAuthorNotice').addClass('d-none');
+        ReactApprovalDetail.currentCodeId = null;
+        ReactApprovalDetail.currentStatus = null;
+    });
+
+    // ── 검색 버튼
+    $('#btnSearch').on('click', function () { ReactApprovalHis.search(); });
+
+    // ── 검색 초기화
+    $('#btnSearchReset').on('click', function () {
+        $('#hisSearchStatus').val('');
+        $('#hisSearchApprovalUserId').val('').prop('disabled', false);
+        $('#hisSearchCreateUserId').val('');
+        $('#hisSearchFromDate').val('');
+        $('#hisSearchToDate').val('');
+        $('#chkHisMyOnly').prop('checked', false);
+        ReactApprovalHis.search();
+    });
+
+    // ── 나의 승인 이력: 체크 시 승인자 입력 필드 비활성화, 즉시 재조회
+    $('#chkHisMyOnly').on('change', function () {
+        $('#hisSearchApprovalUserId').prop('disabled', this.checked).val('');
+        ReactApprovalHis.search();
+    });
+
+    // ── 검색 영역 Enter 키 지원
+    $('.card.border').on('keydown', 'input, select', function (e) {
+        if (e.key === 'Enter') { e.preventDefault(); ReactApprovalHis.search(); }
+    });
+
+    // ── 페이지당 건수 변경
+    $('#limitRows').on('change', function () {
+        ReactApprovalHis.itemsPerPage = parseInt($(this).val()) || 10;
+        ReactApprovalHis.search();
+    });
+
+    // ── 승인 대기 목록 새로고침 버튼
+    $('#btnPendingRefresh').on('click', function () {
+        ReactApprovalPending.load(ReactApprovalPending.currentPage);
+    });
+
+    // ── 새로고침 버튼 (툴바)
+    $('#btnRefresh').on('click', function () { ReactApprovalHis.load(); });
+
+    // ── EventBus: 다른 탭에서 상태 변경 시 대기 목록 갱신
+    EventBus.on('admin:reactApproval:statusChanged', function () {
+        ReactApprovalPending.load(ReactApprovalPending.currentPage);
+    });
+
+    document.addEventListener('tab:deactivated:v3_react_approval', function () {
+        EventBus.off('admin:reactApproval:statusChanged');
+    });
+});
+/*]]>*/
+</script>
+</th:block>
+</body>
+</html>

--- a/admin/src/main/resources/templates/pages/react-approval/react-approval-script.html
+++ b/admin/src/main/resources/templates/pages/react-approval/react-approval-script.html
@@ -10,7 +10,7 @@ const CURRENT_USER_ID = /*[[${currentUserId}]]*/ '';
 
 // 상태 배지 정의
 const APPROVAL_STATUS_LABEL = {
-    GENERATED:        { text: '생성 완료',  cls: 'bg-secondary' },
+    GENERATED:        { text: '생성 완료',  cls: 'bg-primary' },
     FAILED:           { text: '실패',        cls: 'bg-danger' },
     PENDING_APPROVAL: { text: '승인 대기',   cls: 'bg-warning text-dark' },
     APPROVED:         { text: '승인 완료',   cls: 'bg-success' },
@@ -375,6 +375,14 @@ const ReactApprovalDetail = {
         $('#approvalDetailApprovalUserId').text(data.approvalUserId || '—');
         $('#approvalDetailApprovalDtime').text(approvalFormatDtime(data.approvalDtime) || '—');
 
+        // 반려 사유: REJECTED 상태일 때만 노출
+        if (data.status === 'REJECTED') {
+            $('#approvalDetailRejectReason').text(data.failReason || '—');
+            $('#approvalDetailRejectReasonRow').removeClass('d-none');
+        } else {
+            $('#approvalDetailRejectReasonRow').addClass('d-none');
+        }
+
         // 미리보기 섹션
         const hasCode = !!(data.reactCode && data.reactCode.trim());
         if (hasCode) {
@@ -461,9 +469,11 @@ $(document).ready(function () {
         document.getElementById('approvalDetailCodeDisplay').textContent = '';
         $('#approvalDetailContent').addClass('d-none');
         $('#approvalDetailLoading').removeClass('d-none');
-        // 버튼·안내 메시지 모두 초기화 (다음 열기 시 조건에 따라 재노출)
+        // 버튼·안내 메시지·반려 사유 모두 초기화 (다음 열기 시 조건에 따라 재노출)
         $('#approvalDetailBtnApprove, #approvalDetailBtnReject').addClass('d-none');
         $('#approvalDetailAuthorNotice').addClass('d-none');
+        $('#approvalDetailRejectReasonRow').addClass('d-none');
+        $('#approvalDetailRejectReason').text('');
         ReactApprovalDetail.currentCodeId = null;
         ReactApprovalDetail.currentStatus = null;
     });

--- a/admin/src/main/resources/templates/pages/react-approval/react-approval.html
+++ b/admin/src/main/resources/templates/pages/react-approval/react-approval.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<div th:fragment="content">
+
+    <!-- ===== 승인 대기 섹션 ===== -->
+    <div class="page-header">
+        <h4 class="page-title">
+            <i class="bi bi-shield-check text-primary"></i>
+            React 코드 승인 관리
+        </h4>
+    </div>
+
+    <!-- 승인 대기 목록 -->
+    <div th:replace="~{pages/react-approval/react-approval-pending :: pending}"></div>
+
+    <!-- ===== 승인 이력 섹션 ===== -->
+    <div class="page-header mt-4">
+        <h4 class="page-title">
+            <i class="bi bi-clock-history text-primary"></i>
+            승인 이력
+        </h4>
+    </div>
+
+    <!-- 검색 영역 -->
+    <div th:replace="~{pages/react-approval/react-approval-his-search :: search}"></div>
+
+    <!-- 이력 테이블 -->
+    <div th:replace="~{pages/react-approval/react-approval-his-table :: table}"></div>
+
+    <!-- 페이지네이션 -->
+    <div th:replace="~{fragments/page-content-layout :: pagination}"></div>
+
+    <!-- 코드 상세 모달 (대기 목록 + 이력 공용) -->
+    <div th:replace="~{pages/react-approval/react-approval-modal :: modal}"></div>
+
+    <!-- 권한 정보 (JS 참조용) -->
+    <input type="hidden" id="hasWriteAuth"
+           th:value="${userAuthorities != null and userAuthorities.contains('REACT_APPROVAL:W')}">
+
+    <!-- Scripts -->
+    <th:block th:replace="~{pages/react-approval/react-approval-script :: script}" />
+</div>
+</body>
+</html>

--- a/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-modal.html
+++ b/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-modal.html
@@ -54,9 +54,9 @@
                                         <th class="table-light text-nowrap">승인일시</th>
                                         <td id="detailApprovalDtime"></td>
                                     </tr>
-                                    <!-- 실패 사유: status가 FAILED인 경우에만 노출 -->
+                                    <!-- 실패/반려 사유: FAILED 또는 REJECTED 상태일 때만 노출 -->
                                     <tr id="detailFailReasonRow" class="d-none">
-                                        <th class="table-light text-nowrap text-danger">실패 사유</th>
+                                        <th class="table-light text-nowrap text-danger" id="detailFailReasonLabel">실패 사유</th>
                                         <td colspan="3" class="text-danger" id="detailFailReason"></td>
                                     </tr>
                                 </tbody>

--- a/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-script.html
+++ b/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-script.html
@@ -32,6 +32,25 @@
         return d.substring(0, 4) + '-' + d.substring(4, 6) + '-' + d.substring(6, 8);
     }
 
+    /**
+     * URL이 http/https 프로토콜을 사용하는지 검증한다.
+     * javascript: 등 위험 프로토콜을 가진 URL을 href에 바인딩하지 않기 위해 사용한다.
+     *
+     * @param {string} url - 검증할 URL 문자열
+     * @returns {boolean} http/https 프로토콜이면 true, 그 외 또는 파싱 불가이면 false
+     */
+    function isSafeUrl(url) {
+        if (!url) return false;
+        try {
+            const parsed = new URL(url);
+            // http/https 프로토콜만 허용 — javascript:, data: 등 위험 프로토콜 차단
+            return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+        } catch {
+            // URL 파싱 실패 = 유효하지 않은 URL
+            return false;
+        }
+    }
+
     // ─── 이력 목록 모듈 ────────────────────────────────────────
     const ReactGenerateHis = {
         currentPage: 1,
@@ -108,13 +127,18 @@
                 const safeUserId = HtmlUtils.escape(item.createUserId || '');
                 const safeCodeId = HtmlUtils.escape(item.codeId || '');
 
+                // 안전한 URL(http/https)만 href에 바인딩 — javascript: 등 위험 프로토콜 차단
+                const figmaLinkHtml = isSafeUrl(item.figmaUrl)
+                    ? `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer"
+                           class="text-decoration-none text-reset"
+                           onclick="event.stopPropagation();">${safeUrl || '—'}</a>`
+                    : `<span>${safeUrl || '—'}</span>`;
+
                 const row = $(`
                     <tr>
                         <td class="text-center">${offset + idx + 1}</td>
                         <td class="text-truncate" style="max-width: 300px;" title="${safeUrl}">
-                            <a href="${safeUrl}" target="_blank" rel="noopener noreferrer"
-                               class="text-decoration-none text-reset"
-                               onclick="event.stopPropagation();">${safeUrl}</a>
+                            ${figmaLinkHtml}
                         </td>
                         <td class="text-center">
                             <span class="badge ${statusInfo.cls}">${statusInfo.text}</span>
@@ -242,7 +266,12 @@
 
             // ── 상세 정보 섹션 ──
             const safeUrl = HtmlUtils.escape(data.figmaUrl || '');
-            $('#detailFigmaUrl').attr('href', safeUrl).text(safeUrl || '—');
+            // 안전한 URL(http/https)만 href 속성을 설정하고, 그 외에는 링크 없이 텍스트만 표시 (XSS 방지)
+            if (isSafeUrl(data.figmaUrl)) {
+                $('#detailFigmaUrl').attr('href', safeUrl).text(safeUrl || '—');
+            } else {
+                $('#detailFigmaUrl').removeAttr('href').text(safeUrl || '—');
+            }
             $('#detailCreateUserId').text(data.createUserId || '—');
             $('#detailCreateDtime').text(formatDtime(data.createDtime) || '—');
             $('#detailApprovalUserId').text(data.approvalUserId || '—');
@@ -365,7 +394,8 @@
         if (frame.contentDocument?.readyState === 'complete') {
             frame.contentWindow.postMessage({ type: 'UPDATE_CODE', code: '' }, window.location.origin);
         }
-        document.getElementById('detailCodeDisplay').innerHTML = '';
+        // textContent로 초기화하여 innerHTML 사용에 따른 잠재적 XSS 위험 제거
+        document.getElementById('detailCodeDisplay').textContent = '';
         // 다음 열기 시 로딩 상태로 리셋
         $('#detailContent').addClass('d-none');
         $('#detailLoading').removeClass('d-none');

--- a/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-script.html
+++ b/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-script.html
@@ -41,10 +41,12 @@
 
         /** 검색 조건을 수집하고 1페이지부터 재조회한다. */
         search: function () {
+            // 내 것만 보기 체크 시 생성자 ID를 현재 로그인 사용자로 고정
+            const myOnly = $('#chkMyOnly').is(':checked');
             // date input은 yyyy-MM-dd로 오므로 하이픈 제거 후 yyyyMMdd로 전달
             this.appliedSearch = {
                 status:         $('#searchStatus').val(),
-                createUserId:   $('#searchCreateUserId').val().trim(),
+                createUserId:   myOnly ? CURRENT_USER_ID : $('#searchCreateUserId').val().trim(),
                 fromDate:       ($('#searchFromDate').val() || '').replace(/-/g, ''),
                 toDate:         ($('#searchToDate').val() || '').replace(/-/g, '')
             };
@@ -376,9 +378,16 @@
 
     $('#btnSearchReset').on('click', function () {
         $('#searchStatus').val('');
-        $('#searchCreateUserId').val('');
+        $('#searchCreateUserId').val('').prop('disabled', false);
         $('#searchFromDate').val('');
         $('#searchToDate').val('');
+        $('#chkMyOnly').prop('checked', false);
+        ReactGenerateHis.search();
+    });
+
+    // 내 것만 보기: 체크 시 생성자 입력 필드 비활성화, 즉시 재조회
+    $('#chkMyOnly').on('change', function () {
+        $('#searchCreateUserId').prop('disabled', this.checked).val('');
         ReactGenerateHis.search();
     });
 

--- a/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-script.html
+++ b/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-script.html
@@ -9,10 +9,11 @@
 
     // ─── 상태 배지 정의 ────────────────────────────────────────
     const STATUS_LABEL = {
-        GENERATED:        { text: '생성 완료',  cls: 'bg-secondary' },
-        PENDING_APPROVAL: { text: '승인 대기',  cls: 'bg-warning text-dark' },
-        APPROVED:         { text: '승인 완료',  cls: 'bg-success' },
-        FAILED:           { text: '실패',       cls: 'bg-danger' }
+        GENERATED:        { text: '생성 완료',  cls: 'bg-primary' },
+        FAILED:           { text: '실패',        cls: 'bg-danger' },
+        PENDING_APPROVAL: { text: '승인 대기',   cls: 'bg-warning text-dark' },
+        APPROVED:         { text: '승인 완료',   cls: 'bg-success' },
+        REJECTED:         { text: '반려',        cls: 'bg-secondary' },
     };
 
     /** yyyyMMddHHmmss → yyyy-MM-dd HH:mm 형식으로 변환한다. */
@@ -254,8 +255,9 @@
                 .removeClass()
                 .addClass('badge ' + statusInfo.cls);
 
-            // 실패 사유: FAILED 상태일 때만 노출
-            if (data.status === 'FAILED') {
+            // 실패/반려 사유: FAILED 또는 REJECTED 상태일 때 노출, 레이블도 상태에 맞게 변경
+            if (data.status === 'FAILED' || data.status === 'REJECTED') {
+                $('#detailFailReasonLabel').text(data.status === 'REJECTED' ? '반려 사유' : '실패 사유');
                 $('#detailFailReason').text(data.failReason || '—');
                 $('#detailFailReasonRow').removeClass('d-none');
             } else {

--- a/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-search.html
+++ b/admin/src/main/resources/templates/pages/react-generate-his/react-generate-his-search.html
@@ -25,6 +25,12 @@
 
         <div class="flex-grow-1"></div>
 
+        <!-- 내 것만 보기: 생성자(createUserId)를 현재 로그인 사용자로 고정 -->
+        <div class="form-check form-check-inline ms-2 mb-0">
+            <input class="form-check-input" type="checkbox" id="chkMyOnly">
+            <label class="form-check-label small fw-medium" for="chkMyOnly">나의 생성 이력</label>
+        </div>
+
         <select id="limitRows" class="form-select form-select-sm sp-limit-select">
             <option value="10" selected>10</option>
             <option value="20">20</option>

--- a/admin/src/main/resources/templates/pages/react-generate/react-generate-script.html
+++ b/admin/src/main/resources/templates/pages/react-generate/react-generate-script.html
@@ -8,10 +8,13 @@
     let currentId = null;
     let currentStatus = null;
 
+    // 승인·반려 상태는 승인 관리 메뉴에서 처리하므로 GENERATED/FAILED/PENDING_APPROVAL만 표시
     const STATUS_LABEL = {
         GENERATED:        { text: '생성 완료',  cls: 'bg-secondary' },
-        PENDING_APPROVAL: { text: '승인 대기',  cls: 'bg-warning text-dark' },
-        APPROVED:         { text: '승인 완료',  cls: 'bg-success' }
+        FAILED:           { text: '실패',        cls: 'bg-danger' },
+        PENDING_APPROVAL: { text: '승인 대기',   cls: 'bg-warning text-dark' },
+        APPROVED:         { text: '승인 완료',   cls: 'bg-success' },
+        REJECTED:         { text: '반려',        cls: 'bg-danger' },
     };
 
     function updateStatusBadge(status) {
@@ -20,11 +23,8 @@
         const badge = $('#statusBadge');
         badge.text(info.text).removeClass().addClass('badge ' + info.cls);
 
-        // 버튼 상태 업데이트
+        // 승인 요청은 GENERATED 상태에서만 가능
         $('#btnRequestApproval').prop('disabled', status !== 'GENERATED');
-        if ($('#btnApprove').length) {
-            $('#btnApprove').prop('disabled', status !== 'PENDING_APPROVAL');
-        }
     }
 
     // ─── 생성 ───────────────────────────────────────────────
@@ -133,31 +133,6 @@
             },
             error: function (xhr) {
                 Toast.error(xhr.responseJSON?.message || '승인 요청 중 오류가 발생했습니다.');
-            }
-        });
-    });
-
-    // ─── 승인 ────────────────────────────────────────────────
-    $('#btnApprove').on('click', function () {
-        alert('구현 예정입니다.');
-        return;
-
-        if (!currentId) return;
-        if (!confirm('해당 코드를 승인하시겠습니까?')) return;
-
-        $.ajax({
-            url: API_BASE_URL + '/react-generate/' + currentId + '/approve',
-            method: 'POST',
-            success: function (res) {
-                if (res.success && res.data) {
-                    updateStatusBadge(res.data.status);
-                    Toast.success('승인이 완료되었습니다. (승인자: ' + (res.data.approvedBy || '') + ')');
-                } else {
-                    Toast.error(res.message || '승인에 실패했습니다.');
-                }
-            },
-            error: function (xhr) {
-                Toast.error(xhr.responseJSON?.message || '승인 처리 중 오류가 발생했습니다.');
             }
         });
     });

--- a/admin/src/main/resources/templates/pages/react-generate/react-generate.html
+++ b/admin/src/main/resources/templates/pages/react-generate/react-generate.html
@@ -106,15 +106,10 @@
         </div>
 
         <!-- Action Buttons -->
+        <!-- 승인 프로세스는 React 코드 승인 관리 메뉴에서 진행한다 -->
         <div class="d-flex gap-2 mt-3">
             <button type="button" class="btn btn-outline-warning" id="btnRequestApproval">
                 <i class="bi bi-send me-1"></i>승인 요청
-            </button>
-            <button type="button"
-                    class="btn btn-success"
-                    id="btnApprove"
-                    th:if="${userAuthorities != null and userAuthorities.contains('REACT_GENERATE:W')}">
-                <i class="bi bi-check-circle me-1"></i>승인
             </button>
         </div>
     </div>


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

- #22

## ✨ 변경 사항 (Changes)

### 신규 기능

**React 코드 승인 관리 메뉴 (`/react-approval`)**
- 승인 대기 목록 조회 (페이지네이션, 새로고침)
- 승인 이력 조회 (상태·요청자·승인자·날짜 필터, "나의 승인 이력" 체크박스)
- 승인 / 반려 액션 (반려 사유 입력 모달)
- 코드 상세 모달 (화면 미리보기 iframe + 코드 미리보기 + 복사)
- 작성자 본인은 승인 불가 — UI 안내 메시지 + 서버 재검증

**React 코드 생성 이력 (`/react-generate-his`) 개선**
- 승인 요청 버튼: GENERATED 상태이고 작성자 본인일 때만 노출
- "나의 생성 이력" 체크박스
- 상세 모달에서 REJECTED 상태 시 반려 사유 표시

### 보안·안정성 개선 (코드 리뷰 반영)

| 항목 | 내용 |
|------|------|
| XSS 방지 | `isSafeUrl()` 함수로 Figma URL의 `javascript:` 등 위험 프로토콜 차단 |
| 입력값 검증 | 반려 사유 `@Size(max=500)` + `@Valid`, 페이지 번호 `@Min(1)`/`@Max(100)` + `@Validated` |
| Race Condition | `updateStatusConditional()` — `WHERE STATUS = PENDING_APPROVAL` 조건부 UPDATE로 동시 승인 방지 |
| @PreAuthorize | 클래스 레벨 제거, 각 메서드에 명시 (`REACT_APPROVAL:R` / `REACT_APPROVAL:W`) |
| 날짜 형식 검증 | `validateDateFormat()` — SQL 전달 전 yyyyMMdd 패턴 검사 |
| innerHTML 제거 | 모달 초기화 시 `textContent = ''` 로 통일 |

## ⚠️ 고려 및 주의 사항

- `FWK_RPS_CODE_HIS` 테이블에 `FAIL_REASON` (CLOB), `APPROVAL_USER_ID`, `APPROVAL_DTIME` 컬럼이 존재해야 합니다. DDL은 `docs/sql/oracle/01_create_tables.sql` 참조
- 승인 관리 메뉴 접근 권한: `REACT_APPROVAL:R` (읽기), `REACT_APPROVAL:W` (승인·반려)
- `menu-resource-permissions.yml`에 권한 매핑 추가됨

## 💬 리뷰 포인트

- `ReactApprovalService.approve()` — `updateStatusConditional()`의 `affected rows = 0` 처리로 Race Condition을 방어합니다. 별도 트랜잭션 없이 DB 레벨 원자성을 활용한 방식입니다.
- `isSafeUrl()` — `new URL()` 파싱 실패 시 `false`를 반환하므로 malformed URL도 안전하게 처리됩니다.
- Thymeleaf `th:block`으로 카드 + 반려 모달을 하나의 fragment로 묶어 DOM 누락 버그를 방지했습니다.