### PR TITLE
[FEATURE #65]: CMS 이미지 업로드 화면 구현

### DIFF
--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
@@ -1,0 +1,135 @@
+package com.example.admin_demo.domain.cmsasset.client;
+
+import com.example.admin_demo.domain.cmsasset.client.dto.CmsBuilderUploadApiResponse;
+import com.example.admin_demo.domain.cmsasset.config.CmsBuilderProperties;
+import com.example.admin_demo.global.exception.ErrorType;
+import com.example.admin_demo.global.exception.base.BaseException;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * CMS Builder /cms/api/builder/upload 호출 클라이언트 — Issue #65.
+ *
+ * <p>Spider Admin 은 파일을 저장하지 않고 CMS 로 포워딩한다.
+ * CMS 가 파일 저장 + SPW_CMS_ASSET INSERT 를 모두 수행하며, Admin 은 응답만 전달받는다.
+ *
+ * <p>CMS 가 실패 시에도 HTTP 200 을 반환하므로 응답 body 의 {@code ok} 필드로 판단한다.
+ * 네트워크 오류 / 비정상 응답은 {@link BaseException} (HTTP 502) 로 래핑해 상위에 전파.
+ */
+@Slf4j
+@Component
+public class CmsBuilderClient {
+
+    private final RestClient cmsBuilderRestClient;
+    private final CmsBuilderProperties properties;
+
+    public CmsBuilderClient(RestClient cmsBuilderRestClient, CmsBuilderProperties properties) {
+        this.cmsBuilderRestClient = cmsBuilderRestClient;
+        this.properties = properties;
+    }
+
+    /**
+     * CMS Builder 로 이미지 파일을 업로드한다.
+     *
+     * @param file             원본 이미지
+     * @param userId           업로더 ID
+     * @param userName         업로더 이름
+     * @param businessCategory 업무 카테고리 (선택)
+     * @param assetDesc        이미지 설명 (선택)
+     * @return CMS 응답 (assetId, url 포함)
+     * @throws BaseException 업로드 실패 또는 CMS 응답 오류 시 (HTTP 502)
+     */
+    public CmsBuilderUploadApiResponse upload(
+            MultipartFile file, String userId, String userName, String businessCategory, String assetDesc) {
+
+        MultiValueMap<String, Object> form = buildFormData(file, userId, userName, businessCategory, assetDesc);
+
+        try {
+            CmsBuilderUploadApiResponse response = cmsBuilderRestClient
+                    .post()
+                    .uri(properties.getUploadPath())
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .body(form)
+                    .retrieve()
+                    .body(CmsBuilderUploadApiResponse.class);
+
+            if (response == null) {
+                log.error("CMS Builder 응답 body 가 null. path={}", properties.getUploadPath());
+                throw new BaseException(ErrorType.EXTERNAL_SERVICE_ERROR, "CMS 응답이 비어 있습니다.");
+            }
+            if (!response.isSuccess()) {
+                String errMsg = response.getError() != null ? response.getError() : "CMS 업로드 실패";
+                log.warn("CMS Builder 업로드 실패 응답: ok={}, error={}, userId={}", response.getOk(), errMsg, userId);
+                throw new BaseException(ErrorType.EXTERNAL_SERVICE_ERROR, errMsg);
+            }
+
+            log.info(
+                    "CMS Builder 업로드 성공: assetId={}, url={}, userId={}",
+                    response.getAssetId(),
+                    response.getUrl(),
+                    userId);
+            return response;
+
+        } catch (RestClientException e) {
+            log.error("CMS Builder 호출 중 오류 발생: userId={}", userId, e);
+            throw new BaseException(ErrorType.EXTERNAL_SERVICE_ERROR, "CMS 서버와 통신할 수 없습니다. 잠시 후 다시 시도하세요.", e);
+        }
+    }
+
+    /** 멀티파트 form-data 구성. file 은 파일명·Content-Type 을 보존하여 전송한다. */
+    private MultiValueMap<String, Object> buildFormData(
+            MultipartFile file, String userId, String userName, String businessCategory, String assetDesc) {
+
+        MultiValueMap<String, Object> form = new LinkedMultiValueMap<>();
+        form.add("file", toFilePart(file));
+        if (userId != null) {
+            form.add("userId", userId);
+        }
+        if (userName != null) {
+            form.add("userName", userName);
+        }
+        if (businessCategory != null && !businessCategory.isBlank()) {
+            form.add("businessCategory", businessCategory);
+        }
+        if (assetDesc != null && !assetDesc.isBlank()) {
+            form.add("assetDesc", assetDesc);
+        }
+        return form;
+    }
+
+    /**
+     * MultipartFile 을 RestClient 전송 가능한 HttpEntity(Resource) 로 변환.
+     *
+     * <p>파일명을 보존하려면 {@link ByteArrayResource#getFilename()} 를 오버라이드해야 한다.
+     */
+    private org.springframework.http.HttpEntity<ByteArrayResource> toFilePart(MultipartFile file) {
+        byte[] bytes;
+        try {
+            bytes = file.getBytes();
+        } catch (IOException e) {
+            throw new BaseException(ErrorType.INTERNAL_ERROR, "파일을 읽는 중 오류가 발생했습니다.", e);
+        }
+        ByteArrayResource resource = new ByteArrayResource(bytes) {
+            @Override
+            public String getFilename() {
+                return file.getOriginalFilename();
+            }
+        };
+        HttpHeaders partHeaders = new HttpHeaders();
+        if (file.getContentType() != null) {
+            partHeaders.setContentType(MediaType.parseMediaType(file.getContentType()));
+        } else {
+            partHeaders.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+        }
+        return new org.springframework.http.HttpEntity<>(resource, partHeaders);
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
@@ -4,9 +4,9 @@ import com.example.admin_demo.domain.cmsasset.client.dto.CmsBuilderUploadApiResp
 import com.example.admin_demo.domain.cmsasset.config.CmsBuilderProperties;
 import com.example.admin_demo.global.exception.ErrorType;
 import com.example.admin_demo.global.exception.base.BaseException;
-import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -109,27 +109,17 @@ public class CmsBuilderClient {
     /**
      * MultipartFile 을 RestClient 전송 가능한 HttpEntity(Resource) 로 변환.
      *
-     * <p>파일명을 보존하려면 {@link ByteArrayResource#getFilename()} 를 오버라이드해야 한다.
+     * <p>{@link MultipartFile#getResource()} 는 내부 저장소(임시 파일·InputStream)를 직접 참조하는
+     * Resource 를 반환하므로 전체 바이트를 힙에 복사하지 않는다. 20MB 다건 업로드 시 OOM·GC 압박을 피하기 위함.
+     * 반환되는 {@code MultipartFileResource} 는 원본 파일명을 그대로 노출한다.
      */
-    private org.springframework.http.HttpEntity<ByteArrayResource> toFilePart(MultipartFile file) {
-        byte[] bytes;
-        try {
-            bytes = file.getBytes();
-        } catch (IOException e) {
-            throw new BaseException(ErrorType.INTERNAL_ERROR, "파일을 읽는 중 오류가 발생했습니다.", e);
-        }
-        ByteArrayResource resource = new ByteArrayResource(bytes) {
-            @Override
-            public String getFilename() {
-                return file.getOriginalFilename();
-            }
-        };
+    private HttpEntity<Resource> toFilePart(MultipartFile file) {
         HttpHeaders partHeaders = new HttpHeaders();
         if (file.getContentType() != null) {
             partHeaders.setContentType(MediaType.parseMediaType(file.getContentType()));
         } else {
             partHeaders.setContentType(MediaType.APPLICATION_OCTET_STREAM);
         }
-        return new org.springframework.http.HttpEntity<>(resource, partHeaders);
+        return new HttpEntity<>(file.getResource(), partHeaders);
     }
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/dto/CmsBuilderUploadApiResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/dto/CmsBuilderUploadApiResponse.java
@@ -1,0 +1,47 @@
+package com.example.admin_demo.domain.cmsasset.client.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * CMS Builder /cms/api/builder/upload 응답 스키마 — Issue #65.
+ *
+ * <p>CMS 는 실패 시에도 HTTP 200 을 반환하며 {@code ok:false} 로 실패를 표현한다.
+ * 따라서 HTTP status 가 아닌 {@code ok} 필드로 성공/실패를 판단해야 한다.
+ *
+ * <p>성공 시 body: {@code {"url": "/static/xxx.png", "assetId": "uuid"}}
+ * (성공 응답에는 {@code ok} 필드가 없으므로 기본값 null → 아래 isSuccess 로직 참고)
+ * <p>실패 시 body: {@code {"ok": false, "error": "메시지"}}
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class CmsBuilderUploadApiResponse {
+
+    /** 성공 여부 플래그 (실패 시에만 명시). 성공 응답에서는 null 일 수 있음 */
+    private Boolean ok;
+
+    /** 실패 메시지 (ok=false 일 때만 존재) */
+    private String error;
+
+    /** CMS 가 저장한 이미지 URL (성공 시, 예: "/static/xxx.png") */
+    private String url;
+
+    /** CMS 가 발급한 Asset UUID (성공 시) */
+    private String assetId;
+
+    /**
+     * 성공 여부 판단.
+     * <ul>
+     *   <li>{@code ok == Boolean.FALSE} 이면 실패</li>
+     *   <li>그 외에는 assetId 와 url 이 모두 존재해야 성공으로 본다</li>
+     * </ul>
+     */
+    public boolean isSuccess() {
+        if (Boolean.FALSE.equals(ok)) {
+            return false;
+        }
+        return assetId != null && !assetId.isBlank() && url != null && !url.isBlank();
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/config/CmsBuilderConfig.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/config/CmsBuilderConfig.java
@@ -1,0 +1,36 @@
+package com.example.admin_demo.domain.cmsasset.config;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+/**
+ * CMS Builder 호출용 RestClient 빈 구성 — Issue #65.
+ *
+ * <p>별도 RestClient 로 분리한 이유: 타임아웃과 baseUrl 이 다른 CMS 호출과 격리되어야 하고,
+ * 업로드 호출의 독립적인 타임아웃을 관리한다.
+ */
+@Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(CmsBuilderProperties.class)
+public class CmsBuilderConfig {
+
+    private final CmsBuilderProperties properties;
+
+    /** CMS Builder 전용 RestClient */
+    @Bean
+    public RestClient cmsBuilderRestClient() {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(Duration.ofSeconds(properties.getConnectTimeoutSeconds()));
+        requestFactory.setReadTimeout(Duration.ofSeconds(properties.getReadTimeoutSeconds()));
+
+        return RestClient.builder()
+                .baseUrl(properties.getBaseUrl())
+                .requestFactory(requestFactory)
+                .build();
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/config/CmsBuilderProperties.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/config/CmsBuilderProperties.java
@@ -1,0 +1,29 @@
+package com.example.admin_demo.domain.cmsasset.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * CMS Builder(미승인 이미지 업로드) 호출 설정 — Issue #65.
+ *
+ * <p>Spider Admin 은 파일을 직접 저장하지 않고 CMS Builder 서버로 포워딩한다.
+ * 내부망 서버-투-서버 호출 전제이며, 인증 토큰은 현재 없음.
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "cms.builder")
+public class CmsBuilderProperties {
+
+    /** CMS Builder 서버 기본 URL (예: http://133.186.135.23:3000) */
+    private String baseUrl;
+
+    /** 업로드 엔드포인트 경로 (예: /cms/api/builder/upload) */
+    private String uploadPath;
+
+    /** 연결 타임아웃 (초) */
+    private int connectTimeoutSeconds = 5;
+
+    /** 읽기 타임아웃 (초). 대용량 이미지 업로드를 고려해 넉넉히 잡는다. */
+    private int readTimeoutSeconds = 60;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/config/CmsBuilderProperties.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/config/CmsBuilderProperties.java
@@ -15,7 +15,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "cms.builder")
 public class CmsBuilderProperties {
 
-    /** CMS Builder 서버 기본 URL (예: http://133.186.135.23:3000) */
+    /** CMS Builder 서버 기본 URL (예: http://133.186.135.23) — nginx 80 → Next.js 3000 업스트림 프록시 */
     private String baseUrl;
 
     /** 업로드 엔드포인트 경로 (예: /cms/api/builder/upload) */

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/controller/CmsAssetUploadController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/controller/CmsAssetUploadController.java
@@ -1,0 +1,51 @@
+package com.example.admin_demo.domain.cmsasset.controller;
+
+import com.example.admin_demo.domain.cmsasset.dto.CmsAssetUploadResponse;
+import com.example.admin_demo.domain.cmsasset.service.CmsAssetService;
+import com.example.admin_demo.global.dto.ApiResponse;
+import com.example.admin_demo.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 현업 관리자용 — 이미지 업로드 API 컨트롤러 (Issue #65).
+ *
+ * <h4>API 엔드포인트:</h4>
+ * <ul>
+ *   <li>POST /api/cms-admin/asset-uploads (multipart/form-data) — CMS Builder 로 포워딩</li>
+ * </ul>
+ *
+ * <p>Admin 은 파일을 저장하지 않고 CMS 로 위임한다. 업로더 정보(userId/userName)는
+ * {@code @AuthenticationPrincipal} 에서 추출하며 클라이언트 입력은 신뢰하지 않는다.
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class CmsAssetUploadController {
+
+    private final CmsAssetService cmsAssetService;
+
+    /** 이미지 업로드 (CMS Builder 포워딩) */
+    @PostMapping(value = "/api/cms-admin/asset-uploads", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasAuthority('CMS:W')")
+    public ResponseEntity<ApiResponse<CmsAssetUploadResponse>> upload(
+            @RequestParam("file") MultipartFile file,
+            @RequestParam(value = "businessCategory", required = false) String businessCategory,
+            @RequestParam(value = "assetDesc", required = false) String assetDesc,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        CmsAssetUploadResponse response = cmsAssetService.uploadAsset(
+                file, businessCategory, assetDesc, userDetails.getUserId(), userDetails.getDisplayName());
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("이미지 업로드가 완료되었습니다.", response));
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/dto/CmsAssetUploadResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/dto/CmsAssetUploadResponse.java
@@ -1,0 +1,27 @@
+package com.example.admin_demo.domain.cmsasset.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * CMS 이미지 업로드 응답 DTO — Issue #65.
+ *
+ * <p>CMS Builder 가 반환한 {@code assetId} 와 {@code url} 을 그대로 전달한다.
+ * 브라우저는 이 값을 받아 목록을 새로고침하거나 후속 승인 요청(#53)의 기준 ID 로 사용한다.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CmsAssetUploadResponse {
+
+    /** CMS 가 발급한 UUID */
+    private String assetId;
+
+    /** CMS 기준 이미지 URL (예: "/static/xxx.png" 상대경로) */
+    private String url;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetService.java
@@ -1,10 +1,14 @@
 package com.example.admin_demo.domain.cmsasset.service;
 
+import com.example.admin_demo.domain.cmsasset.client.CmsBuilderClient;
+import com.example.admin_demo.domain.cmsasset.client.dto.CmsBuilderUploadApiResponse;
 import com.example.admin_demo.domain.cmsasset.dto.CmsAssetApprovalListRequest;
 import com.example.admin_demo.domain.cmsasset.dto.CmsAssetDetailResponse;
 import com.example.admin_demo.domain.cmsasset.dto.CmsAssetListResponse;
 import com.example.admin_demo.domain.cmsasset.dto.CmsAssetRequestListRequest;
+import com.example.admin_demo.domain.cmsasset.dto.CmsAssetUploadResponse;
 import com.example.admin_demo.domain.cmsasset.mapper.CmsAssetMapper;
+import com.example.admin_demo.domain.cmsasset.validator.AssetUploadValidator;
 import com.example.admin_demo.global.dto.PageRequest;
 import com.example.admin_demo.global.dto.PageResponse;
 import com.example.admin_demo.global.exception.InvalidInputException;
@@ -16,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 /**
  * CMS 이미지(에셋) 승인 관리 서비스.
@@ -48,6 +53,8 @@ public class CmsAssetService {
     private static final int REJECTED_REASON_MAX_BYTES = 1000;
 
     private final CmsAssetMapper cmsAssetMapper;
+    private final CmsBuilderClient cmsBuilderClient;
+    private final AssetUploadValidator assetUploadValidator;
 
     /**
      * 현업 본인 업로드 이미지 목록 조회.
@@ -108,6 +115,28 @@ public class CmsAssetService {
             throw new InvalidStateException("이미 처리된 이미지입니다. assetId=" + assetId);
         }
         log.info("CMS 이미지 승인 완료: assetId={}, modifierId={}", assetId, modifierId);
+    }
+
+    /**
+     * 이미지 업로드 — Issue #65.
+     *
+     * <p>Admin 은 파일을 저장하지 않고 CMS Builder 로 포워딩한다.
+     * CMS 가 파일 저장 + {@code SPW_CMS_ASSET} INSERT (ASSET_STATE='WORK') 까지 수행하며,
+     * Admin 은 응답만 그대로 전달한다.
+     *
+     * <p>업로더 정보({@code uploaderId/Name})는 {@code @AuthenticationPrincipal} 에서 추출된 값이어야 하며,
+     * 클라이언트가 보낸 값은 신뢰하지 않는다 (컨트롤러에서 강제).
+     */
+    public CmsAssetUploadResponse uploadAsset(
+            MultipartFile file, String businessCategory, String assetDesc, String uploaderId, String uploaderName) {
+
+        assetUploadValidator.validate(file);
+        CmsBuilderUploadApiResponse cmsResponse =
+                cmsBuilderClient.upload(file, uploaderId, uploaderName, businessCategory, assetDesc);
+        return CmsAssetUploadResponse.builder()
+                .assetId(cmsResponse.getAssetId())
+                .url(cmsResponse.getUrl())
+                .build();
     }
 
     /** 반려 — PENDING → REJECTED (결재자). 반려 사유는 선택 */

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/validator/AssetUploadValidator.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/validator/AssetUploadValidator.java
@@ -2,6 +2,7 @@ package com.example.admin_demo.domain.cmsasset.validator;
 
 import com.example.admin_demo.global.exception.InvalidInputException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -81,9 +82,10 @@ public class AssetUploadValidator {
 
     /** 파일 헤더의 첫 N 바이트를 읽어 반환. IO 오류 시 InvalidInputException. */
     private byte[] readHeaderBytes(MultipartFile file) {
-        try {
+        // try-with-resources 로 스트림을 명시적으로 닫아 리소스 누수를 방지한다.
+        try (InputStream is = file.getInputStream()) {
             byte[] buf = new byte[MAGIC_BYTE_READ_SIZE];
-            int read = file.getInputStream().readNBytes(buf, 0, MAGIC_BYTE_READ_SIZE);
+            int read = is.readNBytes(buf, 0, MAGIC_BYTE_READ_SIZE);
             if (read < 3) {
                 throw new InvalidInputException("파일을 읽을 수 없습니다.");
             }

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/validator/AssetUploadValidator.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/validator/AssetUploadValidator.java
@@ -1,0 +1,154 @@
+package com.example.admin_demo.domain.cmsasset.validator;
+
+import com.example.admin_demo.global.exception.InvalidInputException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * CMS 이미지 업로드 검증기 — Issue #65.
+ *
+ * <p>CMS 측 MIME 검증이 없으므로 Admin 이 유일한 방어선이다.
+ * 확장자 화이트리스트 + 매직바이트 스니프 + 크기 상한 3단 검증을 수행한다.
+ * 클라이언트가 보낸 Content-Type 은 로깅만 하고 신뢰하지 않는다.
+ */
+@Slf4j
+@Component
+public class AssetUploadValidator {
+
+    /** 최대 허용 파일 크기 (20MB) */
+    public static final long MAX_FILE_SIZE_BYTES = 20L * 1024 * 1024;
+
+    /** 허용 확장자 (소문자) */
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of("png", "jpg", "jpeg", "gif", "webp");
+
+    /** 매직바이트 검사 시 읽어올 최대 바이트 수 (WebP 식별을 위해 최소 12바이트 필요) */
+    private static final int MAGIC_BYTE_READ_SIZE = 12;
+
+    /**
+     * 업로드 파일을 검증한다. 실패 시 {@link InvalidInputException} 을 던진다.
+     *
+     * @param file 멀티파트 파일
+     * @return 매직바이트로 식별된 MIME 타입 (image/png, image/jpeg, image/gif, image/webp)
+     */
+    public String validate(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new InvalidInputException("업로드할 파일을 선택하세요.");
+        }
+        if (file.getSize() > MAX_FILE_SIZE_BYTES) {
+            throw new InvalidInputException(
+                    String.format("파일 크기는 %dMB 이하로 업로드하세요.", MAX_FILE_SIZE_BYTES / (1024 * 1024)));
+        }
+
+        String extension = extractExtension(file.getOriginalFilename());
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+            throw new InvalidInputException("허용하지 않는 파일 형식입니다. (png, jpg, jpeg, gif, webp 만 허용)");
+        }
+
+        byte[] header = readHeaderBytes(file);
+        String sniffedMime = sniffMimeType(header);
+        if (sniffedMime == null) {
+            throw new InvalidInputException("유효한 이미지 파일이 아닙니다.");
+        }
+
+        List<String> expectedExtensionGroup = mimeToExtensionGroup(sniffedMime);
+        if (!expectedExtensionGroup.contains(extension)) {
+            // 확장자-실제 포맷 불일치 (예: .exe 를 .png 로 rename)
+            log.warn("확장자({}) 와 매직바이트({}) 불일치 — 업로드 거부. 파일명={}", extension, sniffedMime, file.getOriginalFilename());
+            throw new InvalidInputException("파일 확장자와 실제 형식이 일치하지 않습니다.");
+        }
+
+        log.debug("업로드 검증 통과: filename={}, size={}, mime={}", file.getOriginalFilename(), file.getSize(), sniffedMime);
+        return sniffedMime;
+    }
+
+    /** 파일명에서 소문자 확장자 추출. 확장자 없으면 빈 문자열. */
+    private String extractExtension(String filename) {
+        if (filename == null) {
+            return "";
+        }
+        int dotIdx = filename.lastIndexOf('.');
+        if (dotIdx < 0 || dotIdx == filename.length() - 1) {
+            return "";
+        }
+        return filename.substring(dotIdx + 1).toLowerCase(Locale.ROOT);
+    }
+
+    /** 파일 헤더의 첫 N 바이트를 읽어 반환. IO 오류 시 InvalidInputException. */
+    private byte[] readHeaderBytes(MultipartFile file) {
+        try {
+            byte[] buf = new byte[MAGIC_BYTE_READ_SIZE];
+            int read = file.getInputStream().readNBytes(buf, 0, MAGIC_BYTE_READ_SIZE);
+            if (read < 3) {
+                throw new InvalidInputException("파일을 읽을 수 없습니다.");
+            }
+            return Arrays.copyOf(buf, read);
+        } catch (IOException e) {
+            throw new InvalidInputException("파일을 읽는 중 오류가 발생했습니다.");
+        }
+    }
+
+    /**
+     * 매직바이트로 MIME 타입 식별.
+     *
+     * <ul>
+     *   <li>PNG: 89 50 4E 47 0D 0A 1A 0A</li>
+     *   <li>JPEG: FF D8 FF</li>
+     *   <li>GIF: 47 49 46 38 (37|39) 61 ("GIF87a" / "GIF89a")</li>
+     *   <li>WebP: 52 49 46 46 ?? ?? ?? ?? 57 45 42 50 ("RIFF....WEBP")</li>
+     * </ul>
+     */
+    private String sniffMimeType(byte[] h) {
+        if (h.length >= 8
+                && h[0] == (byte) 0x89
+                && h[1] == (byte) 0x50
+                && h[2] == (byte) 0x4E
+                && h[3] == (byte) 0x47
+                && h[4] == (byte) 0x0D
+                && h[5] == (byte) 0x0A
+                && h[6] == (byte) 0x1A
+                && h[7] == (byte) 0x0A) {
+            return "image/png";
+        }
+        if (h.length >= 3 && h[0] == (byte) 0xFF && h[1] == (byte) 0xD8 && h[2] == (byte) 0xFF) {
+            return "image/jpeg";
+        }
+        if (h.length >= 6
+                && h[0] == 'G'
+                && h[1] == 'I'
+                && h[2] == 'F'
+                && h[3] == '8'
+                && (h[4] == '7' || h[4] == '9')
+                && h[5] == 'a') {
+            return "image/gif";
+        }
+        if (h.length >= 12
+                && h[0] == 'R'
+                && h[1] == 'I'
+                && h[2] == 'F'
+                && h[3] == 'F'
+                && h[8] == 'W'
+                && h[9] == 'E'
+                && h[10] == 'B'
+                && h[11] == 'P') {
+            return "image/webp";
+        }
+        return null;
+    }
+
+    /** 매직바이트로 식별된 MIME 을 허용 확장자 리스트로 매핑 (jpeg 는 jpg/jpeg 모두 허용). */
+    private List<String> mimeToExtensionGroup(String mime) {
+        return switch (mime) {
+            case "image/png" -> List.of("png");
+            case "image/jpeg" -> List.of("jpg", "jpeg");
+            case "image/gif" -> List.of("gif");
+            case "image/webp" -> List.of("webp");
+            default -> List.of();
+        };
+    }
+}

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -133,6 +133,12 @@ cms:
     receive-url: ${CMS_DEPLOY_RECEIVE_URL:http://133.186.135.23:3001/api/deploy/receive}
     secret: ${CMS_DEPLOY_SECRET:}
     tracker-js-url: ${CMS_DEPLOY_TRACKER_JS_URL:http://133.186.135.23:3001/cms-tracker.js}
+  # CMS Builder (미승인 이미지 업로드) — 내부망 서버-투-서버 호출 (Issue #65)
+  builder:
+    base-url: ${CMS_BUILDER_BASE_URL:http://133.186.135.23:3000}
+    upload-path: ${CMS_BUILDER_UPLOAD_PATH:/cms/api/builder/upload}
+    connect-timeout-seconds: ${CMS_BUILDER_CONNECT_TIMEOUT:5}
+    read-timeout-seconds: ${CMS_BUILDER_READ_TIMEOUT:60}
 
 # Scheduling Configuration (배치 이력 정리 스케줄러)
 scheduling:

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -134,8 +134,9 @@ cms:
     secret: ${CMS_DEPLOY_SECRET:}
     tracker-js-url: ${CMS_DEPLOY_TRACKER_JS_URL:http://133.186.135.23:3001/cms-tracker.js}
   # CMS Builder (미승인 이미지 업로드) — 내부망 서버-투-서버 호출 (Issue #65)
+  # nginx 가 80 → CMS(Next.js) 업스트림으로 프록시하므로 외부에서는 포트 없이 접근한다.
   builder:
-    base-url: ${CMS_BUILDER_BASE_URL:http://133.186.135.23:3000}
+    base-url: ${CMS_BUILDER_BASE_URL:http://133.186.135.23}
     upload-path: ${CMS_BUILDER_UPLOAD_PATH:/cms/api/builder/upload}
     connect-timeout-seconds: ${CMS_BUILDER_CONNECT_TIMEOUT:5}
     read-timeout-seconds: ${CMS_BUILDER_READ_TIMEOUT:60}

--- a/admin/src/main/resources/static/css/asset-requests-content.css
+++ b/admin/src/main/resources/static/css/asset-requests-content.css
@@ -1,2 +1,20 @@
-/* CMS 이미지 승인 요청 페이지 전용 스타일 (현재 비어있음).
-   home.html이 페이지 경로 기반으로 자동 로드하는 규약 때문에 빈 stub 을 유지한다. */
+/* CMS 이미지 승인 요청 페이지 전용 스타일. */
+
+/* 업로드 모달 드롭존 */
+.asset-upload-dropzone {
+    border: 2px dashed #ced4da;
+    border-radius: 8px;
+    background-color: #f8f9fa;
+    cursor: pointer;
+    transition: border-color 0.2s, background-color 0.2s;
+}
+
+.asset-upload-dropzone:hover {
+    border-color: #0d6efd;
+    background-color: #f1f7ff;
+}
+
+.asset-upload-dropzone.is-dragover {
+    border-color: #0d6efd;
+    background-color: #e7f1ff;
+}

--- a/admin/src/main/resources/templates/pages/asset/request-script.html
+++ b/admin/src/main/resources/templates/pages/asset/request-script.html
@@ -259,7 +259,12 @@
 
         _bindDropzone: function() {
             const $dz = $('#assetUploadDropzone');
-            $dz.off('click.assetUpload').on('click.assetUpload', () => $('#assetUploadFileInput').trigger('click'));
+            // jQuery .trigger('click') 은 synthetic event 라 일부 브라우저에서 파일 다이얼로그를 못 연다.
+            // 네이티브 HTMLInputElement.click() 을 사용해야 사용자 제스처 맥락이 유지된다.
+            $dz.off('click.assetUpload').on('click.assetUpload', () => {
+                const input = document.getElementById('assetUploadFileInput');
+                if (input) input.click();
+            });
             $dz.off('dragover.assetUpload').on('dragover.assetUpload', (e) => {
                 e.preventDefault();
                 e.stopPropagation();

--- a/admin/src/main/resources/templates/pages/asset/request-script.html
+++ b/admin/src/main/resources/templates/pages/asset/request-script.html
@@ -230,7 +230,151 @@
             CmsAssetRequestPage.itemsPerPage = parseInt($(this).val()) || 10;
             CmsAssetRequestPage.load(1);
         });
+
+        if (window.HAS_CMS_WRITE) {
+            CmsAssetUploadModal.init();
+        }
     });
+
+    // ==================== CmsAssetUploadModal (Issue #65) ====================
+    // 이미지 업로드 모달 — 파일 선택·드래그앤드롭, 클라이언트 검증, FormData POST.
+
+    window.CmsAssetUploadModal = {
+        MAX_FILE_SIZE: 20 * 1024 * 1024,
+        ALLOWED_MIME: ['image/png', 'image/jpeg', 'image/gif', 'image/webp'],
+        selectedFile: null,
+
+        init: function() {
+            this._bindOpenButton();
+            this._bindDropzone();
+            this._bindFileInput();
+            this._bindSubmit();
+            this._bindClear();
+        },
+
+        _bindOpenButton: function() {
+            $(document).off('click.assetUploadOpen', '#btnOpenAssetUpload')
+                .on('click.assetUploadOpen', '#btnOpenAssetUpload', () => this.open());
+        },
+
+        _bindDropzone: function() {
+            const $dz = $('#assetUploadDropzone');
+            $dz.off('click.assetUpload').on('click.assetUpload', () => $('#assetUploadFileInput').trigger('click'));
+            $dz.off('dragover.assetUpload').on('dragover.assetUpload', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                $dz.addClass('is-dragover');
+            });
+            $dz.off('dragleave.assetUpload').on('dragleave.assetUpload', () => $dz.removeClass('is-dragover'));
+            $dz.off('drop.assetUpload').on('drop.assetUpload', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                $dz.removeClass('is-dragover');
+                const files = e.originalEvent.dataTransfer && e.originalEvent.dataTransfer.files;
+                if (files && files.length > 0) {
+                    this._onFileSelected(files[0]);
+                }
+            });
+        },
+
+        _bindFileInput: function() {
+            $('#assetUploadFileInput').off('change.assetUpload').on('change.assetUpload', (e) => {
+                if (e.target.files && e.target.files.length > 0) {
+                    this._onFileSelected(e.target.files[0]);
+                }
+            });
+        },
+
+        _bindSubmit: function() {
+            $('#btnAssetUploadSubmit').off('click.assetUpload').on('click.assetUpload', () => this._submit());
+        },
+
+        _bindClear: function() {
+            $('#btnAssetUploadClear').off('click.assetUpload').on('click.assetUpload', () => this._clearFile());
+        },
+
+        open: function() {
+            this._clearFile();
+            $('#assetUploadCategory').val('');
+            $('#assetUploadDesc').val('');
+            new bootstrap.Modal('#assetUploadModal').show();
+        },
+
+        _onFileSelected: function(file) {
+            // 클라이언트측 1차 검증 — 서버가 최종 결정권자지만 UX 측면에서 즉시 피드백
+            if (!this.ALLOWED_MIME.includes(file.type)) {
+                Toast.error('지원하지 않는 파일 형식입니다. (PNG, JPG, JPEG, GIF, WebP 만 허용)');
+                return;
+            }
+            if (file.size > this.MAX_FILE_SIZE) {
+                Toast.error('파일 크기는 20MB 이하로 업로드하세요.');
+                return;
+            }
+
+            this.selectedFile = file;
+            $('#assetUploadPreviewWrap').removeClass('d-none');
+            $('#assetUploadPreviewName').text(file.name);
+            $('#assetUploadPreviewSize').text(this._formatSize(file.size));
+            $('#assetUploadPreviewType').text(file.type);
+
+            const reader = new FileReader();
+            reader.onload = (ev) => $('#assetUploadPreview').attr('src', ev.target.result);
+            reader.readAsDataURL(file);
+
+            $('#btnAssetUploadSubmit').prop('disabled', false);
+        },
+
+        _clearFile: function() {
+            this.selectedFile = null;
+            $('#assetUploadFileInput').val('');
+            $('#assetUploadPreviewWrap').addClass('d-none');
+            $('#assetUploadPreview').attr('src', '');
+            $('#btnAssetUploadSubmit').prop('disabled', true);
+        },
+
+        _submit: function() {
+            if (!this.selectedFile) {
+                Toast.warning('업로드할 파일을 선택하세요.');
+                return;
+            }
+            const fd = new FormData();
+            fd.append('file', this.selectedFile);
+            const category = $('#assetUploadCategory').val().trim();
+            const desc = $('#assetUploadDesc').val().trim();
+            if (category) fd.append('businessCategory', category);
+            if (desc) fd.append('assetDesc', desc);
+
+            this._setSubmitting(true);
+
+            fetch('/api/cms-admin/asset-uploads', {
+                method: 'POST',
+                body: fd,
+            })
+                .then(r => r.json().then(body => ({ status: r.status, body })))
+                .then(({ status, body }) => {
+                    if (status >= 200 && status < 300 && body.success) {
+                        Toast.success(body.message || '업로드가 완료되었습니다.');
+                        bootstrap.Modal.getInstance('#assetUploadModal').hide();
+                        CmsAssetRequestPage.load(1);
+                    } else {
+                        Toast.error(body.message || '업로드 처리 중 오류가 발생했습니다.');
+                    }
+                })
+                .catch(() => Toast.error('업로드 처리 중 오류가 발생했습니다.'))
+                .finally(() => this._setSubmitting(false));
+        },
+
+        _setSubmitting: function(submitting) {
+            $('#btnAssetUploadSubmit').prop('disabled', submitting || !this.selectedFile);
+            $('#assetUploadSpinner').toggleClass('d-none', !submitting);
+        },
+
+        _formatSize: function(bytes) {
+            if (bytes < 1024) return bytes + ' B';
+            if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+            return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+        },
+    };
 </script>
 </th:block>
 </body>

--- a/admin/src/main/resources/templates/pages/asset/request-upload-modal.html
+++ b/admin/src/main/resources/templates/pages/asset/request-upload-modal.html
@@ -14,16 +14,16 @@
                 </div>
                 <div class="modal-body">
 
-                    <!-- 드롭존 -->
+                    <!-- 드롭존: input 은 드롭존 밖에 두어 클릭 버블링 루프를 방지한다. -->
                     <div id="assetUploadDropzone" class="asset-upload-dropzone text-center p-4 mb-3">
                         <i class="bi bi-cloud-arrow-up fs-1 text-body-secondary"></i>
                         <p class="mb-1">이미지 파일을 여기로 드래그하거나 클릭하여 선택하세요.</p>
                         <p class="small text-body-secondary mb-0">
                             지원 형식: PNG, JPG, JPEG, GIF, WebP · 최대 20MB
                         </p>
-                        <input type="file" id="assetUploadFileInput" class="d-none"
-                               accept="image/png,image/jpeg,image/gif,image/webp"/>
                     </div>
+                    <input type="file" id="assetUploadFileInput" class="d-none"
+                           accept="image/png,image/jpeg,image/gif,image/webp"/>
 
                     <!-- 선택된 파일 미리보기 -->
                     <div id="assetUploadPreviewWrap" class="d-none mb-3">

--- a/admin/src/main/resources/templates/pages/asset/request-upload-modal.html
+++ b/admin/src/main/resources/templates/pages/asset/request-upload-modal.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<!-- CMS 이미지 업로드 모달 프래그먼트 (Issue #65) -->
+<div th:fragment="modal">
+    <div class="modal fade" id="assetUploadModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">
+                        <i class="bi bi-upload"></i> 이미지 업로드
+                    </h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+
+                    <!-- 드롭존 -->
+                    <div id="assetUploadDropzone" class="asset-upload-dropzone text-center p-4 mb-3">
+                        <i class="bi bi-cloud-arrow-up fs-1 text-body-secondary"></i>
+                        <p class="mb-1">이미지 파일을 여기로 드래그하거나 클릭하여 선택하세요.</p>
+                        <p class="small text-body-secondary mb-0">
+                            지원 형식: PNG, JPG, JPEG, GIF, WebP · 최대 20MB
+                        </p>
+                        <input type="file" id="assetUploadFileInput" class="d-none"
+                               accept="image/png,image/jpeg,image/gif,image/webp"/>
+                    </div>
+
+                    <!-- 선택된 파일 미리보기 -->
+                    <div id="assetUploadPreviewWrap" class="d-none mb-3">
+                        <div class="d-flex align-items-start gap-3">
+                            <img id="assetUploadPreview" alt="preview"
+                                 style="width:120px;height:120px;object-fit:cover;border:1px solid #dee2e6;border-radius:4px;background:#f8f9fa;"/>
+                            <div class="flex-grow-1 small">
+                                <div><strong>파일명:</strong> <span id="assetUploadPreviewName">-</span></div>
+                                <div><strong>크기:</strong> <span id="assetUploadPreviewSize">-</span></div>
+                                <div><strong>형식:</strong> <span id="assetUploadPreviewType">-</span></div>
+                                <button type="button" class="btn btn-outline-secondary btn-xs mt-2"
+                                        id="btnAssetUploadClear">
+                                    <i class="bi bi-x"></i> 파일 제거
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- 메타데이터 입력 -->
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label for="assetUploadCategory" class="form-label small">업무 카테고리 (선택)</label>
+                            <input type="text" id="assetUploadCategory" class="form-control form-control-sm"
+                                   maxlength="50"/>
+                        </div>
+                        <div class="col-12">
+                            <label for="assetUploadDesc" class="form-label small">이미지 설명 (선택)</label>
+                            <textarea id="assetUploadDesc" class="form-control form-control-sm" rows="2"
+                                      maxlength="1000"></textarea>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">취소</button>
+                    <button type="button" class="btn btn-primary btn-sm" id="btnAssetUploadSubmit" disabled>
+                        <span id="assetUploadSpinner" class="spinner-border spinner-border-sm d-none me-1"></span>
+                        <i class="bi bi-upload"></i> 업로드
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/admin/src/main/resources/templates/pages/asset/request.html
+++ b/admin/src/main/resources/templates/pages/asset/request.html
@@ -20,6 +20,12 @@
             <i class="bi bi-exclamation-circle-fill text-danger"></i>
             내 이미지 목록
         </h4>
+        <div class="page-header-actions"
+             th:if="${userAuthorities != null and userAuthorities.contains('CMS:W')}">
+            <button class="btn btn-primary btn-sm" id="btnOpenAssetUpload">
+                <i class="bi bi-upload"></i> 이미지 업로드
+            </button>
+        </div>
     </div>
 
     <!-- 테이블 -->
@@ -27,6 +33,9 @@
 
     <!-- 페이지네이션 -->
     <div th:replace="~{fragments/page-content-layout :: pagination}"></div>
+
+    <!-- 업로드 모달 -->
+    <div th:replace="~{pages/asset/request-upload-modal :: modal}"></div>
 
     <!-- 스크립트 -->
     <th:block th:replace="~{pages/asset/request-script :: script}"/>

--- a/admin/src/test/java/com/example/admin_demo/domain/cmsasset/controller/CmsAssetUploadControllerTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/cmsasset/controller/CmsAssetUploadControllerTest.java
@@ -1,0 +1,107 @@
+package com.example.admin_demo.domain.cmsasset.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.admin_demo.domain.cmsasset.dto.CmsAssetUploadResponse;
+import com.example.admin_demo.domain.cmsasset.service.CmsAssetService;
+import com.example.admin_demo.domain.user.enums.UserState;
+import com.example.admin_demo.global.exception.ErrorType;
+import com.example.admin_demo.global.exception.InvalidInputException;
+import com.example.admin_demo.global.exception.base.BaseException;
+import com.example.admin_demo.global.security.CustomUserDetails;
+import com.example.admin_demo.global.security.dto.AuthenticatedUser;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(CmsAssetUploadController.class)
+@DisplayName("CmsAssetUploadController 테스트")
+class CmsAssetUploadControllerTest {
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {}
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CmsAssetService cmsAssetService;
+
+    private static final String URL = "/api/cms-admin/asset-uploads";
+
+    @Test
+    @DisplayName("[업로드] CMS:W 권한 + 정상 파일 → 201")
+    void upload_withCmsW_returns201() throws Exception {
+        MockMultipartFile file = new MockMultipartFile("file", "a.png", "image/png", new byte[] {1, 2, 3});
+        given(cmsAssetService.uploadAsset(any(), any(), any(), eq("cmsUser01"), any()))
+                .willReturn(CmsAssetUploadResponse.builder()
+                        .assetId("uuid-1")
+                        .url("/static/a.png")
+                        .build());
+
+        mockMvc.perform(multipart(URL)
+                        .file(file)
+                        .param("businessCategory", "마케팅")
+                        .with(csrf())
+                        .with(user(customUserDetails("cmsUser01", "CMS:W"))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.assetId").value("uuid-1"))
+                .andExpect(jsonPath("$.data.url").value("/static/a.png"));
+    }
+
+    @Test
+    @DisplayName("[업로드] CMS:R 만 있으면 403")
+    void upload_onlyCmsR_returns403() throws Exception {
+        MockMultipartFile file = new MockMultipartFile("file", "a.png", "image/png", new byte[] {1});
+
+        mockMvc.perform(multipart(URL).file(file).with(csrf()).with(user(customUserDetails("cmsUser01", "CMS:R"))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("[업로드] Validator 실패 → 400")
+    void upload_invalidInput_returns400() throws Exception {
+        MockMultipartFile file = new MockMultipartFile("file", "a.exe", "application/x-msdownload", new byte[] {1});
+        willThrow(new InvalidInputException("허용하지 않는 형식"))
+                .given(cmsAssetService)
+                .uploadAsset(any(), any(), any(), any(), any());
+
+        mockMvc.perform(multipart(URL).file(file).with(csrf()).with(user(customUserDetails("cmsUser01", "CMS:W"))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("[업로드] CMS 서버 오류 → 502")
+    void upload_externalServiceError_returns502() throws Exception {
+        MockMultipartFile file = new MockMultipartFile("file", "a.png", "image/png", new byte[] {1});
+        willThrow(new BaseException(ErrorType.EXTERNAL_SERVICE_ERROR, "CMS 통신 오류"))
+                .given(cmsAssetService)
+                .uploadAsset(any(), any(), any(), any(), any());
+
+        mockMvc.perform(multipart(URL).file(file).with(csrf()).with(user(customUserDetails("cmsUser01", "CMS:W"))))
+                .andExpect(status().isBadGateway());
+    }
+
+    private CustomUserDetails customUserDetails(String userId, String authority) {
+        AuthenticatedUser user = new AuthenticatedUser(userId, userId + "님", "ROLE_USER", "pwd", UserState.NORMAL);
+        return new CustomUserDetails(user, Set.of(new SimpleGrantedAuthority(authority)));
+    }
+}

--- a/admin/src/test/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetServiceTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetServiceTest.java
@@ -35,6 +35,12 @@ class CmsAssetServiceTest {
     @Mock
     private CmsAssetMapper cmsAssetMapper;
 
+    @Mock
+    private com.example.admin_demo.domain.cmsasset.client.CmsBuilderClient cmsBuilderClient;
+
+    @Mock
+    private com.example.admin_demo.domain.cmsasset.validator.AssetUploadValidator assetUploadValidator;
+
     @InjectMocks
     private CmsAssetService cmsAssetService;
 

--- a/admin/src/test/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetServiceUploadTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetServiceUploadTest.java
@@ -1,0 +1,93 @@
+package com.example.admin_demo.domain.cmsasset.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+
+import com.example.admin_demo.domain.cmsasset.client.CmsBuilderClient;
+import com.example.admin_demo.domain.cmsasset.client.dto.CmsBuilderUploadApiResponse;
+import com.example.admin_demo.domain.cmsasset.dto.CmsAssetUploadResponse;
+import com.example.admin_demo.domain.cmsasset.mapper.CmsAssetMapper;
+import com.example.admin_demo.domain.cmsasset.validator.AssetUploadValidator;
+import com.example.admin_demo.global.exception.InvalidInputException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CmsAssetService.uploadAsset 테스트 (#65)")
+class CmsAssetServiceUploadTest {
+
+    @Mock
+    private CmsAssetMapper cmsAssetMapper;
+
+    @Mock
+    private CmsBuilderClient cmsBuilderClient;
+
+    @Mock
+    private AssetUploadValidator assetUploadValidator;
+
+    @InjectMocks
+    private CmsAssetService cmsAssetService;
+
+    private static final String USER_ID = "cmsUser01";
+    private static final String USER_NAME = "CMS 현업01";
+
+    @Test
+    @DisplayName("[업로드] 정상 흐름 — validator → CMS 호출 → CmsAssetUploadResponse 반환")
+    void uploadAsset_happyPath_returnsResponse() {
+        MockMultipartFile file = new MockMultipartFile("file", "a.png", "image/png", new byte[] {1, 2, 3});
+        given(cmsBuilderClient.upload(eq(file), eq(USER_ID), eq(USER_NAME), eq("카테고리A"), eq("설명")))
+                .willReturn(buildCmsResponse("uuid-1", "/static/a.png"));
+
+        CmsAssetUploadResponse result = cmsAssetService.uploadAsset(file, "카테고리A", "설명", USER_ID, USER_NAME);
+
+        assertThat(result.getAssetId()).isEqualTo("uuid-1");
+        assertThat(result.getUrl()).isEqualTo("/static/a.png");
+        then(assetUploadValidator).should().validate(file);
+        then(cmsBuilderClient).should().upload(file, USER_ID, USER_NAME, "카테고리A", "설명");
+    }
+
+    @Test
+    @DisplayName("[업로드] Validator 가 실패하면 CMS 호출하지 않고 예외 전파")
+    void uploadAsset_validatorFails_noCmsCall() {
+        MockMultipartFile file = new MockMultipartFile("file", "a.exe", "application/x-msdownload", new byte[] {1});
+        willThrow(new InvalidInputException("허용하지 않는 형식"))
+                .given(assetUploadValidator)
+                .validate(any(MultipartFile.class));
+
+        assertThatThrownBy(() -> cmsAssetService.uploadAsset(file, null, null, USER_ID, USER_NAME))
+                .isInstanceOf(InvalidInputException.class);
+        then(cmsBuilderClient).should(never()).upload(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("[업로드] 빈/공백 메타데이터는 null 로 유지된 채 CMS 호출에 그대로 전달")
+    void uploadAsset_blankMetadata_passedAsIs() {
+        MockMultipartFile file = new MockMultipartFile("file", "a.png", "image/png", new byte[] {1});
+        given(cmsBuilderClient.upload(any(), any(), any(), any(), any()))
+                .willReturn(buildCmsResponse("uuid-2", "/static/b.png"));
+
+        cmsAssetService.uploadAsset(file, "   ", "", USER_ID, USER_NAME);
+
+        // Controller 가 @RequestParam 으로 받은 원시값을 그대로 전달하므로 Service 는 정규화하지 않는다.
+        then(cmsBuilderClient).should().upload(file, USER_ID, USER_NAME, "   ", "");
+    }
+
+    private CmsBuilderUploadApiResponse buildCmsResponse(String assetId, String url) {
+        CmsBuilderUploadApiResponse r = new CmsBuilderUploadApiResponse();
+        r.setAssetId(assetId);
+        r.setUrl(url);
+        return r;
+    }
+}

--- a/admin/src/test/java/com/example/admin_demo/domain/cmsasset/validator/AssetUploadValidatorTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/cmsasset/validator/AssetUploadValidatorTest.java
@@ -1,0 +1,128 @@
+package com.example.admin_demo.domain.cmsasset.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.example.admin_demo.global.exception.InvalidInputException;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+@DisplayName("AssetUploadValidator 테스트")
+class AssetUploadValidatorTest {
+
+    private final AssetUploadValidator validator = new AssetUploadValidator();
+
+    // ─── 매직 바이트 샘플 ───────────────────────────────────────────
+
+    private static final byte[] PNG_MAGIC = {
+        (byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x00
+    };
+    private static final byte[] JPEG_MAGIC = {
+        (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    };
+    private static final byte[] GIF89A_MAGIC = {'G', 'I', 'F', '8', '9', 'a', 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    private static final byte[] WEBP_MAGIC = {'R', 'I', 'F', 'F', 0x00, 0x00, 0x00, 0x00, 'W', 'E', 'B', 'P'};
+    private static final byte[] EXE_MAGIC = {'M', 'Z', (byte) 0x90, 0x00, 0x03, 0x00, 0x00, 0x00, 0x04, 0x00, 0, 0};
+
+    // ─── 정상 케이스 ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("[정상] PNG 파일")
+    void validate_png_ok() {
+        MockMultipartFile file = new MockMultipartFile("file", "a.png", "image/png", PNG_MAGIC);
+        assertThat(validator.validate(file)).isEqualTo("image/png");
+    }
+
+    @Test
+    @DisplayName("[정상] JPEG — .jpg 확장자")
+    void validate_jpgExt_ok() {
+        MockMultipartFile file = new MockMultipartFile("file", "a.jpg", "image/jpeg", JPEG_MAGIC);
+        assertThat(validator.validate(file)).isEqualTo("image/jpeg");
+    }
+
+    @Test
+    @DisplayName("[정상] JPEG — .jpeg 확장자")
+    void validate_jpegExt_ok() {
+        MockMultipartFile file = new MockMultipartFile("file", "a.jpeg", "image/jpeg", JPEG_MAGIC);
+        assertThat(validator.validate(file)).isEqualTo("image/jpeg");
+    }
+
+    @Test
+    @DisplayName("[정상] GIF")
+    void validate_gif_ok() {
+        MockMultipartFile file = new MockMultipartFile("file", "a.gif", "image/gif", GIF89A_MAGIC);
+        assertThat(validator.validate(file)).isEqualTo("image/gif");
+    }
+
+    @Test
+    @DisplayName("[정상] WebP")
+    void validate_webp_ok() {
+        MockMultipartFile file = new MockMultipartFile("file", "a.webp", "image/webp", WEBP_MAGIC);
+        assertThat(validator.validate(file)).isEqualTo("image/webp");
+    }
+
+    // ─── 실패 케이스 ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("[실패] 파일 없음")
+    void validate_empty_throws() {
+        MockMultipartFile file = new MockMultipartFile("file", "a.png", "image/png", new byte[0]);
+        assertThatThrownBy(() -> validator.validate(file))
+                .isInstanceOf(InvalidInputException.class)
+                .extracting("detailMessage", InstanceOfAssertFactories.STRING)
+                .contains("파일을 선택");
+    }
+
+    @Test
+    @DisplayName("[실패] 20MB 초과")
+    void validate_oversize_throws() {
+        byte[] big = new byte[(int) (AssetUploadValidator.MAX_FILE_SIZE_BYTES + 1)];
+        System.arraycopy(PNG_MAGIC, 0, big, 0, PNG_MAGIC.length);
+        MockMultipartFile file = new MockMultipartFile("file", "a.png", "image/png", big);
+        assertThatThrownBy(() -> validator.validate(file))
+                .isInstanceOf(InvalidInputException.class)
+                .extracting("detailMessage", InstanceOfAssertFactories.STRING)
+                .contains("20MB");
+    }
+
+    @Test
+    @DisplayName("[실패] SVG 확장자는 허용되지 않음")
+    void validate_svg_throws() {
+        MockMultipartFile file = new MockMultipartFile("file", "a.svg", "image/svg+xml", "<svg/>".getBytes());
+        assertThatThrownBy(() -> validator.validate(file))
+                .isInstanceOf(InvalidInputException.class)
+                .extracting("detailMessage", InstanceOfAssertFactories.STRING)
+                .contains("허용하지 않는 파일 형식");
+    }
+
+    @Test
+    @DisplayName("[실패] 확장자 없음")
+    void validate_noExt_throws() {
+        MockMultipartFile file = new MockMultipartFile("file", "noext", "image/png", PNG_MAGIC);
+        assertThatThrownBy(() -> validator.validate(file)).isInstanceOf(InvalidInputException.class);
+    }
+
+    @Test
+    @DisplayName("[실패] 확장자는 .png 인데 실제 바이트는 EXE — 이미지로 식별되지 않음")
+    void validate_mismatch_exeAsPng_throws() {
+        MockMultipartFile file = new MockMultipartFile("file", "fake.png", "image/png", EXE_MAGIC);
+        // EXE 매직바이트(MZ)는 허용 이미지 포맷 중 어느 것과도 매치되지 않으므로
+        // "확장자/포맷 불일치" 단계보다 앞서 "유효한 이미지 파일이 아닙니다" 로 거부된다.
+        assertThatThrownBy(() -> validator.validate(file))
+                .isInstanceOf(InvalidInputException.class)
+                .extracting("detailMessage", InstanceOfAssertFactories.STRING)
+                .contains("유효한 이미지 파일");
+    }
+
+    @Test
+    @DisplayName("[실패] 확장자는 .png 인데 실제 바이트는 JPEG (cross-format swap)")
+    void validate_mismatch_jpegAsPng_throws() {
+        MockMultipartFile file = new MockMultipartFile("file", "fake.png", "image/png", JPEG_MAGIC);
+        assertThatThrownBy(() -> validator.validate(file))
+                .isInstanceOf(InvalidInputException.class)
+                .extracting("detailMessage", InstanceOfAssertFactories.STRING)
+                .contains("확장자와 실제 형식");
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

- Closes #65
- 선행: #53 (승인 요청·관리 화면) — 본 PR 의 업로드 완료 시 동일 화면에 `WORK` 상태로 노출됨
- 참고: CMS 측 대응 이슈 #11 (businessCategory·assetDesc 파라미터 반영)

## ✨ 변경 사항 (Changes)

현업 관리자가 PC 에서 이미지 파일을 선택해 승인 요청 화면에서 바로 업로드할 수 있도록 한다.
Admin 은 파일을 저장하지 않고 CMS Builder(`/cms/api/builder/upload`)로 HTTP 포워딩하며,
CMS 가 파일 저장 + `SPW_CMS_ASSET` INSERT(`ASSET_STATE='WORK'`)를 수행한다.

### 신규 도메인 요소 (`domain/cmsasset/`)
- **`validator/AssetUploadValidator`** — 확장자 화이트리스트(png/jpg/jpeg/gif/webp) + **매직바이트 스니프** + 20MB 상한. SVG 명시적 거부. CMS 측 MIME 검증이 없어 Admin 이 유일한 방어선.
- **`client/CmsBuilderClient`** + **`client/dto/CmsBuilderUploadApiResponse`** — CMS 호출 전담. RestClient 분리로 baseUrl/타임아웃 격리. CMS 가 실패 시에도 HTTP 200 + `{ok:false, error:"..."}` 로 응답하므로 body 파싱으로 성공/실패 판단.
- **`config/CmsBuilderProperties` + `CmsBuilderConfig`** — `cms.builder.*` 설정 바인딩, 전용 RestClient 빈.
- **`controller/CmsAssetUploadController`** — `POST /api/cms-admin/asset-uploads` (multipart/form-data), `@PreAuthorize("hasAuthority('CMS:W')")`.
- **`dto/CmsAssetUploadResponse`** — `{assetId, url}` (CMS 응답 프록시).

### 서비스 변경
- `CmsAssetService.uploadAsset(file, businessCategory, assetDesc, uploaderId, uploaderName)` 메서드 추가.
- 업로더 정보는 `@AuthenticationPrincipal` 에서만 추출 (클라이언트 입력 신뢰 X).

### 설정 (`application.yml`)
```yaml
cms:
  builder:
    base-url: ${CMS_BUILDER_BASE_URL:http://133.186.135.23:3000}
    upload-path: ${CMS_BUILDER_UPLOAD_PATH:/cms/api/builder/upload}
    connect-timeout-seconds: ${CMS_BUILDER_CONNECT_TIMEOUT:5}
    read-timeout-seconds: ${CMS_BUILDER_READ_TIMEOUT:60}
```

### UI (`templates/pages/asset/`)
- `request.html` — "이미지 업로드" 버튼 (CMS:W 권한 시에만 노출) + 모달 include.
- `request-upload-modal.html` (신규 프래그먼트) — 드래그앤드롭 드롭존 + 미리보기 + 카테고리/설명 입력 + 진행 스피너.
- `request-script.html` — `CmsAssetUploadModal` 모듈 추가: 클라이언트 1차 검증(파일 타입·크기) → FormData POST → 성공 시 Toast + 목록 reload.
- `asset-requests-content.css` — 드롭존 hover/drag-over 스타일.

### 테스트
- Unit: `AssetUploadValidatorTest`(11), `CmsAssetServiceUploadTest`(3)
- Controller: `CmsAssetUploadControllerTest`(4) — 201/400/403/502 매트릭스
- **전체 709 tests 통과** (+19 건), ArchUnit·Spotless 그린

## ⚠️ 고려 및 주의 사항

### 운영 배포 전 확인 필요
1. **내부망 전제** — Admin→CMS 호출은 인증 토큰 없이 서버-투-서버. 두 서버가 동일 내부망에 있어야 함.
2. **nginx body-size** — Admin 앞단 nginx 의 `client_max_body_size` ≥ 20MB 확인. CMS 측은 이미 100MB 로 설정됨(CMS 팀 확인).
3. **환경변수** — 운영 배포 시 `CMS_BUILDER_BASE_URL` 이 실제 CMS:3000 주소로 설정되어야 함.

### CMS 측 대응 (이슈 #11 연동)
- CMS `/cms/api/builder/upload` 가 `businessCategory`, `assetDesc` 파라미터를 새로 받을 예정.
- Admin 은 두 파라미터를 전달하며, CMS 가 받기 전까지는 CMS 측에서 단순 무시됨.

### 본 PR 범위 외 (후속)
- **썸네일 실제 URL 렌더링** — 목록 썸네일은 placeholder 유지, CMS 도메인 prefix 처리는 별도 진행.
- **삭제(DELETE)** — CMS `DELETE /cms/api/assets/{assetId}` 스펙 확정됨. 별도 이슈로 처리.
- **재시도 멱등성** — 네트워크 오류 시 자동 재시도 없음(orphan 방지). 사용자가 수동 재시도.

### 보안 방어선
- **매직바이트 스니프** — 확장자·Content-Type 위조 차단 (`.exe → .png` rename, cross-format swap 테스트 포함).
- **업로더 경계** — 클라이언트가 `userId` 를 form 에 포함시켜도 무시됨. 서버가 `CustomUserDetails` 로 강제 덮어씀.
- **SVG 거부** — XSS 벡터(인라인 스크립트) 우려로 화이트리스트에서 명시적 제외.

## 💬 리뷰 포인트

- **`AssetUploadValidator` 의 매직바이트 매트릭스** — PNG/JPEG/GIF/WebP 시그니처가 올바른지, 확장자 그룹 매핑(`jpg`/`jpeg` 동일 처리)이 합당한지.
- **`CmsBuilderClient` 의 에러 처리** — CMS 의 "HTTP 200 + body.ok" 스펙에 맞춰 `isSuccess()` 판정 로직을 body 기반으로 작성. `RestClientException` 은 502 로 래핑.
- **UI 의 클라이언트 1차 검증 vs 서버 최종 검증** — 클라이언트는 UX 피드백용, 서버가 최종 결정권자. 이중 검증 의도가 코드에서 명확한지.

## 🔗 참고 사항

- 선행 이슈 #53 의 `domain/cmsasset` 모듈 패턴을 그대로 따름.
- CMS 응답 스키마: 성공 `{url, assetId}` / 실패 `{ok:false, error}` (HTTP status 는 항상 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)