### PR TITLE
feat: spider-admin + react-cms 로컬 통합 테스트 환경 구성 (기존 포트 9000 통합)

### DIFF
--- a/admin/nginx/cms-local-proxy.conf
+++ b/admin/nginx/cms-local-proxy.conf
@@ -32,6 +32,20 @@ server {
         proxy_redirect http://localhost/ http://localhost:9000/;
     }
 
+    # /react-cms/** → react-cms Vite dev server (포트 5173)
+    # WebSocket 업그레이드 포함 — Vite HMR 필수
+    location ^~ /react-cms/ {
+        proxy_pass http://host.docker.internal:5173;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port 9000;
+        proxy_redirect http://localhost/ http://localhost:9000/;
+    }
+
     location / {
         proxy_pass http://host.docker.internal:8080;
         proxy_set_header Host $http_host;

--- a/admin/nginx/cms-local-proxy.conf
+++ b/admin/nginx/cms-local-proxy.conf
@@ -32,6 +32,11 @@ server {
         proxy_redirect http://localhost/ http://localhost:9000/;
     }
 
+    # trailing slash 없이 접근 시 301로 리다이렉트 — 없으면 location / 로 폴스루되어 404 발생
+    location = /react-cms {
+        return 301 $scheme://$http_host$uri/;
+    }
+
     # /react-cms/** → react-cms Vite dev server (포트 5173)
     # WebSocket 업그레이드 포함 — Vite HMR 필수
     location ^~ /react-cms/ {

--- a/react-cms/src/main.tsx
+++ b/react-cms/src/main.tsx
@@ -16,12 +16,20 @@ import { blocks, overlays, layouts } from "./cms.config"
 // import { savePage } from "./savePage"
 import userScopeCSS from "./user-scope.css?inline"
 
+// BASE_URL은 Vite가 vite.config.ts의 base 설정값으로 주입한다.
+// VITE_BASE=/cms/ 로 실행 시 '/cms/' — 프록시 연동에서 React Router basename으로 사용.
+// 단독 개발 시 기본값 '/' → basename 미설정으로 현재 동작 유지.
+const basename = import.meta.env.BASE_URL !== '/'
+  ? import.meta.env.BASE_URL.replace(/\/$/, '')
+  : undefined;
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <CMSApp
       blocks={blocks}
       overlays={overlays}
       layouts={layouts}
+      basename={basename}
       codegenConfig={{ blockImportFrom: "@cl", layoutImportFrom: "@cl" }}
       stylesheetContent={userScopeCSS}
       // onSave={savePage}

--- a/react-cms/vite.config.ts
+++ b/react-cms/vite.config.ts
@@ -10,6 +10,14 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // https://vite.dev/config/
 export default defineConfig({
+  // VITE_BASE 환경변수로 base 경로를 제어한다.
+  // 프록시 연동 시: VITE_BASE=/react-cms/ npm run dev
+  // 단독 개발 시: 기본값 '/' 유지 (평소 동작 그대로)
+  base: process.env.VITE_BASE ?? '/',
+  server: {
+    // 모든 네트워크 인터페이스에 바인딩 — Docker(nginx)에서 host.docker.internal로 접근하기 위해 필요
+    host: true,
+  },
   plugins: [
     react(),
     tailwindcss(),


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

Closes #94

## ✨ 변경 사항 (Changes)

별도 포트(9001)를 추가하는 대신 기존 `cms-local-proxy.conf`(포트 9000)에 `/react-cms/` 경로를 통합해 react-cms Vite dev server와 연동한다.

- **`admin/nginx/cms-local-proxy.conf`**
  - `/react-cms/**` → react-cms Vite dev server(:5173) 프록시 블록 추가
  - WebSocket 업그레이드 헤더 포함 (Vite HMR 필수)

- **`react-cms/vite.config.ts`**
  - `VITE_BASE` 환경변수로 base 경로 제어 (`VITE_BASE=/react-cms/ npm run dev`)
  - `server.host: true` 추가 — Docker에서 `host.docker.internal`로 접근하기 위해 필요

- **`react-cms/src/main.tsx`**
  - `import.meta.env.BASE_URL` 기반으로 React Router `basename` 자동 파생
  - 단독 개발 시(`BASE_URL='/'`) basename 미설정으로 기존 동작 유지

## ⚠️ 고려 및 주의 사항 (선택)

- Vite `host: true`는 모든 네트워크 인터페이스에 바인딩되므로 **로컬 개발 환경에서만 사용**
- react-cms 실행 시 반드시 `VITE_BASE=/react-cms/` 환경변수 설정 필요

## 💬 리뷰 포인트 (선택)

- `cms-local-proxy.conf`의 `/react-cms/` location 블록 순서 — `location /` 보다 앞에 위치해 정확히 매칭되는지 확인

## 🔗 참고 사항 (선택)

**실행 순서**
```bash
# 터미널 1 — spider-admin
cd admin && ./mvnw spring-boot:run "-Dspring-boot.run.profiles=oracle"

# 터미널 2 — cms-1-innova-next
cd cms-1-innova-next && npm run dev

# 터미널 3 — react-cms (base 경로 /react-cms/ 설정)
cd react-cms && VITE_BASE=/react-cms/ npm run dev

# 터미널 4 — proxy 실행
cd admin && docker compose --profile admin-proxy up -d
```

접근: `http://localhost:9000/react-cms/`