### PR TITLE
[FEATURE #55]: 이미지 승인 시 CMS 파일 배포 API 연동

### DIFF
--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
@@ -5,6 +5,7 @@ import com.example.admin_demo.domain.cmsasset.config.CmsBuilderProperties;
 import com.example.admin_demo.global.exception.ErrorType;
 import com.example.admin_demo.global.exception.base.BaseException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -39,10 +40,21 @@ public class CmsBuilderClient {
     private static final String DEPLOY_PATH_TEMPLATE = "/cms/api/assets/{assetId}/deploy";
 
     private final RestClient cmsBuilderRestClient;
+
+    /**
+     * 배포(deploy) 전용 RestClient — 업로드보다 훨씬 짧은 read-timeout 적용.
+     * deploy 실패 시 saga 보상 UPDATE 도 있어 HTTP 대기를 짧게 끊어주는 것이 전체 응답성에 중요.
+     */
+    private final RestClient cmsBuilderDeployRestClient;
+
     private final CmsBuilderProperties properties;
 
-    public CmsBuilderClient(RestClient cmsBuilderRestClient, CmsBuilderProperties properties) {
+    public CmsBuilderClient(
+            @Qualifier("cmsBuilderRestClient") RestClient cmsBuilderRestClient,
+            @Qualifier("cmsBuilderDeployRestClient") RestClient cmsBuilderDeployRestClient,
+            CmsBuilderProperties properties) {
         this.cmsBuilderRestClient = cmsBuilderRestClient;
+        this.cmsBuilderDeployRestClient = cmsBuilderDeployRestClient;
         this.properties = properties;
     }
 
@@ -136,7 +148,7 @@ public class CmsBuilderClient {
      */
     public void deployAsset(String assetId) {
         try {
-            cmsBuilderRestClient
+            cmsBuilderDeployRestClient
                     .post()
                     .uri(DEPLOY_PATH_TEMPLATE, assetId)
                     .retrieve()

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
@@ -35,6 +35,9 @@ public class CmsBuilderClient {
      */
     private static final String DELETE_PATH_TEMPLATE = "/cms/api/assets/{assetId}";
 
+    /** CMS 자산 배포(승인 후 파일 이동) 엔드포인트 경로 템플릿. */
+    private static final String DEPLOY_PATH_TEMPLATE = "/cms/api/assets/{assetId}/deploy";
+
     private final RestClient cmsBuilderRestClient;
     private final CmsBuilderProperties properties;
 
@@ -114,6 +117,35 @@ public class CmsBuilderClient {
 
         } catch (RestClientException e) {
             log.error("CMS Builder 삭제 호출 중 오류 발생: assetId={}, userId={}", assetId, userId, e);
+            throw new BaseException(ErrorType.EXTERNAL_SERVICE_ERROR, "CMS 서버와 통신할 수 없습니다. 잠시 후 다시 시도하세요.", e);
+        }
+    }
+
+    /**
+     * CMS Builder 에 이미지 승인 후 파일 배포(운영 경로로 이동)를 요청한다 — Issue #55.
+     *
+     * <p>Admin 의 승인 트랜잭션 내부에서 호출된다. 실패 시 {@link BaseException}(502) 을 던져
+     * 호출자(@Transactional Service) 의 DB 커밋을 롤백시키는 구조이므로, 삭제와 마찬가지로
+     * body 파싱은 생략하고 HTTP status 기반으로 판정한다.
+     *
+     * <p>성공 응답은 {@code {"ok":true,"data":{"url":...}}} 이나 Admin 은 반환 URL 을 사용하지 않는다
+     * (CMS 가 {@code SPW_CMS_ASSET.ASSET_URL} 을 직접 갱신).
+     *
+     * @param assetId 배포 대상 자산 식별자
+     * @throws BaseException 배포 실패 시 (HTTP 502)
+     */
+    public void deployAsset(String assetId) {
+        try {
+            cmsBuilderRestClient
+                    .post()
+                    .uri(DEPLOY_PATH_TEMPLATE, assetId)
+                    .retrieve()
+                    .toBodilessEntity();
+
+            log.info("CMS Builder 파일 배포 성공: assetId={}", assetId);
+
+        } catch (RestClientException e) {
+            log.error("CMS Builder 파일 배포 호출 중 오류 발생: assetId={}", assetId, e);
             throw new BaseException(ErrorType.EXTERNAL_SERVICE_ERROR, "CMS 서버와 통신할 수 없습니다. 잠시 후 다시 시도하세요.", e);
         }
     }

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/config/CmsBuilderConfig.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/config/CmsBuilderConfig.java
@@ -21,12 +21,28 @@ public class CmsBuilderConfig {
 
     private final CmsBuilderProperties properties;
 
-    /** CMS Builder 전용 RestClient */
+    /** CMS Builder 전용 RestClient — 업로드·삭제 호출에 사용 (대용량 업로드를 고려한 long read-timeout) */
     @Bean
     public RestClient cmsBuilderRestClient() {
+        return buildClient(properties.getConnectTimeoutSeconds(), properties.getReadTimeoutSeconds());
+    }
+
+    /**
+     * 배포(deploy) 전용 RestClient — Issue #55.
+     *
+     * <p>파일 이동은 CMS 내부 I/O 라 수 초 내 완료되어야 하므로 업로드용(60초) 보다 훨씬 짧은
+     * read-timeout 을 적용한다. 지연 시 Admin 의 HTTP 스레드와 사용자 UI 가 오래 묶이는 것을 방지.
+     */
+    @Bean
+    public RestClient cmsBuilderDeployRestClient() {
+        return buildClient(properties.getDeployConnectTimeoutSeconds(), properties.getDeployReadTimeoutSeconds());
+    }
+
+    /** baseUrl 공유 + 타임아웃만 다르게 RestClient 를 생성. */
+    private RestClient buildClient(int connectTimeoutSec, int readTimeoutSec) {
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
-        requestFactory.setConnectTimeout(Duration.ofSeconds(properties.getConnectTimeoutSeconds()));
-        requestFactory.setReadTimeout(Duration.ofSeconds(properties.getReadTimeoutSeconds()));
+        requestFactory.setConnectTimeout(Duration.ofSeconds(connectTimeoutSec));
+        requestFactory.setReadTimeout(Duration.ofSeconds(readTimeoutSec));
 
         return RestClient.builder()
                 .baseUrl(properties.getBaseUrl())

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/config/CmsBuilderProperties.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/config/CmsBuilderProperties.java
@@ -26,4 +26,17 @@ public class CmsBuilderProperties {
 
     /** 읽기 타임아웃 (초). 대용량 이미지 업로드를 고려해 넉넉히 잡는다. */
     private int readTimeoutSeconds = 60;
+
+    /**
+     * 배포(deploy) 호출 전용 연결 타임아웃 (초).
+     * 업로드처럼 대용량 전송이 없어 짧게 잡는다 (Issue #55).
+     */
+    private int deployConnectTimeoutSeconds = 5;
+
+    /**
+     * 배포(deploy) 호출 전용 읽기 타임아웃 (초).
+     * 파일 이동은 CMS 내부 디스크 I/O 로 수 초 내 완료되어야 한다. 60초는 너무 길어
+     * Admin HTTP 스레드·사용자 UI 대기 시간을 과다하게 잡기 때문에 짧게 둔다 (Issue #55, Gemini 리뷰 반영).
+     */
+    private int deployReadTimeoutSeconds = 10;
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetService.java
@@ -107,7 +107,16 @@ public class CmsAssetService {
         log.info("CMS 이미지 승인 요청: assetId={}, modifierId={}", assetId, modifierId);
     }
 
-    /** 승인 — PENDING → APPROVED (결재자) */
+    /**
+     * 승인 — PENDING → APPROVED (결재자) + CMS 파일 배포 (Issue #55).
+     *
+     * <p>DB 상태 전이 후 CMS 배포 API 를 호출해 파일을 운영 경로로 이동시킨다.
+     * 배포 실패 시 {@link BaseException} 이 전파되어 {@code @Transactional} 기본 정책에 따라
+     * DB 도 자동 롤백되므로, 승인 DB 상태와 파일 상태의 일관성이 보장된다.
+     *
+     * <p>트랜잭션 순서: 선검증 → UPDATE → CMS 배포 호출 → (정상 종료 시) 커밋. CMS 성공 후 커밋 실패의
+     * 극단적 엣지(파일은 배포됐으나 DB PENDING) 는 수동 재배포로 복구한다.
+     */
     @Transactional
     public void approve(String assetId, String modifierId, String modifierName) {
         assertTransition(assetId, STATE_PENDING, STATE_APPROVED);
@@ -116,7 +125,11 @@ public class CmsAssetService {
         if (updated != 1) {
             throw new InvalidStateException("이미 처리된 이미지입니다. assetId=" + assetId);
         }
-        log.info("CMS 이미지 승인 완료: assetId={}, modifierId={}", assetId, modifierId);
+
+        // CMS 파일 배포 — 실패 시 BaseException 전파 → @Transactional 기본 정책으로 DB 롤백.
+        cmsBuilderClient.deployAsset(assetId);
+
+        log.info("CMS 이미지 승인 + 파일 배포 완료: assetId={}, modifierId={}", assetId, modifierId);
     }
 
     /**

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetService.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
@@ -57,6 +58,13 @@ public class CmsAssetService {
     private final CmsAssetMapper cmsAssetMapper;
     private final CmsBuilderClient cmsBuilderClient;
     private final AssetUploadValidator assetUploadValidator;
+
+    /**
+     * 승인 saga 용 — 상태 UPDATE 를 CMS 호출 전에 독립적으로 커밋하기 위한 TransactionTemplate.
+     * CMS 가 DB 의 {@code APPROVED} 상태를 읽어 검증하므로 Admin 의 UPDATE 가 READ_COMMITTED 관점에서
+     * CMS 에 가시화되어야 한다.
+     */
+    private final TransactionTemplate transactionTemplate;
 
     /**
      * 현업 본인 업로드 이미지 목록 조회.
@@ -110,26 +118,53 @@ public class CmsAssetService {
     /**
      * 승인 — PENDING → APPROVED (결재자) + CMS 파일 배포 (Issue #55).
      *
-     * <p>DB 상태 전이 후 CMS 배포 API 를 호출해 파일을 운영 경로로 이동시킨다.
-     * 배포 실패 시 {@link BaseException} 이 전파되어 {@code @Transactional} 기본 정책에 따라
-     * DB 도 자동 롤백되므로, 승인 DB 상태와 파일 상태의 일관성이 보장된다.
+     * <p>Saga 패턴으로 DB 와 CMS 를 조율한다. CMS 배포 API 가 호출 시점에 DB 의 {@code ASSET_STATE}
+     * 가 이미 {@code APPROVED} 여야 하므로, 단일 {@code @Transactional} 로 감싸면 CMS 가 커밋 전
+     * PENDING 만 보게 되어 항상 거절된다.
      *
-     * <p>트랜잭션 순서: 선검증 → UPDATE → CMS 배포 호출 → (정상 종료 시) 커밋. CMS 성공 후 커밋 실패의
-     * 극단적 엣지(파일은 배포됐으나 DB PENDING) 는 수동 재배포로 복구한다.
+     * <h4>흐름</h4>
+     * <ol>
+     *   <li>선검증 + UPDATE(PENDING→APPROVED) — {@code TransactionTemplate} 으로 독립 TX 커밋.</li>
+     *   <li>{@link CmsBuilderClient#deployAsset(String)} 호출.</li>
+     *   <li>성공 → 정상 종료.</li>
+     *   <li>실패 → 보상 UPDATE(APPROVED→PENDING) 을 또 다른 독립 TX 로 커밋 후, 원 {@link BaseException}
+     *       을 그대로 재던져 502 를 전파. 사용자 관점에서는 "둘 다 실패" 로 보인다.</li>
+     * </ol>
+     *
+     * <h4>한계</h4>
+     * <ul>
+     *   <li>메인 TX 커밋과 CMS 호출 사이의 짧은 윈도우에 다른 결재자 화면은 {@code APPROVED} 를 볼 수 있다.</li>
+     *   <li>보상 UPDATE 자체가 실패하는 초희귀 케이스는 error 로그만 남기고 수동 복구 대상으로 삼는다.</li>
+     * </ul>
      */
-    @Transactional
     public void approve(String assetId, String modifierId, String modifierName) {
-        assertTransition(assetId, STATE_PENDING, STATE_APPROVED);
-        int updated =
-                cmsAssetMapper.updateState(assetId, STATE_PENDING, STATE_APPROVED, null, modifierId, modifierName);
-        if (updated != 1) {
-            throw new InvalidStateException("이미 처리된 이미지입니다. assetId=" + assetId);
+        // Step 1: 선검증 + 상태 UPDATE 를 독립 TX 로 커밋. CMS 가 APPROVED 를 읽어야 deploy 가 성공한다.
+        transactionTemplate.executeWithoutResult(status -> {
+            assertTransition(assetId, STATE_PENDING, STATE_APPROVED);
+            int updated =
+                    cmsAssetMapper.updateState(assetId, STATE_PENDING, STATE_APPROVED, null, modifierId, modifierName);
+            if (updated != 1) {
+                // 선검증 통과 후 race 실패 — 예외 던지면 TransactionTemplate 이 롤백.
+                throw new InvalidStateException("이미 처리된 이미지입니다. assetId=" + assetId);
+            }
+        });
+
+        // Step 2: CMS 파일 배포 시도.
+        try {
+            cmsBuilderClient.deployAsset(assetId);
+            log.info("CMS 이미지 승인 + 파일 배포 완료: assetId={}, modifierId={}", assetId, modifierId);
+        } catch (BaseException deployEx) {
+            // Step 3: 배포 실패 — 승인 상태를 PENDING 으로 보상 롤백.
+            log.error("CMS 배포 실패 — 승인 상태 보상 롤백 시도. assetId={}, modifierId={}", assetId, modifierId, deployEx);
+            try {
+                transactionTemplate.executeWithoutResult(status -> cmsAssetMapper.updateState(
+                        assetId, STATE_APPROVED, STATE_PENDING, null, modifierId, modifierName));
+            } catch (RuntimeException revertEx) {
+                // 보상 실패는 데이터-파일 불일치 상태를 남기므로 수동 복구 알림 차원의 error 로깅.
+                log.error("보상 롤백 실패 — 수동 확인 필요. assetId={}", assetId, revertEx);
+            }
+            throw deployEx;
         }
-
-        // CMS 파일 배포 — 실패 시 BaseException 전파 → @Transactional 기본 정책으로 DB 롤백.
-        cmsBuilderClient.deployAsset(assetId);
-
-        log.info("CMS 이미지 승인 + 파일 배포 완료: assetId={}, modifierId={}", assetId, modifierId);
     }
 
     /**

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetService.java
@@ -38,7 +38,6 @@ import org.springframework.web.multipart.MultipartFile;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class CmsAssetService {
 
     private static final String STATE_WORK = "WORK";
@@ -71,6 +70,7 @@ public class CmsAssetService {
      *
      * <p>클라이언트가 보낸 {@code createUserId}는 신뢰하지 않고 인증 주체의 ID로 덮어쓴다.
      */
+    @Transactional(readOnly = true)
     public PageResponse<CmsAssetListResponse> findMyRequestList(
             String currentUserId, CmsAssetRequestListRequest req, PageRequest pageRequest) {
 
@@ -84,6 +84,7 @@ public class CmsAssetService {
     }
 
     /** 결재자 승인 관리 목록 조회 (기본 PENDING 필터는 Mapper XML에서 처리) */
+    @Transactional(readOnly = true)
     public PageResponse<CmsAssetListResponse> findApprovalList(
             CmsAssetApprovalListRequest req, PageRequest pageRequest) {
 
@@ -95,6 +96,7 @@ public class CmsAssetService {
     }
 
     /** 이미지 상세 조회 (모달 프리뷰) */
+    @Transactional(readOnly = true)
     public CmsAssetDetailResponse findById(String assetId) {
         CmsAssetDetailResponse detail = cmsAssetMapper.findDetailById(assetId);
         if (detail == null) {

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -142,6 +142,9 @@ cms:
     upload-path: ${CMS_BUILDER_UPLOAD_PATH:/cms/api/builder/upload}
     connect-timeout-seconds: ${CMS_BUILDER_CONNECT_TIMEOUT:5}
     read-timeout-seconds: ${CMS_BUILDER_READ_TIMEOUT:60}
+    # 배포(deploy) 전용 — 파일 이동은 CMS 내부 I/O 라 수초 내 완료 기대, 짧게 둔다 (#55)
+    deploy-connect-timeout-seconds: ${CMS_BUILDER_DEPLOY_CONNECT_TIMEOUT:5}
+    deploy-read-timeout-seconds: ${CMS_BUILDER_DEPLOY_READ_TIMEOUT:10}
 
 # Scheduling Configuration (배치 이력 정리 스케줄러)
 scheduling:

--- a/admin/src/main/resources/static/css/app.css
+++ b/admin/src/main/resources/static/css/app.css
@@ -3222,5 +3222,27 @@ tr.sp-modified-row { background-color: var(--sp-warning-subtle); }
 }
 
 /* ========================================
+   LoadingOverlay — 공용 dim + 스피너 (#55)
+   z-index 2000 으로 Bootstrap modal(1055) 위에서도 동작.
+   ======================================== */
+.loading-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.35);
+    z-index: 2000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.loading-overlay__panel {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    color: #fff;
+}
+.loading-overlay__msg { font-size: 0.9rem; }
+
+/* ========================================
    End of Unified Stylesheet
    ======================================== */

--- a/admin/src/main/resources/static/js/components/LoadingOverlay.js
+++ b/admin/src/main/resources/static/js/components/LoadingOverlay.js
@@ -1,0 +1,60 @@
+/**
+ * @file LoadingOverlay.js
+ * @description 전역 dim + 스피너 오버레이 공용 컴포넌트.
+ *
+ *   - 장시간 요청(이미지 승인 처리 등) 중 사용자 입력 차단 + 진행 상황 시각화.
+ *   - body 에 1회 lazy 생성 후 depth 카운팅으로 중첩 show/hide 안전 처리.
+ *   - z-index 2000 — Bootstrap modal(1055) 위에서도 동작.
+ *
+ * @example
+ *   LoadingOverlay.show('승인 처리 중...');
+ *   fetch(...).finally(() => LoadingOverlay.hide());
+ */
+window.LoadingOverlay = (function () {
+    'use strict';
+
+    var OVERLAY_ID = 'spLoadingOverlay';
+    var $overlay = null;
+    // 동시에 여러 비동기 요청이 overlay 를 띄우는 경우를 고려해 참조 카운트로 관리.
+    var depth = 0;
+
+    /** body 에 오버레이 DOM 을 최초 1회만 생성. */
+    function ensureDom() {
+        if ($overlay) return;
+        $overlay = $(
+            '<div id="' + OVERLAY_ID + '" class="loading-overlay d-none" role="status" aria-live="polite">' +
+                '<div class="loading-overlay__panel">' +
+                    '<div class="spinner-border text-light" aria-hidden="true"></div>' +
+                    '<div class="loading-overlay__msg"></div>' +
+                '</div>' +
+            '</div>'
+        ).appendTo(document.body);
+    }
+
+    return {
+        /**
+         * 오버레이를 표시한다. 이미 표시 중이면 depth 만 증가 (메시지는 최근 호출로 갱신).
+         * @param {string} [message] 기본 "처리 중..."
+         */
+        show: function (message) {
+            ensureDom();
+            depth++;
+            $overlay.find('.loading-overlay__msg').text(message || '처리 중...');
+            $overlay.removeClass('d-none');
+        },
+
+        /** 오버레이를 숨긴다. 중첩 show 가 있는 경우 마지막 hide 에서만 실제로 숨김 처리. */
+        hide: function () {
+            if (!$overlay) return;
+            depth = Math.max(0, depth - 1);
+            if (depth === 0) {
+                $overlay.addClass('d-none');
+            }
+        },
+
+        /** 현재 오버레이가 표시 중인지 여부. */
+        isVisible: function () {
+            return depth > 0;
+        },
+    };
+})();

--- a/admin/src/main/resources/templates/home.html
+++ b/admin/src/main/resources/templates/home.html
@@ -83,6 +83,7 @@
 
 <!-- Common Components JS -->
 <script th:src="@{/js/components/Toast.js}"></script>
+<script th:src="@{/js/components/LoadingOverlay.js}"></script>
 <script th:src="@{/js/components/SearchForm.js}"></script>
 <script th:src="@{/js/components/DataTable.js}"></script>
 <script th:src="@{/js/components/Pagination.js}"></script>

--- a/admin/src/main/resources/templates/pages/asset/approval-script.html
+++ b/admin/src/main/resources/templates/pages/asset/approval-script.html
@@ -238,9 +238,13 @@
                 .catch(() => Toast.error('상세 조회 중 오류가 발생했습니다.'));
         },
 
-        // ── 승인 ──
+        // ── 승인 (#55: CMS 파일 배포 연동) ──
+        // 승인 DB UPDATE + CMS 파일 배포가 한 트랜잭션에서 처리되므로 응답이 길어질 수 있다.
+        // LoadingOverlay 로 전체 화면 dim 처리해 중복 클릭·타 작업 진행을 차단.
         approve: function(assetId) {
             if (!confirm('해당 이미지를 승인하시겠습니까?')) return;
+
+            LoadingOverlay.show('승인 처리 중...');
 
             fetch(`/api/cms-admin/asset-approvals/${encodeURIComponent(assetId)}/approve`, {
                 method: 'POST',
@@ -251,7 +255,8 @@
                     if (res.success) { Toast.success(res.message); this.load(); }
                     else             { Toast.error(res.message); }
                 })
-                .catch(() => Toast.error('승인 처리 중 오류가 발생했습니다.'));
+                .catch(() => Toast.error('승인 처리 중 오류가 발생했습니다.'))
+                .finally(() => LoadingOverlay.hide());
         },
 
         // ── 반려 모달 ──

--- a/admin/src/test/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetServiceTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetServiceTest.java
@@ -9,7 +9,9 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 import com.example.admin_demo.domain.cmsasset.dto.CmsAssetApprovalListRequest;
 import com.example.admin_demo.domain.cmsasset.dto.CmsAssetDetailResponse;
@@ -24,6 +26,8 @@ import com.example.admin_demo.global.exception.InvalidStateException;
 import com.example.admin_demo.global.exception.NotFoundException;
 import com.example.admin_demo.global.exception.base.BaseException;
 import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,8 +49,29 @@ class CmsAssetServiceTest {
     @Mock
     private com.example.admin_demo.domain.cmsasset.validator.AssetUploadValidator assetUploadValidator;
 
+    @Mock
+    private org.springframework.transaction.support.TransactionTemplate transactionTemplate;
+
     @InjectMocks
     private CmsAssetService cmsAssetService;
+
+    /**
+     * TransactionTemplate mock 이 받은 callback 을 동기 실행하도록 설정.
+     * 실제 트랜잭션 경계는 단위 테스트 범위 밖이며, 여기서는 approve() 내부에서
+     * UPDATE → CMS → (보상 UPDATE) 흐름이 호출되는지만 검증한다.
+     */
+    @BeforeEach
+    void setUpTransactionTemplate() {
+        // lenient — approve 외 테스트는 TransactionTemplate 를 사용하지 않아 strict stubbing 에 걸리는 것을 방지.
+        lenient()
+                .doAnswer(inv -> {
+                    Consumer<org.springframework.transaction.TransactionStatus> cb = inv.getArgument(0);
+                    cb.accept(null);
+                    return null;
+                })
+                .when(transactionTemplate)
+                .executeWithoutResult(any());
+    }
 
     private static final String ASSET_ID = "ASSET-001";
     private static final String USER_ID = "cmsUser01";
@@ -179,8 +204,8 @@ class CmsAssetServiceTest {
     }
 
     @Test
-    @DisplayName("[승인] CMS 배포 실패 시 BaseException 전파 (TX 롤백 유도)")
-    void approve_cmsDeployFails_propagatesExceptionForRollback() {
+    @DisplayName("[승인] CMS 배포 실패 시 보상 UPDATE(APPROVED→PENDING) 후 BaseException 재전파")
+    void approve_cmsDeployFails_compensatesAndRethrows() {
         given(cmsAssetMapper.findAssetStateById(ASSET_ID)).willReturn("PENDING");
         given(cmsAssetMapper.updateState(any(), any(), any(), any(), any(), any()))
                 .willReturn(1);
@@ -191,8 +216,11 @@ class CmsAssetServiceTest {
         assertThatThrownBy(() -> cmsAssetService.approve(ASSET_ID, USER_ID, USER_NAME))
                 .isInstanceOfSatisfying(BaseException.class, ex -> assertThat(ex.getErrorType())
                         .isEqualTo(ErrorType.EXTERNAL_SERVICE_ERROR));
-        // updateState 는 호출됐음 (Spring TX 가 예외로 자동 롤백 — 단위 테스트 범위 밖)
-        then(cmsAssetMapper).should().updateState(any(), any(), any(), any(), any(), any());
+
+        // 메인 UPDATE(PENDING→APPROVED) + 보상 UPDATE(APPROVED→PENDING) 두 번 호출됐어야 한다.
+        then(cmsAssetMapper).should().updateState(ASSET_ID, "PENDING", "APPROVED", null, USER_ID, USER_NAME);
+        then(cmsAssetMapper).should().updateState(ASSET_ID, "APPROVED", "PENDING", null, USER_ID, USER_NAME);
+        then(cmsAssetMapper).should(times(2)).updateState(any(), any(), any(), any(), any(), any());
     }
 
     // ─── reject ────────────────────────────────────────────────────────

--- a/admin/src/test/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetServiceTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetServiceTest.java
@@ -8,6 +8,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
 
 import com.example.admin_demo.domain.cmsasset.dto.CmsAssetApprovalListRequest;
 import com.example.admin_demo.domain.cmsasset.dto.CmsAssetDetailResponse;
@@ -16,9 +18,11 @@ import com.example.admin_demo.domain.cmsasset.dto.CmsAssetRequestListRequest;
 import com.example.admin_demo.domain.cmsasset.mapper.CmsAssetMapper;
 import com.example.admin_demo.global.dto.PageRequest;
 import com.example.admin_demo.global.dto.PageResponse;
+import com.example.admin_demo.global.exception.ErrorType;
 import com.example.admin_demo.global.exception.InvalidInputException;
 import com.example.admin_demo.global.exception.InvalidStateException;
 import com.example.admin_demo.global.exception.NotFoundException;
+import com.example.admin_demo.global.exception.base.BaseException;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -152,8 +156,8 @@ class CmsAssetServiceTest {
     // ─── approve ───────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[승인] PENDING → APPROVED 정상 전이")
-    void approve_fromPending_succeeds() {
+    @DisplayName("[승인] PENDING → APPROVED 전이 + CMS 배포 호출까지 성공")
+    void approve_fromPending_succeedsAndDeploys() {
         given(cmsAssetMapper.findAssetStateById(ASSET_ID)).willReturn("PENDING");
         given(cmsAssetMapper.updateState(any(), any(), any(), any(), any(), any()))
                 .willReturn(1);
@@ -161,15 +165,34 @@ class CmsAssetServiceTest {
         cmsAssetService.approve(ASSET_ID, USER_ID, USER_NAME);
 
         then(cmsAssetMapper).should().updateState(ASSET_ID, "PENDING", "APPROVED", null, USER_ID, USER_NAME);
+        then(cmsBuilderClient).should().deployAsset(ASSET_ID);
     }
 
     @Test
-    @DisplayName("[승인] WORK 상태에서 승인 시 InvalidStateException")
+    @DisplayName("[승인] WORK 상태에서 승인 시 InvalidStateException, CMS 배포 호출 없음")
     void approve_fromWork_throwsInvalidState() {
         given(cmsAssetMapper.findAssetStateById(ASSET_ID)).willReturn("WORK");
 
         assertThatThrownBy(() -> cmsAssetService.approve(ASSET_ID, USER_ID, USER_NAME))
                 .isInstanceOf(InvalidStateException.class);
+        then(cmsBuilderClient).should(never()).deployAsset(any());
+    }
+
+    @Test
+    @DisplayName("[승인] CMS 배포 실패 시 BaseException 전파 (TX 롤백 유도)")
+    void approve_cmsDeployFails_propagatesExceptionForRollback() {
+        given(cmsAssetMapper.findAssetStateById(ASSET_ID)).willReturn("PENDING");
+        given(cmsAssetMapper.updateState(any(), any(), any(), any(), any(), any()))
+                .willReturn(1);
+        willThrow(new BaseException(ErrorType.EXTERNAL_SERVICE_ERROR, "CMS 통신 오류"))
+                .given(cmsBuilderClient)
+                .deployAsset(ASSET_ID);
+
+        assertThatThrownBy(() -> cmsAssetService.approve(ASSET_ID, USER_ID, USER_NAME))
+                .isInstanceOfSatisfying(BaseException.class, ex -> assertThat(ex.getErrorType())
+                        .isEqualTo(ErrorType.EXTERNAL_SERVICE_ERROR));
+        // updateState 는 호출됐음 (Spring TX 가 예외로 자동 롤백 — 단위 테스트 범위 밖)
+        then(cmsAssetMapper).should().updateState(any(), any(), any(), any(), any(), any());
     }
 
     // ─── reject ────────────────────────────────────────────────────────


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
- Closes #55
- 선행: #53 (승인 Service), #65 (업로드·CmsBuilderClient 패턴)
- CMS 연동: [Springware-CMS#18](https://github.com/neobnsrnd-team/Springware-CMS/pull/18) — `/cms/api/assets/{assetId}/deploy` 제공

## ✨ 변경 사항 (Changes)

이미지 승인(`PENDING → APPROVED`) 시 Admin 이 CMS 의 파일 배포 API 를 호출해 `/data/uploads/` → `/data/deployed/img/` 이동까지 원자적으로 처리한다.

### Backend
- **`CmsBuilderClient#deployAsset(assetId)`** — `POST {cms.builder.base-url}/cms/api/assets/{assetId}/deploy` (body 없음). 삭제와 동일하게 `.retrieve().toBodilessEntity()` 로 status 기반 판정. `RestClientException` → `BaseException(EXTERNAL_SERVICE_ERROR)` (HTTP 502) 래핑.
- **`CmsAssetService#approve(...)`** — `updateState` 직후 `deployAsset` 호출. 배포 실패 시 `BaseException` 전파 → `@Transactional` 기본 정책으로 DB 롤백. **승인 DB 전이와 파일 이동의 원자성 보장**. 시그니처 변경 없음.

### Frontend — 공용 `LoadingOverlay` 컴포넌트 신규
다른 화면에서도 장시간 요청에 쓸 수 있도록 공용화.
- **`static/js/components/LoadingOverlay.js`** — `LoadingOverlay.show(msg?)` / `.hide()` / `.isVisible()`. depth 카운팅으로 중첩 호출 안전, body lazy-init, z-index 2000 (Bootstrap modal 위에서도 동작), `role=\"status\" aria-live=\"polite\"`.
- **`app.css`** — `.loading-overlay` / `.loading-overlay__panel` / `.loading-overlay__msg` 추가.
- **`home.html`** — 공통 script 로드 목록에 추가 → 전 페이지 즉시 사용 가능.
- **`approval-script.html` `approve()`** — `LoadingOverlay.show('승인 처리 중...')` → `finally` 로 hide. 중복 클릭·타 작업 자연 차단.

### 테스트 (+1, 기존 2 수정)
- `CmsAssetServiceTest`:
  - 기존 `approve_fromPending_succeeds` → `approve_fromPending_succeedsAndDeploys` 로 확장, `deployAsset` 호출 verify.
  - 기존 `approve_fromWork_throwsInvalidState` 에 `deployAsset` **미호출** verify 추가.
  - [신규] `approve_cmsDeployFails_propagatesExceptionForRollback` — 배포 실패 시 `BaseException(EXTERNAL_SERVICE_ERROR)` 전파 확인.

## ⚠️ 고려 및 주의 사항

### 트랜잭션 경계
- 순서: `선검증 → updateState → deployAsset → (정상종료 시) TX 커밋`.
- 배포 실패 → 예외 전파 → DB 롤백 → `ASSET_STATE=PENDING` 유지. 일관성 확보.
- 극단 엣지: CMS 배포 성공 후 TX 커밋 실패 시 파일은 배포됐으나 DB 는 PENDING. 매우 드묾 — 운영 로그로 탐지 + 수동 재배포로 복구.

### 본 PR 범위 외 (원 이슈 #55 분해 → 후속 이슈)
- 재시도 / 지수 백오프
- 배포 실패 목록 + 재배포 UI
- deploy 전용 read-timeout

### UX
- 60초 read-timeout 동안 dim 유지. 오버레이 메시지는 \"승인 처리 중...\" 으로 명확. 필요 시 후속으로 deploy 전용 timeout 단축 검토.

## 💬 리뷰 포인트

1. **TX 안의 외부 호출 vs 외부 호출 후 TX** — 현재 DB UPDATE 후 CMS 호출 순서 선택. 반대(CMS 먼저, DB 나중)는 CMS 멱등성 필요해 간소화 범위에서는 제외.
2. **LoadingOverlay depth 카운팅** — 중첩 호출(모달 내부에서 별도 로딩 등) 대비. 과한가 / 적정한가.
3. **공용 layout 로드 위치** — `home.html` 에 추가. 모든 페이지 상속 구조 맞는지 확인 필요.

## 🔗 참고 사항
- CMS 응답 body `{ok:true,data:{url}}` 는 Admin 이 사용하지 않음 — CMS 가 `ASSET_URL` 자체 갱신.
- 삭제(#88) 와 동일하게 body 파싱 생략, status 기반 판정.