### PR TITLE
feat: CmsRedirectController 엔드포인트 /cms/user-dashboard 변경 및 외부 URL 리다이렉트 수정

### DIFF
--- a/admin/docs/sql/oracle/03_insert_initial_data.sql
+++ b/admin/docs/sql/oracle/03_insert_initial_data.sql
@@ -558,7 +558,7 @@ ${fieldDeclarations}
 
 -- CMS extension menus (sort_order 13 to avoid conflict with emergency_notice at 12)
 INSERT INTO FWK_MENU (MENU_ID, PRIOR_MENU_ID, SORT_ORDER, MENU_NAME, MENU_URL, DISPLAY_YN, USE_YN, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID)
-VALUES ('v3_cms_manage', 'v3_acl_manage', 13, 'CMS', '/cms', 'Y', 'Y', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), 'system');
+VALUES ('v3_cms_manage', 'v3_acl_manage', 13, 'CMS', '/cms/user-dashboard', 'Y', 'Y', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), 'system');
 
 INSERT INTO FWK_MENU (MENU_ID, PRIOR_MENU_ID, SORT_ORDER, MENU_NAME, MENU_URL, DISPLAY_YN, USE_YN, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID)
 VALUES ('v3_cms_dashboard', 'v3_cms_manage', 1, 'CMS 작업자 대시보드', '/cms/dashboard', 'N', 'Y', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), 'system');

--- a/admin/src/main/java/com/example/admin_demo/global/page/controller/CmsRedirectController.java
+++ b/admin/src/main/java/com/example/admin_demo/global/page/controller/CmsRedirectController.java
@@ -1,9 +1,11 @@
 package com.example.admin_demo.global.page.controller;
 
 import com.example.admin_demo.global.security.CustomUserDetails;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
