### PR TITLE
feat: cmsUser 리다이렉트 URL을 외부 CMS 서버로 변경

### DIFF
--- a/admin/.env.example
+++ b/admin/.env.example
@@ -49,7 +49,7 @@ CLAUDE_API_KEY=sk-ant-api03-...
 
 # === CMS ===
 # cmsUser 역할 사용자가 /cms 접근 시 이동할 외부 CMS 서버 URL
-CMS_USER_URL=http://133.186.135.23:3001/
+CMS_USER_URL=http://localhost:3001/
 
 # === CMS Deploy ===
 CMS_DEPLOY_RECEIVE_URL=http://133.186.135.23:3001/api/deploy/receive

--- a/admin/.env.example
+++ b/admin/.env.example
@@ -47,6 +47,10 @@ FIGMA_ACCESS_TOKEN=figd_...
 # === Claude API (React Generate — React 코드 생성) ===
 CLAUDE_API_KEY=sk-ant-api03-...
 
+# === CMS ===
+# cmsUser 역할 사용자가 /cms 접근 시 이동할 외부 CMS 서버 URL
+CMS_USER_URL=http://133.186.135.23:3001/
+
 # === CMS Deploy ===
 CMS_DEPLOY_RECEIVE_URL=http://133.186.135.23:3001/api/deploy/receive
 CMS_DEPLOY_SECRET=your-deploy-secret-token

--- a/admin/src/main/java/com/example/admin_demo/global/page/controller/CmsRedirectController.java
+++ b/admin/src/main/java/com/example/admin_demo/global/page/controller/CmsRedirectController.java
@@ -1,6 +1,7 @@
 package com.example.admin_demo.global.page.controller;
 
 import com.example.admin_demo.global.security.CustomUserDetails;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,11 +12,15 @@ public class CmsRedirectController {
     private static final String ADMIN_ROLE = "ADMIN";
     private static final String CMS_ADMIN_ROLE = "cms_admin";
     private static final String CMS_ADMIN_APPROVALS_PATH = "/cms-admin/approvals";
-    private static final String CMS_DASHBOARD_PATH = "/cms/dashboard";
+
+    /** cmsUser 역할 사용자가 이동할 외부 CMS 서버 URL (환경변수 CMS_USER_URL로 오버라이드 가능) */
+    @Value("${cms.user-url}")
+    private String cmsUserUrl;
 
     @GetMapping({"/cms", "/cms/"})
     public String redirectCmsRoot(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        String targetPath = isCmsAdmin(userDetails) ? CMS_ADMIN_APPROVALS_PATH : CMS_DASHBOARD_PATH;
+        // cms_admin·ADMIN은 승인 관리 페이지, 그 외(cmsUser)는 외부 CMS 서버로 이동
+        String targetPath = isCmsAdmin(userDetails) ? CMS_ADMIN_APPROVALS_PATH : cmsUserUrl;
         return "redirect:" + targetPath;
     }
 

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -128,6 +128,7 @@ claude:
 
 # CMS Deploy Configuration
 cms:
+  user-url: ${CMS_USER_URL:http://133.186.135.23:3001/}
   deploy:
     receive-url: ${CMS_DEPLOY_RECEIVE_URL:http://133.186.135.23:3001/api/deploy/receive}
     secret: ${CMS_DEPLOY_SECRET:}

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -128,7 +128,7 @@ claude:
 
 # CMS Deploy Configuration
 cms:
-  user-url: ${CMS_USER_URL:http://133.186.135.23:3001/}
+  user-url: ${CMS_USER_URL:http://localhost:3001/}
   deploy:
     receive-url: ${CMS_DEPLOY_RECEIVE_URL:http://133.186.135.23:3001/api/deploy/receive}
     secret: ${CMS_DEPLOY_SECRET:}

--- a/admin/src/test/java/com/example/admin_demo/global/page/controller/CmsRedirectControllerTest.java
+++ b/admin/src/test/java/com/example/admin_demo/global/page/controller/CmsRedirectControllerTest.java
@@ -14,9 +14,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(CmsRedirectController.class)
+@TestPropertySource(properties = "cms.user-url=http://133.186.135.23:3001/")
 @DisplayName("CMS root redirect")
 class CmsRedirectControllerTest {
 
@@ -40,11 +42,11 @@ class CmsRedirectControllerTest {
     }
 
     @Test
-    @DisplayName("cms_user role redirects /cms to /cms/dashboard")
-    void cmsRoot_cmsUserRole_redirectsDashboard() throws Exception {
+    @DisplayName("cms_user role redirects /cms to external CMS server")
+    void cmsRoot_cmsUserRole_redirectsExternalCmsServer() throws Exception {
         mockMvc.perform(get("/cms").with(user(userDetails("worker", "cms_user", "CMS:R"))))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("/cms/dashboard"));
+                .andExpect(redirectedUrl("http://133.186.135.23:3001/"));
     }
 
     @Test

--- a/admin/src/test/resources/application.yml
+++ b/admin/src/test/resources/application.yml
@@ -52,6 +52,10 @@ app:
 xml-property:
   directory: ${java.io.tmpdir}/xml-properties-test
 
+# CMS (테스트 환경용 더미 URL — 실제 외부 서버 호출 없음)
+cms:
+  user-url: http://localhost:3001/
+
 # Claude API (테스트 환경에서는 실제 호출 없음 — 0초 타임아웃 방지를 위해 더미 값 설정)
 claude:
   api:


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
- #58

## ✨ 변경 사항 (Changes)
- `CmsRedirectController`: `cmsUser` 역할 리다이렉트 대상을 로컬 경로(`/cms/dashboard`) → 외부 CMS 서버(`http://133.186.135.23:3001/`)로 변경, `@Value("${cms.user-url}")` 주입으로 환경변수 오버라이드 가능
- `application.yml`: `cms.user-url` 프로퍼티 추가 (기본값 `http://133.186.135.23:3001/`, 환경변수 `CMS_USER_URL`로 오버라이드)
- `.env.example`: `CMS_USER_URL` 항목 추가
- `CmsRedirectControllerTest`: `@TestPropertySource`로 프로퍼티 주입, `cmsUser` 리다이렉트 기대 URL 수정 및 테스트 통과 확인

## ⚠️ 고려 및 주의 사항 (선택)
- `cms_admin` / `ADMIN` 역할은 기존과 동일하게 `/cms-admin/approvals`로 이동
- CMS 서버 URL은 `CMS_USER_URL` 환경변수로 오버라이드 가능하므로 환경별 분리 용이

## 🔗 참고 사항 (선택)
- 미리보기 서버: `http://133.186.135.23:3000/` (포트 3000)
- 배포·리다이렉트 서버: `http://133.186.135.23:3001/` (포트 3001)