@@ -14,19 +16,38 @@ public class CmsRedirectController {
     private static final String CMS_ADMIN_APPROVALS_PATH = "/cms-admin/approvals";
     private static final String CMS_DASHBOARD_PATH = "/dashboard";
 
+    /** 탭 시스템 AJAX 요청 식별 헤더 */
+    private static final String TAB_REQUEST_HEADER = "X-Tab-Request";
+    private static final String TAB_REQUEST_VALUE = "true";
+
     @Value("${cms.app-base-url:/cms}")
     private String cmsAppBaseUrl;
 
     @Value("${cms.user-url:}")
     private String cmsUserUrl;
 
-    @GetMapping({"/cms", "/cms/"})
-    public String redirectCmsRoot(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    @GetMapping("/cms/user-dashboard")
+    public String redirectCmsRoot(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            HttpServletRequest request,
+            Model model) {
+
         if (isCmsAdmin(userDetails)) {
+            // 관리자 — 동일 출처 내부 경로이므로 서버 사이드 redirect 사용
             return "redirect:" + CMS_ADMIN_APPROVALS_PATH;
         }
 
-        return "redirect:" + cmsUserRedirectUrl();
+        String targetUrl = cmsUserRedirectUrl();
+
+        if (TAB_REQUEST_VALUE.equals(request.getHeader(TAB_REQUEST_HEADER))) {
+            // 탭 시스템 AJAX 요청: 외부 URL로 서버 사이드 redirect 시 CORS 차단 문제 발생
+            // window.top.location.href 로 브라우저 전체 화면을 외부 URL로 이동시킨다.
+            model.addAttribute("cmsUserUrl", targetUrl);
+            return "cms-user-redirect";
+        }
+
+        // 직접 브라우저 접근 (북마크, 주소창 입력 등)
+        return "redirect:" + targetUrl;
     }
 
     private String cmsUserRedirectUrl() {

--- a/admin/src/main/java/com/example/admin_demo/global/page/controller/CmsRedirectController.java
+++ b/admin/src/main/java/com/example/admin_demo/global/page/controller/CmsRedirectController.java
@@ -18,6 +18,7 @@ public class CmsRedirectController {
 
     /** 탭 시스템 AJAX 요청 식별 헤더 */
     private static final String TAB_REQUEST_HEADER = "X-Tab-Request";
+
     private static final String TAB_REQUEST_VALUE = "true";
 
     @Value("${cms.app-base-url:/cms}")
@@ -28,9 +29,7 @@ public class CmsRedirectController {
 
     @GetMapping("/cms/user-dashboard")
     public String redirectCmsRoot(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            HttpServletRequest request,
-            Model model) {
+            @AuthenticationPrincipal CustomUserDetails userDetails, HttpServletRequest request, Model model) {
 
         if (isCmsAdmin(userDetails)) {
             // 관리자 — 동일 출처 내부 경로이므로 서버 사이드 redirect 사용

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -7,7 +7,7 @@
 
 spring:
   config:
-    import: classpath:menu-resource-permissions.yml
+    import: classpath:menu-resource-permissions.yml, optional:file:.env[.properties]
   profiles:
     active: oracle  # oracle 또는 mysql
 
@@ -129,11 +129,12 @@ claude:
 # CMS Deploy Configuration
 cms:
   app-base-url: ${CMS_APP_BASE_URL:/cms}
-  user-url: ${CMS_USER_URL:http://localhost:3000/}
+  #user-url: ${CMS_USER_URL:http://localhost:3000/}
+  user-url: ${CMS_USER_URL:http://133.186.135.23:3001/}
   preview-url: ${CMS_PREVIEW_URL:http://localhost}
   deploy:
     # CMS push API — HTML 조립(ContentBuilder CSS·런타임, 에셋 경로 치환)·파일 저장·이력 기록을 CMS가 담당
-    push-url: ${CMS_DEPLOY_PUSH_URL:http://133.186.135.23:3001/api/deploy/push}
+    push-url: ${CMS_DEPLOY_PUSH_URL:http://133.186.135.23:3001/cms/api/deploy/push}
     secret: ${CMS_DEPLOY_SECRET:}
   # CMS Builder (미승인 이미지 업로드) — 내부망 서버-투-서버 호출 (Issue #65)
   # nginx 가 80 → CMS(Next.js) 업스트림으로 프록시하므로 외부에서는 포트 없이 접근한다.

--- a/admin/src/main/resources/mapper/oracle/cmsdeployment/CmsDeployMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/cmsdeployment/CmsDeployMapper.xml
@@ -34,7 +34,7 @@
                     p.CREATE_USER_NAME                                          AS createUserName,
                     CASE WHEN lh.FILE_ID IS NOT NULL
                         THEN 'http://' || si.INSTANCE_IP || ':' || TO_CHAR(si.INSTANCE_PORT)
-                             || '/deployed/' || p.PAGE_ID || '.html'
+                             || '/cms/deployed/' || p.PAGE_ID || '.html'
                     END                                                         AS deployedUrl
                 FROM SPW_CMS_PAGE p
                 LEFT JOIN (

--- a/admin/src/main/resources/templates/cms-user-redirect.html
+++ b/admin/src/main/resources/templates/cms-user-redirect.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<!--
+    탭 시스템 AJAX 응답용 — window.top.location.href 로 브라우저 전체를 외부 CMS URL로 이동시킨다.
+    서버 사이드 redirect 를 사용하면 AJAX가 외부 URL을 따라가 CORS 차단 문제가 발생하므로
+    클라이언트 사이드 이동 방식을 사용한다.
+-->
+<script th:inline="javascript">
+    window.top.location.href = /*[[${cmsUserUrl}]]*/ '/';
+</script>
+</body>
+</html>

--- a/admin/src/main/resources/templates/pages/cms-deployment/cms-deployment.html
+++ b/admin/src/main/resources/templates/pages/cms-deployment/cms-deployment.html
@@ -48,11 +48,11 @@
         </div>
     </div>
 
-    <div class="alert alert-info py-2 small" role="alert">
+    <!--<div class="alert alert-info py-2 small" role="alert">
         <strong>CMS 리소스 경계</strong>
         이 화면은 승인완료 페이지 HTML의 배포 실행과 배포이력 조회만 제공합니다.
         이미지 업로드, 삭제, 폴더 생성 같은 리소스 파일 관리는 spider-admin에서 수행하지 않습니다.
-    </div>
+    </div> -->
 
     <!-- 테이블 -->
     <div th:replace="~{pages/cms-deployment/cms-deployment-table :: table}"></div>

--- a/admin/src/test/java/com/example/admin_demo/domain/cmsdeployment/controller/CmsDeployControllerTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/cmsdeployment/controller/CmsDeployControllerTest.java
@@ -217,7 +217,7 @@ class CmsDeployControllerTest {
                 .pageId(PAGE_ID)
                 .pageName("테스트 페이지")
                 .createUserName("홍길동")
-                .deployedUrl("http://133.186.135.23:3001/deployed/" + PAGE_ID + ".html")
+                .deployedUrl("http://133.186.135.23:3001/cms/deployed/" + PAGE_ID + ".html")
                 .build();
     }
 

--- a/admin/src/test/java/com/example/admin_demo/domain/cmsdeployment/service/CmsDeployServiceTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/cmsdeployment/service/CmsDeployServiceTest.java
@@ -177,7 +177,7 @@ class CmsDeployServiceTest {
                 .pageId(PAGE_ID)
                 .pageName("테스트 페이지")
                 .createUserName("홍길동")
-                .deployedUrl("http://133.186.135.23:3001/deployed/" + PAGE_ID + ".html")
+                .deployedUrl("http://133.186.135.23:3001/cms/deployed/" + PAGE_ID + ".html")
                 .build();
     }
 

--- a/admin/src/test/java/com/example/admin_demo/global/page/controller/CmsRedirectControllerTest.java
+++ b/admin/src/test/java/com/example/admin_demo/global/page/controller/CmsRedirectControllerTest.java
@@ -4,6 +4,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 import com.example.admin_demo.domain.user.enums.UserState;
 import com.example.admin_demo.global.security.CustomUserDetails;
@@ -27,41 +28,43 @@ class CmsRedirectControllerTest {
     private MockMvc mockMvc;
 
     @Test
-    @DisplayName("cms_admin role redirects /cms to /cms-admin/approvals")
+    @DisplayName("cms_admin role redirects /cms/user-dashboard to /cms-admin/approvals")
     void cmsRoot_cmsAdminRole_redirectsApprovals() throws Exception {
-        mockMvc.perform(get("/cms").with(user(userDetails("admin", "cms_admin", "CMS:W"))))
+        mockMvc.perform(get("/cms/user-dashboard").with(user(userDetails("admin", "cms_admin", "CMS:W"))))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/cms-admin/approvals"));
     }
 
     @Test
-    @DisplayName("ADMIN role redirects /cms to /cms-admin/approvals")
+    @DisplayName("ADMIN role redirects /cms/user-dashboard to /cms-admin/approvals")
     void cmsRoot_adminRole_redirectsApprovals() throws Exception {
-        mockMvc.perform(get("/cms").with(user(userDetails("admin", "ADMIN", "CMS:W"))))
+        mockMvc.perform(get("/cms/user-dashboard").with(user(userDetails("admin", "ADMIN", "CMS:W"))))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/cms-admin/approvals"));
     }
 
     @Test
-    @DisplayName("cms_user role redirects /cms to configured CMS user URL")
-    void cmsRoot_cmsUserRole_redirectsConfiguredCmsUserUrl() throws Exception {
-        mockMvc.perform(get("/cms").with(user(userDetails("worker", "cms_user", "CMS:R"))))
+    @DisplayName("cms_user role — 직접 브라우저 접근 시 CMS_USER_URL로 redirect")
+    void cmsRoot_cmsUserRole_directAccess_redirectsConfiguredCmsUserUrl() throws Exception {
+        mockMvc.perform(get("/cms/user-dashboard").with(user(userDetails("worker", "cms_user", "CMS:R"))))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("http://133.186.135.23:3001/"));
     }
 
     @Test
-    @DisplayName("/cms/ trailing slash follows same role policy")
-    void cmsRootSlash_cmsAdminRole_redirectsApprovals() throws Exception {
-        mockMvc.perform(get("/cms/").with(user(userDetails("admin", "cms_admin", "CMS:W"))))
-                .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("/cms-admin/approvals"));
+    @DisplayName("cms_user role — 탭 AJAX 요청 시 cms-user-redirect 뷰 반환")
+    void cmsRoot_cmsUserRole_tabRequest_returnsCmsUserRedirectView() throws Exception {
+        mockMvc.perform(get("/cms/user-dashboard")
+                        .header("X-Tab-Request", "true")
+                        .with(user(userDetails("worker", "cms_user", "CMS:R"))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("cms-user-redirect"));
     }
 
     @Test
-    @DisplayName("/cms requires authentication")
+    @DisplayName("/cms/user-dashboard requires authentication")
     void cmsRoot_unauthenticated_returnsUnauthorized() throws Exception {
-        mockMvc.perform(get("/cms")).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/cms/user-dashboard")).andExpect(status().isUnauthorized());
     }
 
     private CustomUserDetails userDetails(String userId, String roleId, String authority) {


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #107

## ✨ 변경 사항 (Changes)

**1. `CmsRedirectController` 엔드포인트 변경**
- `{"/cms", "/cms/"}` → `/cms/user-dashboard`
- DB `v3_cms_manage` 메뉴 URL도 `/cms/user-dashboard`로 변경 (초기 데이터 반영)

**2. 외부 URL 리다이렉트 방식 수정**
- 기존: 서버 사이드 `redirect:` → AJAX 탭 요청 시 CORS 차단으로 `/cms/dashboard` 화면이 노출되는 버그
- 수정: `X-Tab-Request` 헤더 감지 → `cms-user-redirect.html` 반환 → `window.top.location.href` 로 브라우저 전체를 외부 CMS URL로 이동

**3. `.env` 로드 설정 추가**
- `spring.config.import`에 `optional:file:.env[.properties]` 추가
- `spring-dotenv` 4.0.0 사용 시 명시적 import 필요

**4. `cms.user-url` 기본값 변경**
- `http://localhost:3000/` → `http://133.186.135.23:3001/`

## ⚠️ 고려 및 주의 사항 (선택)
- DB `SPW_MENU` 테이블의 `v3_cms_manage` `MENU_URL`을 `/cms/user-dashboard`로 직접 UPDATE 필요 (운영 DB)
  ```sql
  UPDATE SPW_MENU SET MENU_URL = '/cms/user-dashboard' WHERE MENU_ID = 'v3_cms_manage';
  COMMIT;
  ```

## 💬 리뷰 포인트 (선택)
- `cms-user-redirect.html` — `window.top.location.href` 사용으로 탭 내 AJAX 응답에서도 상위 창 전체 이동 보장