### PR TITLE
feat: React CMS 사용자 대시보드 및 빌더-어드민 승인 상태 연동 (#100)

### DIFF
--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/controller/ReactCmsDashboardController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/controller/ReactCmsDashboardController.java
@@ -1,5 +1,6 @@
 package com.example.admin_demo.domain.reactcmsdashboard.controller;
 
+import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsApprovalStatusResponse;
 import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsDashboardApproveRequestDto;
 import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsDashboardListRequest;
 import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsDashboardPageResponse;
@@ -27,9 +28,10 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * <h4>API 엔드포인트:</h4>
  * <ul>
- *   <li>GET    /api/react-cms-dashboard/pages                          — 내 페이지 목록</li>
- *   <li>DELETE /api/react-cms-dashboard/pages/{pageId}                 — 페이지 삭제</li>
- *   <li>PATCH  /api/react-cms-dashboard/pages/{pageId}/approve-request — 승인 요청</li>
+ *   <li>GET    /api/react-cms-dashboard/pages                                  — 내 페이지 목록</li>
+ *   <li>GET    /api/react-cms-dashboard/pages/{pageId}/approval-status         — 승인 상태 조회</li>
+ *   <li>DELETE /api/react-cms-dashboard/pages/{pageId}                         — 페이지 삭제</li>
+ *   <li>PATCH  /api/react-cms-dashboard/pages/{pageId}/approve-request         — 승인 요청</li>
  * </ul>
  *
  * <p>새 페이지 생성은 react-cms 빌더(/react-cms/builder)에서 직접 수행하므로 POST 엔드포인트가 없다.
@@ -55,6 +57,15 @@ public class ReactCmsDashboardController {
 
         return ResponseEntity.ok(ApiResponse.success(
                 reactCmsDashboardService.findMyPageList(req, userDetails.getUserId(), pageRequest)));
+    }
+
+    /** 승인 상태 조회 — react-cms 빌더가 편집 모드 진입 시 호출 (REACT-CMS:R) */
+    @GetMapping("/api/react-cms-dashboard/pages/{pageId}/approval-status")
+    @PreAuthorize("hasAuthority('REACT-CMS:R')")
+    public ResponseEntity<ApiResponse<ReactCmsApprovalStatusResponse>> findApprovalStatus(
+            @PathVariable String pageId) {
+
+        return ResponseEntity.ok(ApiResponse.success(reactCmsDashboardService.findApprovalStatus(pageId)));
     }
 
     /**

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/controller/ReactCmsDashboardController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/controller/ReactCmsDashboardController.java
@@ -62,8 +62,7 @@ public class ReactCmsDashboardController {
     /** 승인 상태 조회 — react-cms 빌더가 편집 모드 진입 시 호출 (REACT-CMS:R) */
     @GetMapping("/api/react-cms-dashboard/pages/{pageId}/approval-status")
     @PreAuthorize("hasAuthority('REACT-CMS:R')")
-    public ResponseEntity<ApiResponse<ReactCmsApprovalStatusResponse>> findApprovalStatus(
-            @PathVariable String pageId) {
+    public ResponseEntity<ApiResponse<ReactCmsApprovalStatusResponse>> findApprovalStatus(@PathVariable String pageId) {
 
         return ResponseEntity.ok(ApiResponse.success(reactCmsDashboardService.findApprovalStatus(pageId)));
     }

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/controller/ReactCmsDashboardController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/controller/ReactCmsDashboardController.java
@@ -1,0 +1,84 @@
+package com.example.admin_demo.domain.reactcmsdashboard.controller;
+
+import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsDashboardApproveRequestDto;
+import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsDashboardListRequest;
+import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsDashboardPageResponse;
+import com.example.admin_demo.domain.reactcmsdashboard.service.ReactCmsDashboardService;
+import com.example.admin_demo.global.dto.ApiResponse;
+import com.example.admin_demo.global.dto.PageRequest;
+import com.example.admin_demo.global.dto.PageResponse;
+import com.example.admin_demo.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * React CMS 사용자 대시보드 API 컨트롤러
+ *
+ * <h4>API 엔드포인트:</h4>
+ * <ul>
+ *   <li>GET    /api/react-cms-dashboard/pages                          — 내 페이지 목록</li>
+ *   <li>DELETE /api/react-cms-dashboard/pages/{pageId}                 — 페이지 삭제</li>
+ *   <li>PATCH  /api/react-cms-dashboard/pages/{pageId}/approve-request — 승인 요청</li>
+ * </ul>
+ *
+ * <p>새 페이지 생성은 react-cms 빌더(/react-cms/builder)에서 직접 수행하므로 POST 엔드포인트가 없다.
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class ReactCmsDashboardController {
+
+    private final ReactCmsDashboardService reactCmsDashboardService;
+
+    /** 내 페이지 목록 조회 (REACT-CMS:R) */
+    @GetMapping("/api/react-cms-dashboard/pages")
+    @PreAuthorize("hasAuthority('REACT-CMS:R')")
+    public ResponseEntity<ApiResponse<PageResponse<ReactCmsDashboardPageResponse>>> findMyPageList(
+            @ModelAttribute ReactCmsDashboardListRequest req,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        PageRequest pageRequest =
+                PageRequest.builder().page(Math.max(0, page - 1)).size(size).build();
+
+        return ResponseEntity.ok(ApiResponse.success(
+                reactCmsDashboardService.findMyPageList(req, userDetails.getUserId(), pageRequest)));
+    }
+
+    /**
+     * 페이지 삭제 (REACT-CMS:W)
+     * 이력 있으면 소프트(USE_YN='N'), 없으면 하드 삭제.
+     */
+    @DeleteMapping("/api/react-cms-dashboard/pages/{pageId}")
+    @PreAuthorize("hasAuthority('REACT-CMS:W')")
+    public ResponseEntity<ApiResponse<Void>> deletePage(
+            @PathVariable String pageId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        reactCmsDashboardService.deletePage(pageId, userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.success("페이지가 삭제되었습니다.", null));
+    }
+
+    /** 승인 요청 — APPROVE_STATE → PENDING (REACT-CMS:W) */
+    @PatchMapping("/api/react-cms-dashboard/pages/{pageId}/approve-request")
+    @PreAuthorize("hasAuthority('REACT-CMS:W')")
+    public ResponseEntity<ApiResponse<Void>> requestApproval(
+            @PathVariable String pageId,
+            @RequestBody ReactCmsDashboardApproveRequestDto req,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        reactCmsDashboardService.requestApproval(pageId, req, userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.success("승인 요청이 완료되었습니다.", null));
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/dto/ReactCmsApprovalStatusResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/dto/ReactCmsApprovalStatusResponse.java
@@ -1,0 +1,18 @@
+package com.example.admin_demo.domain.reactcmsdashboard.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** React CMS 페이지 승인 상태 응답 DTO */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReactCmsApprovalStatusResponse {
+
+    /** 승인 상태 (WORK / PENDING / APPROVED / REJECTED) */
+    private String approveState;
+
+    /** 반려 사유 — REJECTED 상태일 때만 값이 존재 */
+    private String rejectedReason;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/dto/ReactCmsDashboardApproveRequestDto.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/dto/ReactCmsDashboardApproveRequestDto.java
@@ -1,5 +1,7 @@
 package com.example.admin_demo.domain.reactcmsdashboard.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -15,9 +17,11 @@ public class ReactCmsDashboardApproveRequestDto {
     /** 승인자 ID (APPROVER_ID) — 이름은 서버에서 DB 조회하여 결정 (위변조 방지) */
     private String approverId;
 
-    /** 노출 시작일 (YYYY-MM-DD, 선택) */
-    private String beginningDate;
+    /** 노출 시작일 (선택) — 잘못된 형식은 Jackson 역직렬화 단계에서 400으로 처리 */
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate beginningDate;
 
-    /** 노출 종료일 (YYYY-MM-DD, 선택) */
-    private String expiredDate;
+    /** 노출 종료일 (선택) */
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate expiredDate;
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/dto/ReactCmsDashboardApproveRequestDto.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/dto/ReactCmsDashboardApproveRequestDto.java
@@ -1,0 +1,23 @@
+package com.example.admin_demo.domain.reactcmsdashboard.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * React CMS 페이지 승인 요청 DTO — APPROVE_STATE: WORK / REJECTED / APPROVED → PENDING
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReactCmsDashboardApproveRequestDto {
+
+    /** 승인자 ID (APPROVER_ID) — 이름은 서버에서 DB 조회하여 결정 (위변조 방지) */
+    private String approverId;
+
+    /** 노출 시작일 (YYYY-MM-DD, 선택) */
+    private String beginningDate;
+
+    /** 노출 종료일 (YYYY-MM-DD, 선택) */
+    private String expiredDate;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/dto/ReactCmsDashboardListRequest.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/dto/ReactCmsDashboardListRequest.java
@@ -1,0 +1,28 @@
+package com.example.admin_demo.domain.reactcmsdashboard.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * React CMS 사용자 대시보드 목록 조회 요청 DTO
+ *
+ * <p>VIEW_MODE는 React CMS에서 'mobile' 고정이므로 필터 항목에서 제외한다.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReactCmsDashboardListRequest {
+
+    /** 승인 상태 필터 (WORK / PENDING / APPROVED / REJECTED) */
+    private String approveState;
+
+    /** 검색어 (PAGE_NAME) */
+    private String search;
+
+    /** 정렬 기준 */
+    private String sortBy;
+
+    /** 정렬 방향 (ASC / DESC) */
+    private String sortDirection;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/dto/ReactCmsDashboardPageResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/dto/ReactCmsDashboardPageResponse.java
@@ -1,0 +1,51 @@
+package com.example.admin_demo.domain.reactcmsdashboard.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * React CMS 사용자 대시보드 페이지 응답 DTO (SPW_CMS_PAGE 기반)
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReactCmsDashboardPageResponse {
+
+    /** 페이지 ID (PAGE_ID) */
+    private String pageId;
+
+    /** 페이지명 (PAGE_NAME) */
+    private String pageName;
+
+    /** 뷰 모드 (VIEW_MODE: React CMS는 'mobile' 고정) */
+    private String viewMode;
+
+    /** 승인 상태 (APPROVE_STATE: WORK / PENDING / APPROVED / REJECTED) */
+    private String approveState;
+
+    /**
+     * 파일 존재 여부 (Y / N)
+     * PAGE_HTML IS NOT NULL AND DBMS_LOB.GETLENGTH(PAGE_HTML) > 0 조건으로 SQL에서 판단
+     */
+    private String hasFile;
+
+    /** 만료 여부 (Y / N) — EXPIRED_DATE < SYSDATE */
+    private String isExpired;
+
+    /** 노출 시작일 (BEGINNING_DATE, YYYY-MM-DD) */
+    private String beginningDate;
+
+    /** 노출 종료일 (EXPIRED_DATE, YYYY-MM-DD) */
+    private String expiredDate;
+
+    /** 반려 사유 (REJECTED_REASON) */
+    private String rejectedReason;
+
+    /** 최종 수정일시 (LAST_MODIFIED_DTIME, YYYY-MM-DD HH24:MI:SS) */
+    private String lastModifiedDtime;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/mapper/ReactCmsDashboardMapper.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/mapper/ReactCmsDashboardMapper.java
@@ -1,5 +1,6 @@
 package com.example.admin_demo.domain.reactcmsdashboard.mapper;
 
+import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsApprovalStatusResponse;
 import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsDashboardListRequest;
 import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsDashboardPageResponse;
 import java.util.List;
@@ -43,6 +44,13 @@ public interface ReactCmsDashboardMapper {
      * @return 승인자 USER_NAME, 없으면 null
      */
     String findApproverNameById(@Param("approverId") String approverId);
+
+    /**
+     * 페이지 승인 상태 조회
+     *
+     * @return 승인 상태·반려 사유, 페이지 없으면 null
+     */
+    ReactCmsApprovalStatusResponse findApprovalStatus(@Param("pageId") String pageId);
 
     /** 승인 요청 — APPROVE_STATE = 'PENDING', 승인자 정보 저장 */
     void requestApproval(

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/mapper/ReactCmsDashboardMapper.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/mapper/ReactCmsDashboardMapper.java
@@ -1,0 +1,55 @@
+package com.example.admin_demo.domain.reactcmsdashboard.mapper;
+
+import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsDashboardListRequest;
+import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsDashboardPageResponse;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+/**
+ * React CMS 사용자 대시보드 Mapper (SPW_CMS_PAGE, SPW_CMS_PAGE_HISTORY)
+ *
+ * <p>PAGE_TYPE = 'REACT' 조건을 모든 쿼리에 적용한다.
+ * 새 페이지 생성은 react-cms 빌더에서 직접 수행하므로 INSERT 없음.
+ */
+@Mapper
+public interface ReactCmsDashboardMapper {
+
+    /** 내 페이지 목록 페이징 조회 */
+    List<ReactCmsDashboardPageResponse> findMyPageList(
+            @Param("req") ReactCmsDashboardListRequest req,
+            @Param("userId") String userId,
+            @Param("offset") int offset,
+            @Param("endRow") int endRow);
+
+    /** 내 페이지 목록 건수 */
+    long countMyPageList(@Param("req") ReactCmsDashboardListRequest req, @Param("userId") String userId);
+
+    /** 페이지 존재 여부 확인 (소유권 포함 — 본인 REACT 페이지만 허용) */
+    int existsByPageIdAndUserId(@Param("pageId") String pageId, @Param("userId") String userId);
+
+    /** 이력 존재 여부 확인 — 삭제 분기(하드/소프트)에 사용 */
+    int hasHistory(@Param("pageId") String pageId);
+
+    /** 소프트 삭제 — USE_YN = 'N' (이력 있는 페이지) */
+    void deleteSoft(@Param("pageId") String pageId, @Param("userId") String userId);
+
+    /** 하드 삭제 — 물리 행 삭제 (이력 없는 페이지) */
+    void deleteHard(@Param("pageId") String pageId, @Param("userId") String userId);
+
+    /**
+     * 승인자 이름 조회 — 클라이언트 전달값 대신 서버에서 직접 조회하여 위변조 방지
+     *
+     * @return 승인자 USER_NAME, 없으면 null
+     */
+    String findApproverNameById(@Param("approverId") String approverId);
+
+    /** 승인 요청 — APPROVE_STATE = 'PENDING', 승인자 정보 저장 */
+    void requestApproval(
+            @Param("pageId") String pageId,
+            @Param("approverId") String approverId,
+            @Param("approverName") String approverName,
+            @Param("beginningDate") String beginningDate,
+            @Param("expiredDate") String expiredDate,
+            @Param("userId") String userId);
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/mapper/ReactCmsDashboardMapper.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/mapper/ReactCmsDashboardMapper.java
@@ -27,9 +27,6 @@ public interface ReactCmsDashboardMapper {
     /** 내 페이지 목록 건수 */
     long countMyPageList(@Param("req") ReactCmsDashboardListRequest req, @Param("userId") String userId);
 
-    /** 페이지 존재 여부 확인 (소유권 포함 — 본인 REACT 페이지만 허용) */
-    int existsByPageIdAndUserId(@Param("pageId") String pageId, @Param("userId") String userId);
-
     /** 이력 존재 여부 확인 — 삭제 분기(하드/소프트)에 사용 */
     int hasHistory(@Param("pageId") String pageId);
 
@@ -53,8 +50,8 @@ public interface ReactCmsDashboardMapper {
      */
     ReactCmsApprovalStatusResponse findApprovalStatus(@Param("pageId") String pageId);
 
-    /** 승인 요청 — APPROVE_STATE = 'PENDING', 승인자 정보 저장 */
-    void requestApproval(
+    /** 승인 요청 — APPROVE_STATE = 'PENDING', 승인자 정보 저장. 영향받은 행 수 반환 */
+    int requestApproval(
             @Param("pageId") String pageId,
             @Param("approverId") String approverId,
             @Param("approverName") String approverName,

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/mapper/ReactCmsDashboardMapper.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/mapper/ReactCmsDashboardMapper.java
@@ -3,6 +3,7 @@ package com.example.admin_demo.domain.reactcmsdashboard.mapper;
 import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsApprovalStatusResponse;
 import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsDashboardListRequest;
 import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsDashboardPageResponse;
+import java.time.LocalDate;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -32,11 +33,11 @@ public interface ReactCmsDashboardMapper {
     /** 이력 존재 여부 확인 — 삭제 분기(하드/소프트)에 사용 */
     int hasHistory(@Param("pageId") String pageId);
 
-    /** 소프트 삭제 — USE_YN = 'N' (이력 있는 페이지) */
-    void deleteSoft(@Param("pageId") String pageId, @Param("userId") String userId);
+    /** 소프트 삭제 — USE_YN = 'N' (이력 있는 페이지). 영향받은 행 수 반환 */
+    int deleteSoft(@Param("pageId") String pageId, @Param("userId") String userId);
 
-    /** 하드 삭제 — 물리 행 삭제 (이력 없는 페이지) */
-    void deleteHard(@Param("pageId") String pageId, @Param("userId") String userId);
+    /** 하드 삭제 — 물리 행 삭제 (이력 없는 페이지). 영향받은 행 수 반환 */
+    int deleteHard(@Param("pageId") String pageId, @Param("userId") String userId);
 
     /**
      * 승인자 이름 조회 — 클라이언트 전달값 대신 서버에서 직접 조회하여 위변조 방지
@@ -57,7 +58,7 @@ public interface ReactCmsDashboardMapper {
             @Param("pageId") String pageId,
             @Param("approverId") String approverId,
             @Param("approverName") String approverName,
-            @Param("beginningDate") String beginningDate,
-            @Param("expiredDate") String expiredDate,
+            @Param("beginningDate") LocalDate beginningDate,
+            @Param("expiredDate") LocalDate expiredDate,
             @Param("userId") String userId);
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/service/ReactCmsDashboardService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/service/ReactCmsDashboardService.java
@@ -1,5 +1,6 @@
 package com.example.admin_demo.domain.reactcmsdashboard.service;
 
+import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsApprovalStatusResponse;
 import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsDashboardApproveRequestDto;
 import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsDashboardListRequest;
 import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsDashboardPageResponse;
@@ -56,6 +57,15 @@ public class ReactCmsDashboardService {
             reactCmsDashboardMapper.deleteHard(pageId, userId);
             log.info("React CMS 페이지 하드 삭제 (이력 없음): pageId={}, userId={}", pageId, userId);
         }
+    }
+
+    /** 페이지 승인 상태 조회 — react-cms 빌더가 편집 모드 진입 시 호출 */
+    public ReactCmsApprovalStatusResponse findApprovalStatus(String pageId) {
+        ReactCmsApprovalStatusResponse status = reactCmsDashboardMapper.findApprovalStatus(pageId);
+        if (status == null) {
+            throw new NotFoundException("페이지를 찾을 수 없습니다. pageId=" + pageId);
+        }
+        return status;
     }
 
     /** 승인 요청 — APPROVE_STATE: WORK / REJECTED / APPROVED → PENDING */

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/service/ReactCmsDashboardService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/service/ReactCmsDashboardService.java
@@ -9,8 +9,8 @@ import com.example.admin_demo.global.dto.PageRequest;
 import com.example.admin_demo.global.dto.PageResponse;
 import com.example.admin_demo.global.exception.InvalidInputException;
 import com.example.admin_demo.global.exception.NotFoundException;
-import java.util.List;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -75,14 +75,16 @@ public class ReactCmsDashboardService {
         return status;
     }
 
-    /** 승인 요청 — APPROVE_STATE: WORK / REJECTED / APPROVED → PENDING */
+    /**
+     * 승인 요청 — APPROVE_STATE: WORK / REJECTED / APPROVED → PENDING
+     *
+     * <p>UPDATE 결과값으로 소유권·존재 여부를 검증하여 Race Condition을 방지한다.
+     */
     @Transactional
     public void requestApproval(String pageId, ReactCmsDashboardApproveRequestDto req, String userId) {
-        checkPageOwner(pageId, userId);
-
         // 시작일·종료일 대소 검증 — Jackson이 형식 오류를 400으로 처리하므로 여기서는 논리 검증만
         LocalDate beginning = req.getBeginningDate();
-        LocalDate expired   = req.getExpiredDate();
+        LocalDate expired = req.getExpiredDate();
         if (beginning != null && expired != null && expired.isBefore(beginning)) {
             throw new InvalidInputException("종료일은 시작일 이후여야 합니다.");
         }
@@ -94,16 +96,11 @@ public class ReactCmsDashboardService {
             throw new InvalidInputException("유효하지 않은 승인자입니다.");
         }
 
-        reactCmsDashboardMapper.requestApproval(
+        int affected = reactCmsDashboardMapper.requestApproval(
                 pageId, req.getApproverId(), approverName, beginning, expired, userId);
-        log.info("React CMS 페이지 승인 요청: pageId={}, approverId={}, userId={}", pageId, req.getApproverId(), userId);
-    }
-
-    /** 페이지 소유권 확인 — 존재하지 않거나 본인 REACT 페이지가 아니면 예외 */
-    private void checkPageOwner(String pageId, String userId) {
-        if (reactCmsDashboardMapper.existsByPageIdAndUserId(pageId, userId) == 0) {
-            log.debug("페이지를 찾을 수 없습니다. pageId={}, userId={}", pageId, userId);
+        if (affected == 0) {
             throw new NotFoundException("페이지를 찾을 수 없습니다.");
         }
+        log.info("React CMS 페이지 승인 요청: pageId={}, approverId={}, userId={}", pageId, req.getApproverId(), userId);
     }
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/service/ReactCmsDashboardService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/service/ReactCmsDashboardService.java
@@ -1,0 +1,83 @@
+package com.example.admin_demo.domain.reactcmsdashboard.service;
+
+import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsDashboardApproveRequestDto;
+import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsDashboardListRequest;
+import com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsDashboardPageResponse;
+import com.example.admin_demo.domain.reactcmsdashboard.mapper.ReactCmsDashboardMapper;
+import com.example.admin_demo.global.dto.PageRequest;
+import com.example.admin_demo.global.dto.PageResponse;
+import com.example.admin_demo.global.exception.InvalidInputException;
+import com.example.admin_demo.global.exception.NotFoundException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * React CMS 사용자 대시보드 서비스
+ *
+ * <p>로그인한 사용자가 본인이 생성한 React CMS 페이지(PAGE_TYPE='REACT')를 조회·삭제·승인 요청할 수 있다.
+ * 새 페이지 생성은 react-cms 빌더(/react-cms/builder)에서 직접 수행한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReactCmsDashboardService {
+
+    private final ReactCmsDashboardMapper reactCmsDashboardMapper;
+
+    /** 내 페이지 목록 조회 */
+    public PageResponse<ReactCmsDashboardPageResponse> findMyPageList(
+            ReactCmsDashboardListRequest req, String userId, PageRequest pageRequest) {
+
+        long total = reactCmsDashboardMapper.countMyPageList(req, userId);
+        List<ReactCmsDashboardPageResponse> list =
+                reactCmsDashboardMapper.findMyPageList(req, userId, pageRequest.getOffset(), pageRequest.getEndRow());
+
+        return PageResponse.of(list, total, pageRequest.getPage(), pageRequest.getSize());
+    }
+
+    /**
+     * 페이지 삭제
+     *
+     * <p>이력이 있으면 소프트 삭제(USE_YN='N'), 없으면 하드 삭제(물리 행 삭제).
+     */
+    @Transactional
+    public void deletePage(String pageId, String userId) {
+        checkPageOwner(pageId, userId);
+
+        int historyCount = reactCmsDashboardMapper.hasHistory(pageId);
+        if (historyCount > 0) {
+            reactCmsDashboardMapper.deleteSoft(pageId, userId);
+            log.info("React CMS 페이지 소프트 삭제 (이력 존재): pageId={}, userId={}", pageId, userId);
+        } else {
+            reactCmsDashboardMapper.deleteHard(pageId, userId);
+            log.info("React CMS 페이지 하드 삭제 (이력 없음): pageId={}, userId={}", pageId, userId);
+        }
+    }
+
+    /** 승인 요청 — APPROVE_STATE: WORK / REJECTED / APPROVED → PENDING */
+    @Transactional
+    public void requestApproval(String pageId, ReactCmsDashboardApproveRequestDto req, String userId) {
+        checkPageOwner(pageId, userId);
+
+        // 클라이언트 전달값 대신 DB에서 직접 승인자 이름 조회 — 위변조 방지
+        String approverName = reactCmsDashboardMapper.findApproverNameById(req.getApproverId());
+        if (approverName == null) {
+            throw new InvalidInputException("유효하지 않은 승인자입니다. approverId=" + req.getApproverId());
+        }
+
+        reactCmsDashboardMapper.requestApproval(
+                pageId, req.getApproverId(), approverName, req.getBeginningDate(), req.getExpiredDate(), userId);
+        log.info("React CMS 페이지 승인 요청: pageId={}, approverId={}, userId={}", pageId, req.getApproverId(), userId);
+    }
+
+    /** 페이지 소유권 확인 — 존재하지 않거나 본인 REACT 페이지가 아니면 예외 */
+    private void checkPageOwner(String pageId, String userId) {
+        if (reactCmsDashboardMapper.existsByPageIdAndUserId(pageId, userId) == 0) {
+            throw new NotFoundException("페이지를 찾을 수 없습니다. pageId=" + pageId);
+        }
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/service/ReactCmsDashboardService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/service/ReactCmsDashboardService.java
@@ -10,6 +10,7 @@ import com.example.admin_demo.global.dto.PageResponse;
 import com.example.admin_demo.global.exception.InvalidInputException;
 import com.example.admin_demo.global.exception.NotFoundException;
 import java.util.List;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -44,18 +45,23 @@ public class ReactCmsDashboardService {
      * 페이지 삭제
      *
      * <p>이력이 있으면 소프트 삭제(USE_YN='N'), 없으면 하드 삭제(물리 행 삭제).
+     * DELETE/UPDATE 쿼리에 소유권 조건(CREATE_USER_ID)을 포함하여 결과를 검증함으로써
+     * checkPageOwner와 실제 삭제 사이의 Race Condition을 방지한다.
      */
     @Transactional
     public void deletePage(String pageId, String userId) {
-        checkPageOwner(pageId, userId);
-
         int historyCount = reactCmsDashboardMapper.hasHistory(pageId);
+        int affected;
         if (historyCount > 0) {
-            reactCmsDashboardMapper.deleteSoft(pageId, userId);
+            affected = reactCmsDashboardMapper.deleteSoft(pageId, userId);
             log.info("React CMS 페이지 소프트 삭제 (이력 존재): pageId={}, userId={}", pageId, userId);
         } else {
-            reactCmsDashboardMapper.deleteHard(pageId, userId);
+            affected = reactCmsDashboardMapper.deleteHard(pageId, userId);
             log.info("React CMS 페이지 하드 삭제 (이력 없음): pageId={}, userId={}", pageId, userId);
+        }
+        // 소유권 불일치 또는 이미 삭제된 경우 0 반환 → 404
+        if (affected == 0) {
+            throw new NotFoundException("페이지를 찾을 수 없습니다.");
         }
     }
 
@@ -63,7 +69,8 @@ public class ReactCmsDashboardService {
     public ReactCmsApprovalStatusResponse findApprovalStatus(String pageId) {
         ReactCmsApprovalStatusResponse status = reactCmsDashboardMapper.findApprovalStatus(pageId);
         if (status == null) {
-            throw new NotFoundException("페이지를 찾을 수 없습니다. pageId=" + pageId);
+            log.debug("페이지를 찾을 수 없습니다. pageId={}", pageId);
+            throw new NotFoundException("페이지를 찾을 수 없습니다.");
         }
         return status;
     }
@@ -73,21 +80,30 @@ public class ReactCmsDashboardService {
     public void requestApproval(String pageId, ReactCmsDashboardApproveRequestDto req, String userId) {
         checkPageOwner(pageId, userId);
 
+        // 시작일·종료일 대소 검증 — Jackson이 형식 오류를 400으로 처리하므로 여기서는 논리 검증만
+        LocalDate beginning = req.getBeginningDate();
+        LocalDate expired   = req.getExpiredDate();
+        if (beginning != null && expired != null && expired.isBefore(beginning)) {
+            throw new InvalidInputException("종료일은 시작일 이후여야 합니다.");
+        }
+
         // 클라이언트 전달값 대신 DB에서 직접 승인자 이름 조회 — 위변조 방지
         String approverName = reactCmsDashboardMapper.findApproverNameById(req.getApproverId());
         if (approverName == null) {
-            throw new InvalidInputException("유효하지 않은 승인자입니다. approverId=" + req.getApproverId());
+            log.debug("유효하지 않은 승인자입니다. approverId={}", req.getApproverId());
+            throw new InvalidInputException("유효하지 않은 승인자입니다.");
         }
 
         reactCmsDashboardMapper.requestApproval(
-                pageId, req.getApproverId(), approverName, req.getBeginningDate(), req.getExpiredDate(), userId);
+                pageId, req.getApproverId(), approverName, beginning, expired, userId);
         log.info("React CMS 페이지 승인 요청: pageId={}, approverId={}, userId={}", pageId, req.getApproverId(), userId);
     }
 
     /** 페이지 소유권 확인 — 존재하지 않거나 본인 REACT 페이지가 아니면 예외 */
     private void checkPageOwner(String pageId, String userId) {
         if (reactCmsDashboardMapper.existsByPageIdAndUserId(pageId, userId) == 0) {
-            throw new NotFoundException("페이지를 찾을 수 없습니다. pageId=" + pageId);
+            log.debug("페이지를 찾을 수 없습니다. pageId={}, userId={}", pageId, userId);
+            throw new NotFoundException("페이지를 찾을 수 없습니다.");
         }
     }
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/user/mapper/UserMapper.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/user/mapper/UserMapper.java
@@ -199,6 +199,13 @@ public interface UserMapper {
     List<CmsApproverResponse> findCmsApprovers();
 
     /**
+     * React CMS 결재자 목록 조회 (v3_react_cms_admin_approvals 쓰기 권한 보유 활성 사용자)
+     *
+     * @return {@link List} {@link CmsApproverResponse} 결재자 목록
+     */
+    List<CmsApproverResponse> findReactCmsApprovers();
+
+    /**
      * 엑셀 내보내기용 전체 목록 조회 (페이징 없음)
      */
     List<UserWithRoleResponse> findAllForExport(

--- a/admin/src/main/java/com/example/admin_demo/global/auth/controller/AuthController.java
+++ b/admin/src/main/java/com/example/admin_demo/global/auth/controller/AuthController.java
@@ -78,6 +78,11 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.success(userMapper.findCmsApprovers()));
     }
 
+    @GetMapping("/react-cms-approvers")
+    public ResponseEntity<ApiResponse<List<CmsApproverResponse>>> reactCmsApprovers() {
+        return ResponseEntity.ok(ApiResponse.success(userMapper.findReactCmsApprovers()));
+    }
+
     @GetMapping("/permission/menu")
     public ResponseEntity<ApiResponse<Boolean>> checkMenuPermission(
             @RequestParam String userId, @RequestParam String menuId) {

--- a/admin/src/main/java/com/example/admin_demo/global/page/controller/PageController.java
+++ b/admin/src/main/java/com/example/admin_demo/global/page/controller/PageController.java
@@ -399,7 +399,12 @@ public class PageController {
         return resolveView(request, "pages/datasource-manage/datasource-manage :: content", model);
     }
 
-    // CMS dashboard route is kept available even when it is not exposed as a menu.
+    // React CMS / HTML CMS 대시보드 라우트 — 메뉴 노출 여부와 무관하게 경로 유지
+
+    @GetMapping("/react-cms/dashboard")
+    public String reactCmsDashboard(HttpServletRequest request, Model model) {
+        return resolveView(request, "pages/react-cms-dashboard/react-cms-dashboard :: content", model);
+    }
 
     @GetMapping("/cms/dashboard")
     public String cmsDashboard(HttpServletRequest request, Model model) {

--- a/admin/src/main/resources/mapper/oracle/reactcmsdashboard/ReactCmsDashboardMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/reactcmsdashboard/ReactCmsDashboardMapper.xml
@@ -135,6 +135,19 @@
           AND USER_STATE_CODE = '1'
     </select>
 
+    <!-- ==================== 승인 상태 조회 ==================== -->
+
+    <select id="findApprovalStatus"
+            resultType="com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsApprovalStatusResponse">
+        SELECT
+            APPROVE_STATE   AS approveState,
+            REJECTED_REASON AS rejectedReason
+        FROM SPW_CMS_PAGE
+        WHERE PAGE_ID   = #{pageId}
+          AND PAGE_TYPE = 'REACT'
+          AND USE_YN    = 'Y'
+    </select>
+
     <!-- ==================== 승인 요청 — PENDING 전환 ==================== -->
 
     <update id="requestApproval">

--- a/admin/src/main/resources/mapper/oracle/reactcmsdashboard/ReactCmsDashboardMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/reactcmsdashboard/ReactCmsDashboardMapper.xml
@@ -95,17 +95,6 @@
         <include refid="searchConditions"/>
     </select>
 
-    <!-- ==================== 페이지 존재·소유권 확인 ==================== -->
-
-    <select id="existsByPageIdAndUserId" resultType="int">
-        SELECT COUNT(*)
-        FROM SPW_CMS_PAGE
-        WHERE PAGE_ID        = #{pageId}
-          AND PAGE_TYPE      = 'REACT'
-          AND CREATE_USER_ID = #{userId}
-          AND USE_YN         = 'Y'
-    </select>
-
     <!-- ==================== 이력 존재 확인 ==================== -->
 
     <select id="hasHistory" resultType="int">
@@ -124,6 +113,7 @@
         WHERE PAGE_ID        = #{pageId}
           AND PAGE_TYPE      = 'REACT'
           AND CREATE_USER_ID = #{userId}
+          AND USE_YN         = 'Y'
     </update>
 
     <!-- ==================== 하드 삭제 — 물리 행 삭제 ==================== -->

--- a/admin/src/main/resources/mapper/oracle/reactcmsdashboard/ReactCmsDashboardMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/reactcmsdashboard/ReactCmsDashboardMapper.xml
@@ -42,23 +42,33 @@
         </where>
     </sql>
 
+    <!-- ${} 문자열 치환 대신 <if>로 ASC/DESC를 직접 분기하여 SQL Injection 방지 -->
     <sql id="orderBy">
-        <bind name="orderDir" value="req.sortDirection == 'ASC' ? 'ASC' : 'DESC'"/>
         <choose>
             <when test="req.sortBy == 'pageName'">
-                ORDER BY p.PAGE_NAME ${orderDir} NULLS LAST, p.LAST_MODIFIED_DTIME DESC NULLS LAST
+                ORDER BY p.PAGE_NAME
+                <if test="req.sortDirection == 'ASC'">ASC</if><if test="req.sortDirection != 'ASC'">DESC</if>
+                NULLS LAST, p.LAST_MODIFIED_DTIME DESC NULLS LAST
             </when>
             <when test="req.sortBy == 'approveState'">
-                ORDER BY p.APPROVE_STATE ${orderDir} NULLS LAST, p.LAST_MODIFIED_DTIME DESC NULLS LAST
+                ORDER BY p.APPROVE_STATE
+                <if test="req.sortDirection == 'ASC'">ASC</if><if test="req.sortDirection != 'ASC'">DESC</if>
+                NULLS LAST, p.LAST_MODIFIED_DTIME DESC NULLS LAST
             </when>
             <when test="req.sortBy == 'beginningDate'">
-                ORDER BY p.BEGINNING_DATE ${orderDir} NULLS LAST, p.LAST_MODIFIED_DTIME DESC NULLS LAST
+                ORDER BY p.BEGINNING_DATE
+                <if test="req.sortDirection == 'ASC'">ASC</if><if test="req.sortDirection != 'ASC'">DESC</if>
+                NULLS LAST, p.LAST_MODIFIED_DTIME DESC NULLS LAST
             </when>
             <when test="req.sortBy == 'expiredDate'">
-                ORDER BY p.EXPIRED_DATE ${orderDir} NULLS LAST, p.LAST_MODIFIED_DTIME DESC NULLS LAST
+                ORDER BY p.EXPIRED_DATE
+                <if test="req.sortDirection == 'ASC'">ASC</if><if test="req.sortDirection != 'ASC'">DESC</if>
+                NULLS LAST, p.LAST_MODIFIED_DTIME DESC NULLS LAST
             </when>
             <when test="req.sortBy == 'lastModifiedDtime'">
-                ORDER BY p.LAST_MODIFIED_DTIME ${orderDir} NULLS LAST
+                ORDER BY p.LAST_MODIFIED_DTIME
+                <if test="req.sortDirection == 'ASC'">ASC</if><if test="req.sortDirection != 'ASC'">DESC</if>
+                NULLS LAST
             </when>
             <otherwise>
                 ORDER BY p.LAST_MODIFIED_DTIME DESC NULLS LAST
@@ -150,22 +160,14 @@
 
     <!-- ==================== 승인 요청 — PENDING 전환 ==================== -->
 
+    <!-- beginningDate/expiredDate는 LocalDate 타입 — MyBatis가 java.sql.Date로 변환하므로 TO_DATE 불필요 -->
     <update id="requestApproval">
         UPDATE SPW_CMS_PAGE
         SET APPROVE_STATE       = 'PENDING',
             APPROVER_ID         = #{approverId},
             APPROVER_NAME       = #{approverName},
-            <!-- Oracle에서 '' = NULL이므로 IS NOT NULL만으로 충분 -->
-            BEGINNING_DATE      = CASE
-                                      WHEN #{beginningDate} IS NOT NULL
-                                      THEN TO_DATE(#{beginningDate}, 'YYYY-MM-DD')
-                                      ELSE NULL
-                                  END,
-            EXPIRED_DATE        = CASE
-                                      WHEN #{expiredDate} IS NOT NULL
-                                      THEN TO_DATE(#{expiredDate}, 'YYYY-MM-DD')
-                                      ELSE NULL
-                                  END,
+            BEGINNING_DATE      = #{beginningDate},
+            EXPIRED_DATE        = #{expiredDate},
             LAST_MODIFIER_ID    = #{userId},
             LAST_MODIFIED_DTIME = SYSTIMESTAMP
         WHERE PAGE_ID        = #{pageId}

--- a/admin/src/main/resources/mapper/oracle/reactcmsdashboard/ReactCmsDashboardMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/reactcmsdashboard/ReactCmsDashboardMapper.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!--
+    ReactCmsDashboard Mapper
+    - SPW_CMS_PAGE         : 내 페이지 목록 조회, 삭제, 승인 요청 (PAGE_TYPE = 'REACT')
+    - SPW_CMS_PAGE_HISTORY : 이력 존재 여부 확인 (삭제 하드/소프트 분기용)
+    - 새 페이지 생성은 react-cms 빌더에서 직접 수행 → INSERT 없음
+-->
+<mapper namespace="com.example.admin_demo.domain.reactcmsdashboard.mapper.ReactCmsDashboardMapper">
+
+    <!-- ==================== 목록 조회 ==================== -->
+
+    <sql id="myPageListColumns">
+        p.PAGE_ID                                                           AS pageId,
+        p.PAGE_NAME                                                         AS pageName,
+        p.VIEW_MODE                                                         AS viewMode,
+        p.APPROVE_STATE                                                     AS approveState,
+        <!-- PAGE_HTML은 CLOB이므로 != '' 비교 불가 (ORA-00932). IS NOT NULL + 길이 체크로 대체 -->
+        CASE WHEN p.PAGE_HTML IS NOT NULL AND DBMS_LOB.GETLENGTH(p.PAGE_HTML) > 0
+             THEN 'Y' ELSE 'N' END                                         AS hasFile,
+        CASE WHEN p.EXPIRED_DATE IS NOT NULL AND p.EXPIRED_DATE <![CDATA[<]]> SYSDATE
+             THEN 'Y' ELSE 'N' END                                         AS isExpired,
+        TO_CHAR(p.BEGINNING_DATE, 'YYYY-MM-DD')                            AS beginningDate,
+        TO_CHAR(p.EXPIRED_DATE, 'YYYY-MM-DD')                              AS expiredDate,
+        p.REJECTED_REASON                                                   AS rejectedReason,
+        TO_CHAR(p.LAST_MODIFIED_DTIME, 'YYYY-MM-DD HH24:MI:SS')           AS lastModifiedDtime
+    </sql>
+
+    <sql id="searchConditions">
+        <where>
+            p.USE_YN = 'Y'
+            AND p.PAGE_TYPE = 'REACT'
+            AND p.CREATE_USER_ID = #{userId}
+            <if test="req.approveState != null and req.approveState != ''">
+                AND p.APPROVE_STATE = #{req.approveState}
+            </if>
+            <if test="req.search != null and req.search != ''">
+                AND p.PAGE_NAME LIKE '%' || #{req.search} || '%'
+            </if>
+        </where>
+    </sql>
+
+    <sql id="orderBy">
+        <bind name="orderDir" value="req.sortDirection == 'ASC' ? 'ASC' : 'DESC'"/>
+        <choose>
+            <when test="req.sortBy == 'pageName'">
+                ORDER BY p.PAGE_NAME ${orderDir} NULLS LAST, p.LAST_MODIFIED_DTIME DESC NULLS LAST
+            </when>
+            <when test="req.sortBy == 'approveState'">
+                ORDER BY p.APPROVE_STATE ${orderDir} NULLS LAST, p.LAST_MODIFIED_DTIME DESC NULLS LAST
+            </when>
+            <when test="req.sortBy == 'beginningDate'">
+                ORDER BY p.BEGINNING_DATE ${orderDir} NULLS LAST, p.LAST_MODIFIED_DTIME DESC NULLS LAST
+            </when>
+            <when test="req.sortBy == 'expiredDate'">
+                ORDER BY p.EXPIRED_DATE ${orderDir} NULLS LAST, p.LAST_MODIFIED_DTIME DESC NULLS LAST
+            </when>
+            <when test="req.sortBy == 'lastModifiedDtime'">
+                ORDER BY p.LAST_MODIFIED_DTIME ${orderDir} NULLS LAST
+            </when>
+            <otherwise>
+                ORDER BY p.LAST_MODIFIED_DTIME DESC NULLS LAST
+            </otherwise>
+        </choose>
+    </sql>
+
+    <select id="findMyPageList" resultType="com.example.admin_demo.domain.reactcmsdashboard.dto.ReactCmsDashboardPageResponse">
+        SELECT * FROM (
+            SELECT INNER_QRY.*, ROWNUM AS RNUM FROM (
+                SELECT
+                <include refid="myPageListColumns"/>
+                FROM SPW_CMS_PAGE p
+                <include refid="searchConditions"/>
+                <include refid="orderBy"/>
+            ) INNER_QRY
+            WHERE ROWNUM <![CDATA[<=]]> #{endRow}
+        ) WHERE RNUM > #{offset}
+    </select>
+
+    <select id="countMyPageList" resultType="long">
+        SELECT COUNT(*)
+        FROM SPW_CMS_PAGE p
+        <include refid="searchConditions"/>
+    </select>
+
+    <!-- ==================== 페이지 존재·소유권 확인 ==================== -->
+
+    <select id="existsByPageIdAndUserId" resultType="int">
+        SELECT COUNT(*)
+        FROM SPW_CMS_PAGE
+        WHERE PAGE_ID        = #{pageId}
+          AND PAGE_TYPE      = 'REACT'
+          AND CREATE_USER_ID = #{userId}
+          AND USE_YN         = 'Y'
+    </select>
+
+    <!-- ==================== 이력 존재 확인 ==================== -->
+
+    <select id="hasHistory" resultType="int">
+        SELECT COUNT(*)
+        FROM SPW_CMS_PAGE_HISTORY
+        WHERE PAGE_ID = #{pageId}
+    </select>
+
+    <!-- ==================== 소프트 삭제 — USE_YN = 'N' ==================== -->
+
+    <update id="deleteSoft">
+        UPDATE SPW_CMS_PAGE
+        SET USE_YN              = 'N',
+            LAST_MODIFIER_ID    = #{userId},
+            LAST_MODIFIED_DTIME = SYSTIMESTAMP
+        WHERE PAGE_ID        = #{pageId}
+          AND PAGE_TYPE      = 'REACT'
+          AND CREATE_USER_ID = #{userId}
+    </update>
+
+    <!-- ==================== 하드 삭제 — 물리 행 삭제 ==================== -->
+
+    <delete id="deleteHard">
+        DELETE FROM SPW_CMS_PAGE
+        WHERE PAGE_ID        = #{pageId}
+          AND PAGE_TYPE      = 'REACT'
+          AND CREATE_USER_ID = #{userId}
+          AND USE_YN         = 'Y'
+    </delete>
+
+    <!-- ==================== 승인자 이름 조회 ==================== -->
+
+    <select id="findApproverNameById" resultType="string">
+        SELECT USER_NAME
+        FROM FWK_USER
+        WHERE USER_ID = #{approverId}
+          AND USER_STATE_CODE = '1'
+    </select>
+
+    <!-- ==================== 승인 요청 — PENDING 전환 ==================== -->
+
+    <update id="requestApproval">
+        UPDATE SPW_CMS_PAGE
+        SET APPROVE_STATE       = 'PENDING',
+            APPROVER_ID         = #{approverId},
+            APPROVER_NAME       = #{approverName},
+            <!-- Oracle에서 '' = NULL이므로 IS NOT NULL만으로 충분 -->
+            BEGINNING_DATE      = CASE
+                                      WHEN #{beginningDate} IS NOT NULL
+                                      THEN TO_DATE(#{beginningDate}, 'YYYY-MM-DD')
+                                      ELSE NULL
+                                  END,
+            EXPIRED_DATE        = CASE
+                                      WHEN #{expiredDate} IS NOT NULL
+                                      THEN TO_DATE(#{expiredDate}, 'YYYY-MM-DD')
+                                      ELSE NULL
+                                  END,
+            LAST_MODIFIER_ID    = #{userId},
+            LAST_MODIFIED_DTIME = SYSTIMESTAMP
+        WHERE PAGE_ID        = #{pageId}
+          AND PAGE_TYPE      = 'REACT'
+          AND CREATE_USER_ID = #{userId}
+          AND USE_YN         = 'Y'
+    </update>
+
+</mapper>

--- a/admin/src/main/resources/mapper/oracle/user/UserMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/user/UserMapper.xml
@@ -322,6 +322,33 @@
         ORDER BY u.USER_NAME ASC, u.USER_ID ASC
     </select>
 
+    <!-- React CMS 결재자 목록 조회 (v3_react_cms_admin_approvals 쓰기 권한 보유 활성 사용자) -->
+    <select id="findReactCmsApprovers"
+            resultType="com.example.admin_demo.global.auth.dto.CmsApproverResponse">
+        SELECT DISTINCT
+            u.USER_ID   AS userId,
+            u.USER_NAME AS userName
+        FROM FWK_USER u
+        WHERE u.USER_STATE_CODE = '1'
+          AND (
+              EXISTS (
+                  SELECT 1
+                  FROM FWK_USER_MENU um
+                  WHERE um.USER_ID = u.USER_ID
+                    AND um.MENU_ID = 'v3_react_cms_admin_approvals'
+                    AND um.AUTH_CODE = 'W'
+              )
+              OR EXISTS (
+                  SELECT 1
+                  FROM FWK_ROLE_MENU rm
+                  WHERE rm.ROLE_ID = u.ROLE_ID
+                    AND rm.MENU_ID = 'v3_react_cms_admin_approvals'
+                    AND rm.AUTH_CODE = 'W'
+              )
+          )
+        ORDER BY u.USER_NAME ASC, u.USER_ID ASC
+    </select>
+
     <!-- ==================== 엑셀 내보내기 (페이징 없음) ==================== -->
 
     <select id="findAllForExport"

--- a/admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard-script.html
+++ b/admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard-script.html
@@ -1,0 +1,315 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<th:block th:fragment="script">
+<script th:inline="javascript">
+/*<![CDATA[*/
+    const HAS_REACT_CMS_WRITE = /*[[${userAuthorities != null && userAuthorities.contains('REACT-CMS:W')}]]*/ false;
+/*]]>*/
+</script>
+<script>
+    // ==================== ReactCmsDashboardPage ====================
+
+    window.ReactCmsDashboardPage = {
+        currentPage: 1,
+        totalItems: 0,
+        itemsPerPage: 10,
+        sortBy: null,
+        sortDirection: null,
+        rowsByPageId: {},
+
+        APPROVE_STATE_BADGE: {
+            WORK:     '<span class="badge bg-secondary">작업중</span>',
+            PENDING:  '<span class="badge bg-warning text-dark">승인대기</span>',
+            APPROVED: '<span class="badge bg-success">승인완료</span>',
+            REJECTED: '<span class="badge bg-danger">반려</span>',
+        },
+
+        load: function(page) {
+            if (page !== undefined) this.currentPage = page;
+            const params = new URLSearchParams({
+                page:         this.currentPage,
+                size:         this.itemsPerPage,
+                approveState: $('#filterApproveState').val(),
+                search:       $('#filterSearch').val().trim(),
+            });
+            if (this.sortBy) {
+                params.append('sortBy', this.sortBy);
+                params.append('sortDirection', this.sortDirection);
+            }
+
+            fetch('/api/react-cms-dashboard/pages?' + params)
+                .then(r => r.json())
+                .then(res => {
+                    if (!res.success) { Toast.error(res.message); return; }
+                    const pageData = res.data;
+                    this.totalItems = pageData.totalElements;
+                    this.renderTable(pageData.content);
+                    this.renderPagination();
+                    this.updateSortIndicators();
+                })
+                .catch(() => Toast.error('목록 조회 중 오류가 발생했습니다.'));
+        },
+
+        attachSortHandlers: function() {
+            $(document)
+                .off('click.reactCmsDashboardSort', '#reactCmsDashboardTable thead th[data-sort]')
+                .on('click.reactCmsDashboardSort', '#reactCmsDashboardTable thead th[data-sort]', function() {
+                    const sortKey = $(this).data('sort');
+                    if (!sortKey) return;
+
+                    if (ReactCmsDashboardPage.sortBy === sortKey) {
+                        if (ReactCmsDashboardPage.sortDirection === 'ASC') {
+                            ReactCmsDashboardPage.sortDirection = 'DESC';
+                        } else {
+                            ReactCmsDashboardPage.sortBy = null;
+                            ReactCmsDashboardPage.sortDirection = null;
+                        }
+                    } else {
+                        ReactCmsDashboardPage.sortBy = sortKey;
+                        ReactCmsDashboardPage.sortDirection = 'ASC';
+                    }
+
+                    ReactCmsDashboardPage.updateSortIndicators();
+                    ReactCmsDashboardPage.load(1);
+                });
+        },
+
+        updateSortIndicators: function() {
+            const headers = $('#reactCmsDashboardTable thead th.sortable');
+            headers.removeClass('sort-asc sort-desc');
+            if (!this.sortBy || !this.sortDirection) return;
+            headers.filter(`[data-sort="${this.sortBy}"]`)
+                .addClass(this.sortDirection === 'ASC' ? 'sort-asc' : 'sort-desc');
+        },
+
+        renderTable: function(rows) {
+            const $tbody = $('#reactCmsDashboardTableBody');
+            if (!rows || rows.length === 0) {
+                this.rowsByPageId = {};
+                $tbody.html('<tr><td colspan="8" class="text-center py-4 text-body-secondary">조회된 데이터가 없습니다.</td></tr>');
+                return;
+            }
+
+            this.rowsByPageId = rows.reduce((map, row) => {
+                if (row.pageId) map[row.pageId] = row;
+                return map;
+            }, {});
+
+            const html = rows.map(row => {
+                const badge      = this.APPROVE_STATE_BADGE[row.approveState] || HtmlUtils.escape(row.approveState);
+                const expiredCls = row.isExpired === 'Y' ? 'text-danger fw-bold' : '';
+                const pid        = HtmlUtils.escape(row.pageId);
+
+                // 승인요청 버튼 — WORK: "승인요청", REJECTED/APPROVED: "재승인요청", PENDING: 버튼 없음
+                let tdApprove = '-';
+                if (HAS_REACT_CMS_WRITE) {
+                    if (row.approveState === 'WORK') {
+                        tdApprove = `<button class="btn btn-primary btn-xs"
+                            onclick="ReactCmsDashboardPage.openApproveRequestModal('${pid}')">승인요청</button>`;
+                    } else if (row.approveState === 'REJECTED' || row.approveState === 'APPROVED') {
+                        tdApprove = `<button class="btn btn-outline-primary btn-xs"
+                            onclick="ReactCmsDashboardPage.openApproveRequestModal('${pid}')">재승인요청</button>`;
+                    }
+                }
+
+                const tdDelete = HAS_REACT_CMS_WRITE
+                    ? `<button class="btn btn-outline-danger btn-xs"
+                           onclick="ReactCmsDashboardPage.deletePage('${pid}')">삭제</button>`
+                    : '-';
+
+                // 반려 상태면 페이지명 옆에 반려 사유 확인 아이콘 표시
+                const rejectedLink = (row.approveState === 'REJECTED' && row.rejectedReason)
+                    ? ` <a href="#" class="text-danger small" title="반려 사유 확인"
+                            onclick="ReactCmsDashboardPage.showRejectedReason('${pid}'); return false;">
+                            <i class="bi bi-exclamation-circle"></i></a>`
+                    : '';
+
+                return `<tr>
+                    <td>
+                        <span class="clickable-cell"
+                              onclick="ReactCmsDashboardPage.openEditor('${pid}')"
+                              title="React CMS 에디터로 이동">${HtmlUtils.escape(row.pageName || '')}</span>${rejectedLink}
+                    </td>
+                    <td class="text-center">${HtmlUtils.escape(row.viewMode || 'mobile')}</td>
+                    <td class="text-center">${badge}</td>
+                    <td class="text-center">${HtmlUtils.escape(row.beginningDate || '-')}</td>
+                    <td class="text-center ${expiredCls}">${HtmlUtils.escape(row.expiredDate || '-')}</td>
+                    <td class="text-center small">${HtmlUtils.escape(row.lastModifiedDtime || '-')}</td>
+                    <td class="text-center">${tdApprove}</td>
+                    <td class="text-center">${tdDelete}</td>
+                </tr>`;
+            }).join('');
+
+            $tbody.html(html);
+        },
+
+        renderPagination: function() {
+            const totalPages = Math.ceil(this.totalItems / this.itemsPerPage);
+            const pagination = $('#pagination');
+            pagination.empty();
+
+            pagination.append(`
+                <li class="page-item ${this.currentPage === 1 ? 'disabled' : ''}">
+                    <a class="page-link" href="#" onclick="ReactCmsDashboardPage.changePage(1); return false;"><i class="bi bi-chevron-double-left"></i></a>
+                </li>
+                <li class="page-item ${this.currentPage === 1 ? 'disabled' : ''}">
+                    <a class="page-link" href="#" onclick="ReactCmsDashboardPage.changePage(${this.currentPage - 1}); return false;"><i class="bi bi-chevron-left"></i></a>
+                </li>
+            `);
+
+            const maxButtons = 5;
+            let startPage = Math.max(1, this.currentPage - Math.floor(maxButtons / 2));
+            let endPage   = Math.min(totalPages, startPage + maxButtons - 1);
+            if (endPage - startPage + 1 < maxButtons) {
+                startPage = Math.max(1, endPage - maxButtons + 1);
+            }
+
+            for (let i = startPage; i <= endPage; i++) {
+                pagination.append(`
+                    <li class="page-item ${i === this.currentPage ? 'active' : ''}">
+                        <a class="page-link" href="#" onclick="ReactCmsDashboardPage.changePage(${i}); return false;">${i}</a>
+                    </li>
+                `);
+            }
+
+            pagination.append(`
+                <li class="page-item ${this.currentPage === totalPages || totalPages === 0 ? 'disabled' : ''}">
+                    <a class="page-link" href="#" onclick="ReactCmsDashboardPage.changePage(${this.currentPage + 1}); return false;"><i class="bi bi-chevron-right"></i></a>
+                </li>
+                <li class="page-item ${this.currentPage === totalPages || totalPages === 0 ? 'disabled' : ''}">
+                    <a class="page-link" href="#" onclick="ReactCmsDashboardPage.changePage(${totalPages}); return false;"><i class="bi bi-chevron-double-right"></i></a>
+                </li>
+            `);
+
+            const start = this.totalItems === 0 ? 0 : (this.currentPage - 1) * this.itemsPerPage + 1;
+            const end   = Math.min(this.currentPage * this.itemsPerPage, this.totalItems);
+            $('#pageInfo').text(`${start} - ${end} of ${this.totalItems} items`);
+        },
+
+        changePage: function(page) {
+            const totalPages = Math.ceil(this.totalItems / this.itemsPerPage);
+            if (page < 1 || page > totalPages) return;
+            this.currentPage = page;
+            this.load();
+        },
+
+        reset: function() {
+            $('#filterApproveState').val('');
+            $('#filterSearch').val('');
+            this.sortBy = null;
+            this.sortDirection = null;
+            this.updateSortIndicators();
+            this.itemsPerPage = parseInt($('#limitRows').val()) || 10;
+            this.load(1);
+        },
+
+        // ── React CMS 에디터 — 팝업 창으로 열기 ──
+        openEditor: function(pageId) {
+            window.open(
+                '/react-cms/builder?pageId=' + encodeURIComponent(pageId),
+                'reactCmsEditor',
+                'width=1280,height=800,scrollbars=yes,resizable=yes'
+            );
+        },
+
+        // ── 승인 요청 모달 ──
+        openApproveRequestModal: function(pageId) {
+            const row = this.rowsByPageId[pageId] || {};
+            const isReApprove = row.approveState === 'REJECTED' || row.approveState === 'APPROVED';
+            $('#approveRequestModalTitle').text(isReApprove ? '재승인요청' : '승인 요청');
+            $('#approveRequestPageId').val(pageId);
+            $('#approveRequestPageName').text(row.pageName || '-');
+            $('#approveRequestApproverId').html('<option value="">승인자 선택</option>');
+            $('#approveRequestBeginningDate').val(row.beginningDate || '');
+            $('#approveRequestExpiredDate').val(row.expiredDate || '');
+
+            // 승인자 목록 로드
+            fetch('/api/auth/cms-approvers')
+                .then(r => r.json())
+                .then(res => {
+                    if (!res.success) return;
+                    const options = res.data.map(a =>
+                        `<option value="${HtmlUtils.escape(a.userId)}" data-name="${HtmlUtils.escape(a.userName)}">
+                            ${HtmlUtils.escape(a.userName)}
+                        </option>`
+                    ).join('');
+                    $('#approveRequestApproverId').append(options);
+                });
+
+            new bootstrap.Modal('#approveRequestModal').show();
+        },
+
+        _submitApproveRequest: function() {
+            const pageId     = $('#approveRequestPageId').val();
+            const approverId = $('#approveRequestApproverId').val();
+
+            if (!approverId) { Toast.warning('승인자를 선택하세요.'); return; }
+
+            const beginningDate = $('#approveRequestBeginningDate').val();
+            const expiredDate   = $('#approveRequestExpiredDate').val();
+
+            // approverName은 서버에서 DB 조회 — 클라이언트에서 전달하지 않음 (위변조 방지)
+            fetch(`/api/react-cms-dashboard/pages/${pageId}/approve-request`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ approverId, beginningDate, expiredDate }),
+            })
+                .then(r => r.json())
+                .then(res => {
+                    bootstrap.Modal.getInstance('#approveRequestModal').hide();
+                    if (res.success) { Toast.success(res.message); this.load(); }
+                    else             { Toast.error(res.message); }
+                })
+                .catch(() => Toast.error('승인 요청 중 오류가 발생했습니다.'));
+        },
+
+        // ── 반려 사유 확인 ──
+        showRejectedReason: function(pageId) {
+            const row = this.rowsByPageId[pageId] || {};
+            $('#rejectedReasonText').text(row.rejectedReason || '반려 사유가 없습니다.');
+            new bootstrap.Modal('#rejectedReasonModal').show();
+        },
+
+        // ── 삭제 ──
+        deletePage: function(pageId) {
+            const row = this.rowsByPageId[pageId] || {};
+            if (!confirm(`'${row.pageName || pageId}' 페이지를 삭제하시겠습니까?`)) return;
+
+            fetch(`/api/react-cms-dashboard/pages/${pageId}`, { method: 'DELETE' })
+                .then(r => r.json())
+                .then(res => {
+                    if (res.success) { Toast.success(res.message); this.load(); }
+                    else             { Toast.error(res.message); }
+                })
+                .catch(() => Toast.error('삭제 중 오류가 발생했습니다.'));
+        },
+    };
+
+    // ==================== 이벤트 바인딩 ====================
+
+    $(document).ready(function() {
+        ReactCmsDashboardPage.itemsPerPage = parseInt($('#limitRows').val()) || 10;
+        ReactCmsDashboardPage.attachSortHandlers();
+        ReactCmsDashboardPage.load(1);
+
+        $('#limitRows').on('change', function() {
+            ReactCmsDashboardPage.itemsPerPage = parseInt($(this).val()) || 10;
+            ReactCmsDashboardPage.load(1);
+        });
+
+        // [새 페이지] 버튼 — 빌더 팝업 열기
+        $('#btnNewPage').on('click', function() {
+            window.open(
+                '/react-cms/builder',
+                'reactCmsEditor',
+                'width=1280,height=800,scrollbars=yes,resizable=yes'
+            );
+        });
+
+        $('#btnApproveRequestConfirm').on('click', function() { ReactCmsDashboardPage._submitApproveRequest(); });
+    });
+</script>
+</th:block>
+</body>
+</html>

--- a/admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard-script.html
+++ b/admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard-script.html
@@ -225,7 +225,7 @@
             $('#approveRequestExpiredDate').val(row.expiredDate || '');
 
             // 승인자 목록 로드
-            fetch('/api/auth/cms-approvers')
+            fetch('/api/auth/react-cms-approvers')
                 .then(r => r.json())
                 .then(res => {
                     if (!res.success) return;
@@ -298,13 +298,21 @@
             ReactCmsDashboardPage.load(1);
         });
 
-        // [새 페이지] 버튼 — 빌더 팝업 열기
+        // [새 페이지] 버튼 — 빌더 팝업 열기 (창 참조 보관)
         $('#btnNewPage').on('click', function() {
-            window.open(
+            ReactCmsDashboardPage._editorWin = window.open(
                 '/react-cms/builder',
                 'reactCmsEditor',
                 'width=1280,height=800,scrollbars=yes,resizable=yes'
             );
+        });
+
+        // 빌더에서 저장 완료 신호 수신 → 팝업 닫기 + 목록 새로고침
+        window.addEventListener('message', function(e) {
+            if (e.data === 'reactCmsSaved') {
+                ReactCmsDashboardPage._editorWin?.close();
+                ReactCmsDashboardPage.load(1);
+            }
         });
 
         $('#btnApproveRequestConfirm').on('click', function() { ReactCmsDashboardPage._submitApproveRequest(); });

--- a/admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard-script.html
+++ b/admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard-script.html
@@ -99,36 +99,37 @@
             const html = rows.map(row => {
                 const badge      = this.APPROVE_STATE_BADGE[row.approveState] || HtmlUtils.escape(row.approveState);
                 const expiredCls = row.isExpired === 'Y' ? 'text-danger fw-bold' : '';
+                // XSS 방지: pageId는 data-* 속성에만 저장하고 onclick 인라인 삽입 금지
                 const pid        = HtmlUtils.escape(row.pageId);
 
                 // 승인요청 버튼 — WORK: "승인요청", REJECTED/APPROVED: "재승인요청", PENDING: 버튼 없음
                 let tdApprove = '-';
                 if (HAS_REACT_CMS_WRITE) {
                     if (row.approveState === 'WORK') {
-                        tdApprove = `<button class="btn btn-primary btn-xs"
-                            onclick="ReactCmsDashboardPage.openApproveRequestModal('${pid}')">승인요청</button>`;
+                        tdApprove = `<button class="btn btn-primary btn-xs js-approve-request"
+                            data-page-id="${pid}">승인요청</button>`;
                     } else if (row.approveState === 'REJECTED' || row.approveState === 'APPROVED') {
-                        tdApprove = `<button class="btn btn-outline-primary btn-xs"
-                            onclick="ReactCmsDashboardPage.openApproveRequestModal('${pid}')">재승인요청</button>`;
+                        tdApprove = `<button class="btn btn-outline-primary btn-xs js-approve-request"
+                            data-page-id="${pid}">재승인요청</button>`;
                     }
                 }
 
                 const tdDelete = HAS_REACT_CMS_WRITE
-                    ? `<button class="btn btn-outline-danger btn-xs"
-                           onclick="ReactCmsDashboardPage.deletePage('${pid}')">삭제</button>`
+                    ? `<button class="btn btn-outline-danger btn-xs js-delete-page"
+                           data-page-id="${pid}">삭제</button>`
                     : '-';
 
                 // 반려 상태면 페이지명 옆에 반려 사유 확인 아이콘 표시
                 const rejectedLink = (row.approveState === 'REJECTED' && row.rejectedReason)
-                    ? ` <a href="#" class="text-danger small" title="반려 사유 확인"
-                            onclick="ReactCmsDashboardPage.showRejectedReason('${pid}'); return false;">
+                    ? ` <a href="#" class="text-danger small js-rejected-reason" title="반려 사유 확인"
+                            data-page-id="${pid}">
                             <i class="bi bi-exclamation-circle"></i></a>`
                     : '';
 
                 return `<tr>
                     <td>
-                        <span class="clickable-cell"
-                              onclick="ReactCmsDashboardPage.openEditor('${pid}')"
+                        <span class="clickable-cell js-open-editor"
+                              data-page-id="${pid}"
                               title="React CMS 에디터로 이동">${HtmlUtils.escape(row.pageName || '')}</span>${rejectedLink}
                     </td>
                     <td class="text-center">${HtmlUtils.escape(row.viewMode || 'mobile')}</td>
@@ -213,6 +214,21 @@
             );
         },
 
+        // 승인자 목록 캐시 — 변경 빈도가 낮으므로 페이지 세션 동안 재사용
+        _approversCache: null,
+
+        _loadApprovers: function() {
+            if (this._approversCache) {
+                return Promise.resolve(this._approversCache);
+            }
+            return fetch('/api/auth/react-cms-approvers')
+                .then(r => r.json())
+                .then(res => {
+                    if (res.success) this._approversCache = res.data;
+                    return res.success ? res.data : [];
+                });
+        },
+
         // ── 승인 요청 모달 ──
         openApproveRequestModal: function(pageId) {
             const row = this.rowsByPageId[pageId] || {};
@@ -224,23 +240,23 @@
             $('#approveRequestBeginningDate').val(row.beginningDate || '');
             $('#approveRequestExpiredDate').val(row.expiredDate || '');
 
-            // 승인자 목록 로드
-            fetch('/api/auth/react-cms-approvers')
-                .then(r => r.json())
-                .then(res => {
-                    if (!res.success) return;
-                    const options = res.data.map(a =>
-                        `<option value="${HtmlUtils.escape(a.userId)}" data-name="${HtmlUtils.escape(a.userName)}">
-                            ${HtmlUtils.escape(a.userName)}
-                        </option>`
-                    ).join('');
-                    $('#approveRequestApproverId').append(options);
-                });
+            this._loadApprovers().then(approvers => {
+                const options = approvers.map(a =>
+                    `<option value="${HtmlUtils.escape(a.userId)}" data-name="${HtmlUtils.escape(a.userName)}">
+                        ${HtmlUtils.escape(a.userName)}
+                    </option>`
+                ).join('');
+                $('#approveRequestApproverId').append(options);
+            });
 
             new bootstrap.Modal('#approveRequestModal').show();
         },
 
+        _isSubmittingApproval: false,
+
         _submitApproveRequest: function() {
+            if (this._isSubmittingApproval) return;
+
             const pageId     = $('#approveRequestPageId').val();
             const approverId = $('#approveRequestApproverId').val();
 
@@ -248,6 +264,9 @@
 
             const beginningDate = $('#approveRequestBeginningDate').val();
             const expiredDate   = $('#approveRequestExpiredDate').val();
+
+            this._isSubmittingApproval = true;
+            $('#btnApproveRequestConfirm').prop('disabled', true);
 
             // approverName은 서버에서 DB 조회 — 클라이언트에서 전달하지 않음 (위변조 방지)
             fetch(`/api/react-cms-dashboard/pages/${pageId}/approve-request`, {
@@ -261,7 +280,11 @@
                     if (res.success) { Toast.success(res.message); this.load(); }
                     else             { Toast.error(res.message); }
                 })
-                .catch(() => Toast.error('승인 요청 중 오류가 발생했습니다.'));
+                .catch(() => Toast.error('승인 요청 중 오류가 발생했습니다.'))
+                .finally(() => {
+                    this._isSubmittingApproval = false;
+                    $('#btnApproveRequestConfirm').prop('disabled', false);
+                });
         },
 
         // ── 반려 사유 확인 ──
@@ -308,12 +331,30 @@
         });
 
         // 빌더에서 저장 완료 신호 수신 → 팝업 닫기 + 목록 새로고침
+        // Origin 검증으로 타 도메인 메시지 차단
         window.addEventListener('message', function(e) {
+            if (e.origin !== window.location.origin) return;
             if (e.data === 'reactCmsSaved') {
                 ReactCmsDashboardPage._editorWin?.close();
                 ReactCmsDashboardPage.load(1);
             }
         });
+
+        // 이벤트 위임 — XSS 방지를 위해 onclick 인라인 대신 data-page-id로 pageId 전달
+        $(document)
+            .on('click', '.js-open-editor', function() {
+                ReactCmsDashboardPage.openEditor($(this).data('page-id'));
+            })
+            .on('click', '.js-approve-request', function() {
+                ReactCmsDashboardPage.openApproveRequestModal($(this).data('page-id'));
+            })
+            .on('click', '.js-delete-page', function() {
+                ReactCmsDashboardPage.deletePage($(this).data('page-id'));
+            })
+            .on('click', '.js-rejected-reason', function(e) {
+                e.preventDefault();
+                ReactCmsDashboardPage.showRejectedReason($(this).data('page-id'));
+            });
 
         $('#btnApproveRequestConfirm').on('click', function() { ReactCmsDashboardPage._submitApproveRequest(); });
     });

--- a/admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard-search.html
+++ b/admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard-search.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<!-- React CMS 사용자 대시보드 검색 프래그먼트 -->
+<!-- VIEW_MODE는 'mobile' 고정이므로 뷰모드 필터는 제공하지 않음 -->
+<div th:fragment="search" class="card border p-2 mb-3">
+    <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
+        <label class="form-label mb-0 small fw-medium">승인상태</label>
+        <select id="filterApproveState" class="form-select form-select-sm flex-fixed-130">
+            <option value="">전체</option>
+            <option value="WORK">작업중</option>
+            <option value="PENDING">승인대기</option>
+            <option value="APPROVED">승인완료</option>
+            <option value="REJECTED">반려</option>
+        </select>
+
+        <input type="text" id="filterSearch" class="form-control form-control-sm flex-fixed-200"
+               placeholder="페이지명 검색"
+               onkeypress="if(event.key === 'Enter') ReactCmsDashboardPage.load(1)">
+
+        <div class="flex-grow-1"></div>
+
+        <select id="limitRows" class="form-select form-select-sm sp-limit-select">
+            <option value="10" selected>10</option>
+            <option value="20">20</option>
+            <option value="50">50</option>
+            <option value="100">100</option>
+        </select>
+        <label class="form-label mb-0 small fw-medium ms-1 me-2 fs-xs">건씩</label>
+
+        <button class="btn btn-primary btn-sm" onclick="ReactCmsDashboardPage.load(1)">
+            <i class="bi bi-search"></i> 조회
+        </button>
+        <button class="btn btn-outline-secondary btn-sm" onclick="ReactCmsDashboardPage.reset()">초기화</button>
+    </div>
+</div>
+</body>
+</html>

--- a/admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard-table.html
+++ b/admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard-table.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<!-- React CMS 사용자 대시보드 테이블 프래그먼트 -->
+<div th:fragment="table" class="table-responsive">
+    <table class="table table-sm table-hover sp-data-grid" id="reactCmsDashboardTable" style="min-width: 840px;">
+        <thead class="table-light">
+            <tr>
+                <th class="sortable" data-sort="pageName">페이지명</th>
+                <th class="col-w-80">뷰모드</th>
+                <th class="col-w-100 sortable" data-sort="approveState">승인상태</th>
+                <th class="col-w-100 sortable" data-sort="beginningDate">노출시작일</th>
+                <th class="col-w-100 sortable" data-sort="expiredDate">노출종료일</th>
+                <th class="col-w-150 sortable" data-sort="lastModifiedDtime">최종수정일시</th>
+                <th class="col-w-90">승인요청</th>
+                <th class="col-w-60">삭제</th>
+            </tr>
+        </thead>
+        <tbody id="reactCmsDashboardTableBody">
+            <tr>
+                <td colspan="8" class="text-center py-4 text-body-secondary">
+                    조회 버튼을 클릭하여 데이터를 불러오세요.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+</body>
+</html>

--- a/admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard-table.html
+++ b/admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard-table.html
@@ -13,7 +13,7 @@
                 <th class="col-w-100 sortable" data-sort="expiredDate">노출종료일</th>
                 <th class="col-w-150 sortable" data-sort="lastModifiedDtime">최종수정일시</th>
                 <th class="col-w-90">승인요청</th>
-                <th class="col-w-60">삭제</th>
+                <th class="col-w-80">삭제</th>
             </tr>
         </thead>
         <tbody id="reactCmsDashboardTableBody">

--- a/admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard.html
+++ b/admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<div th:fragment="content">
+
+    <!-- 검색조건 헤더 -->
+    <div class="page-header">
+        <h4 class="page-title">
+            <i class="bi bi-exclamation-circle-fill text-danger"></i>
+            검색조건
+        </h4>
+    </div>
+
+    <!-- 검색 영역 -->
+    <div th:replace="~{pages/react-cms-dashboard/react-cms-dashboard-search :: search}"></div>
+
+    <!-- 리스트 헤더 + 툴바 -->
+    <div class="page-header mt-3">
+        <h4 class="page-title">
+            <i class="bi bi-exclamation-circle-fill text-danger"></i>
+            내 페이지 목록
+        </h4>
+        <div class="page-header-actions">
+            <!-- react-cms 빌더를 새 창으로 열어 페이지를 생성 -->
+            <button class="btn btn-primary btn-sm" id="btnNewPage"
+                    th:if="${userAuthorities != null && userAuthorities.contains('REACT-CMS:W')}">
+                <i class="bi bi-plus-lg"></i> 새 페이지
+            </button>
+        </div>
+    </div>
+
+    <!-- 테이블 -->
+    <div th:replace="~{pages/react-cms-dashboard/react-cms-dashboard-table :: table}"></div>
+
+    <!-- 페이지네이션 -->
+    <div th:replace="~{fragments/page-content-layout :: pagination}"></div>
+
+    <!-- ==================== 승인 요청 모달 ==================== -->
+    <div class="modal fade" id="approveRequestModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="approveRequestModalTitle">승인 요청</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" id="approveRequestPageId"/>
+                    <div class="table-responsive">
+                        <table class="table table-sm mb-3">
+                            <tbody>
+                                <tr>
+                                    <th class="col-w-120">페이지명</th>
+                                    <td id="approveRequestPageName">-</td>
+                                </tr>
+                                <tr>
+                                    <th>승인자 <span class="text-danger">*</span></th>
+                                    <td>
+                                        <select id="approveRequestApproverId" class="form-select form-select-sm">
+                                            <option value="">승인자 선택</option>
+                                        </select>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>노출 시작일</th>
+                                    <td>
+                                        <input type="date" id="approveRequestBeginningDate"
+                                               class="form-control form-control-sm"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>노출 종료일</th>
+                                    <td>
+                                        <input type="date" id="approveRequestExpiredDate"
+                                               class="form-control form-control-sm"/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+                    <button type="button" id="btnApproveRequestConfirm" class="btn btn-primary">요청</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- ==================== 반려 사유 확인 모달 ==================== -->
+    <div class="modal fade" id="rejectedReasonModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">반려 사유</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <p id="rejectedReasonText" class="mb-0 text-break"></p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- 스크립트 -->
+    <th:block th:replace="~{pages/react-cms-dashboard/react-cms-dashboard-script :: script}"/>
+
+</div>
+</body>
+</html>

--- a/react-cms/src/cms-core/CMSBuilder.tsx
+++ b/react-cms/src/cms-core/CMSBuilder.tsx
@@ -45,11 +45,19 @@ export interface CMSBuilderProps {
   onSave?: (page: CMSPage, params: SavePageParams) => void | Promise<void>;
   /** 초기 페이지 데이터 (불러오기용) */
   initialPage?: CMSPage;
+  /**
+   * 빌더 모드.
+   * 'edit': 기존 페이지 수정 — 가져오기 버튼 비표시.
+   * 'create': 새 페이지 생성 (기본값).
+   */
+  mode?: "create" | "edit";
+  /** 편집 모드에서 저장 모달의 초기 페이지명 */
+  initialPageName?: string;
 }
 
 // ── CMSBuilder ─────────────────────────────────────────────────────────────────
 
-export function CMSBuilder({ onSave, initialPage }: CMSBuilderProps) {
+export function CMSBuilder({ onSave, initialPage, mode = "create", initialPageName }: CMSBuilderProps) {
   const blockMeta = useContext(BlockMetaContext);
   const blockRegistry = useContext(BlockRegistryContext);
   const overlayTemplates = useContext(OverlayTemplatesContext);
@@ -225,6 +233,8 @@ export function CMSBuilder({ onSave, initialPage }: CMSBuilderProps) {
           layoutType={builder.layoutType}
           editingOverlay={editingOverlay}
           onExitOverlay={builder.exitOverlay}
+          // 편집 모드에서는 외부 파일 가져오기가 기존 편집 내용을 덮어쓸 수 있어 비표시
+          showImport={mode !== "edit"}
           onImport={handleImport}
           onExport={() => downloadPageJson(page)}
           onViewCode={() => setCodeOpen(true)}
@@ -298,6 +308,7 @@ export function CMSBuilder({ onSave, initialPage }: CMSBuilderProps) {
             page={page}
             onSave={wrappedOnSave}
             onClose={() => setSaveOpen(false)}
+            initialPageName={initialPageName}
           />,
           document.body,
         )}
@@ -315,6 +326,7 @@ function Toolbar({
   layoutType,
   editingOverlay,
   onExitOverlay,
+  showImport,
   onImport,
   onExport,
   onViewCode,
@@ -326,6 +338,7 @@ function Toolbar({
   layoutType: string | undefined;
   editingOverlay?: CMSOverlay;
   onExitOverlay: () => void;
+  showImport: boolean;
   onImport: () => void;
   onExport: () => void;
   onViewCode: () => void;
@@ -361,7 +374,7 @@ function Toolbar({
         )}
       </div>
       <div className="flex items-center gap-1.5">
-        <ToolbarButton onClick={onImport}>가져오기</ToolbarButton>
+        {showImport && <ToolbarButton onClick={onImport}>가져오기</ToolbarButton>}
         <ToolbarButton onClick={onExport} disabled={blockCount === 0 && !layoutType}>
           내보내기
         </ToolbarButton>

--- a/react-cms/src/cms-core/CMSBuilder.tsx
+++ b/react-cms/src/cms-core/CMSBuilder.tsx
@@ -53,11 +53,15 @@ export interface CMSBuilderProps {
   mode?: "create" | "edit";
   /** 편집 모드에서 저장 모달의 초기 페이지명 */
   initialPageName?: string;
+  /** 현재 페이지 승인 상태 (WORK / PENDING / APPROVED / REJECTED) */
+  approveState?: string;
+  /** 반려 사유 — REJECTED 상태일 때 배너에 표시 */
+  rejectedReason?: string | null;
 }
 
 // ── CMSBuilder ─────────────────────────────────────────────────────────────────
 
-export function CMSBuilder({ onSave, initialPage, mode = "create", initialPageName }: CMSBuilderProps) {
+export function CMSBuilder({ onSave, initialPage, mode = "create", initialPageName, approveState, rejectedReason }: CMSBuilderProps) {
   const blockMeta = useContext(BlockMetaContext);
   const blockRegistry = useContext(BlockRegistryContext);
   const overlayTemplates = useContext(OverlayTemplatesContext);
@@ -205,6 +209,16 @@ export function CMSBuilder({ onSave, initialPage, mode = "create", initialPageNa
 
   const page = builder.getPage();
 
+  // APPROVED 상태에서 저장 시 확인 후 모달 열기
+  function handleSavePageClick() {
+    if (approveState === "APPROVED") {
+      if (!window.confirm(
+        "이 페이지는 승인된 상태입니다.\n수정하면 승인이 취소되고 '작업 중' 상태로 돌아갑니다.\n계속 수정하시겠습니까?"
+      )) return;
+    }
+    setSaveOpen(true);
+  }
+
   // page 선언 이후에 위치해야 TDZ 에러가 발생하지 않음
   const handlePreview = useCallback(() => {
     localStorage.setItem("cms_preview", JSON.stringify(page));
@@ -238,10 +252,25 @@ export function CMSBuilder({ onSave, initialPage, mode = "create", initialPageNa
           onImport={handleImport}
           onExport={() => downloadPageJson(page)}
           onViewCode={() => setCodeOpen(true)}
-          onSavePage={() => setSaveOpen(true)}
+          onSavePage={handleSavePageClick}
           onPreview={handlePreview}
           onClear={builder.clearBlocks}
+          approveState={approveState}
         />
+
+        {/* ── 승인 상태 배너 ── */}
+        {approveState === "PENDING" && (
+          <div className="px-4 py-2 bg-yellow-50 border-b border-yellow-200 text-xs text-yellow-800 flex items-center gap-2 flex-shrink-0">
+            <span>⏳</span>
+            <span>승인 요청 중인 페이지입니다. 승인이 완료되거나 요청이 취소된 후 수정할 수 있습니다.</span>
+          </div>
+        )}
+        {approveState === "REJECTED" && (
+          <div className="px-4 py-2 bg-red-50 border-b border-red-200 text-xs text-red-800 flex items-center gap-2 flex-shrink-0">
+            <span>⚠</span>
+            <span>반려 사유: {rejectedReason || "(사유 없음)"}</span>
+          </div>
+        )}
 
         <div className="flex flex-1 overflow-hidden">
           {/* ── 좌측: 블록 팔레트 + Overlays ── */}
@@ -333,6 +362,7 @@ function Toolbar({
   onSavePage,
   onPreview,
   onClear,
+  approveState,
 }: {
   blockCount: number;
   layoutType: string | undefined;
@@ -345,7 +375,9 @@ function Toolbar({
   onSavePage: () => void;
   onPreview: () => void;
   onClear: () => void;
+  approveState?: string;
 }) {
+  const isPending = approveState === "PENDING";
   return (
     <header className="flex items-center justify-between px-4 h-12 border-b border-gray-200 bg-white flex-shrink-0">
       <div className="flex items-center gap-2">
@@ -381,8 +413,12 @@ function Toolbar({
         <ToolbarButton onClick={onViewCode} disabled={blockCount === 0 && !layoutType}>
           코드 보기
         </ToolbarButton>
-        <ToolbarButton onClick={onSavePage} variant="success" disabled={blockCount === 0 && !layoutType}>
-          페이지 저장
+        <ToolbarButton
+          onClick={onSavePage}
+          variant="success"
+          disabled={(blockCount === 0 && !layoutType) || isPending}
+        >
+          {isPending ? "승인 요청 중" : "페이지 저장"}
         </ToolbarButton>
         <ToolbarButton onClick={onPreview} variant="primary" disabled={blockCount === 0}>
           미리보기

--- a/react-cms/src/cms-core/SavePageModal.tsx
+++ b/react-cms/src/cms-core/SavePageModal.tsx
@@ -59,7 +59,8 @@ export default function SavePageModal({ page, onClose, onSave, initialPageName }
       }
       setStatus("success");
       // 팝업으로 열린 경우 어드민 대시보드에 저장 완료 신호 전달
-      window.opener?.postMessage('reactCmsSaved', '*');
+      // 동일 Origin으로 한정하여 타 도메인 메시지 수신 차단
+      window.opener?.postMessage('reactCmsSaved', window.location.origin);
     } catch (e) {
       setErrorMsg(e instanceof Error ? e.message : "알 수 없는 오류가 발생했습니다.");
       setStatus("error");

--- a/react-cms/src/cms-core/SavePageModal.tsx
+++ b/react-cms/src/cms-core/SavePageModal.tsx
@@ -58,6 +58,8 @@ export default function SavePageModal({ page, onClose, onSave, initialPageName }
         await onSave(page, params);
       }
       setStatus("success");
+      // 팝업으로 열린 경우 어드민 대시보드에 저장 완료 신호 전달
+      window.opener?.postMessage('reactCmsSaved', '*');
     } catch (e) {
       setErrorMsg(e instanceof Error ? e.message : "알 수 없는 오류가 발생했습니다.");
       setStatus("error");

--- a/react-cms/src/cms-core/SavePageModal.tsx
+++ b/react-cms/src/cms-core/SavePageModal.tsx
@@ -23,6 +23,8 @@ interface SavePageModalProps {
   onClose: () => void;
   /** 소비자가 제공하는 저장 핸들러. 생략 시 저장 버튼은 비활성 */
   onSave?: (page: CMSPage, params: SavePageParams) => void | Promise<void>;
+  /** 편집 모드에서 기존 페이지명을 초기값으로 설정 */
+  initialPageName?: string;
 }
 
 function validate(params: SavePageParams): string | null {
@@ -34,8 +36,8 @@ function validate(params: SavePageParams): string | null {
   return null;
 }
 
-export default function SavePageModal({ page, onClose, onSave }: SavePageModalProps) {
-  const [pageName, setPageName] = useState("");
+export default function SavePageModal({ page, onClose, onSave, initialPageName }: SavePageModalProps) {
+  const [pageName, setPageName] = useState(initialPageName ?? "");
   const [uri, setUri] = useState("/");
   const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
   const [errorMsg, setErrorMsg] = useState("");

--- a/react-cms/src/main.tsx
+++ b/react-cms/src/main.tsx
@@ -40,19 +40,30 @@ function BuilderPage() {
 
   const [initialPage, setInitialPage] = useState<CMSPage | undefined>(undefined);
   const [initialPageName, setInitialPageName] = useState<string | undefined>(undefined);
+  const [approveState, setApproveState] = useState<string | undefined>(undefined);
+  const [rejectedReason, setRejectedReason] = useState<string | null>(null);
   const [loading, setLoading] = useState(!!pageId);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!pageId) return;
 
-    fetch(`${cmsBase}/api/load`, {
+    const pageLoad = fetch(`${cmsBase}/api/load`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ pageId }),
-    })
-      .then((r) => r.json())
-      .then((data: { page?: { PAGE_HTML?: string | null; PAGE_NAME?: string } | null }) => {
+    }).then((r) => r.json());
+
+    // admin 연동 모드에서만 승인 상태 조회
+    const approvalLoad = isAdminMode
+      ? fetch(`/api/react-cms-dashboard/pages/${pageId}/approval-status`).then((r) => r.json())
+      : Promise.resolve(null);
+
+    Promise.all([pageLoad, approvalLoad])
+      .then(([data, approvalData]: [
+        { page?: { PAGE_HTML?: string | null; PAGE_NAME?: string } | null },
+        { data?: { approveState?: string; rejectedReason?: string | null } } | null,
+      ]) => {
         const row = data.page;
         if (!row) {
           setError("페이지를 찾을 수 없습니다.");
@@ -69,6 +80,10 @@ function BuilderPage() {
           } catch {
             setError("페이지 데이터를 불러올 수 없습니다.");
           }
+        }
+        if (approvalData?.data) {
+          setApproveState(approvalData.data.approveState);
+          setRejectedReason(approvalData.data.rejectedReason ?? null);
         }
       })
       .catch(() => setError("페이지 불러오기 중 오류가 발생했습니다."))
@@ -97,6 +112,8 @@ function BuilderPage() {
       initialPage={initialPage}
       mode={pageId ? "edit" : "create"}
       initialPageName={initialPageName}
+      approveState={approveState}
+      rejectedReason={rejectedReason}
     />
   );
 }

--- a/react-cms/src/main.tsx
+++ b/react-cms/src/main.tsx
@@ -55,8 +55,11 @@ function BuilderPage() {
     }).then((r) => r.json());
 
     // admin 연동 모드에서만 승인 상태 조회
+    // 승인 상태는 부가 정보이므로 실패해도 에디터 진입이 가능하도록 독립 에러 처리
     const approvalLoad = isAdminMode
-      ? fetch(`/api/react-cms-dashboard/pages/${pageId}/approval-status`).then((r) => r.json())
+      ? fetch(`/api/react-cms-dashboard/pages/${pageId}/approval-status`)
+          .then((r) => r.json())
+          .catch(() => null)
       : Promise.resolve(null);
 
     Promise.all([pageLoad, approvalLoad])

--- a/react-cms/src/main.tsx
+++ b/react-cms/src/main.tsx
@@ -12,11 +12,12 @@
  *   - /builder         : CMS 에디터
  *   - /preview         : 페이지 미리보기
  */
-import { StrictMode } from "react";
+import { StrictMode, useState, useEffect } from "react";
 import { createRoot } from "react-dom/client";
-import { createBrowserRouter, RouterProvider, Navigate, Outlet } from "react-router-dom";
+import { createBrowserRouter, RouterProvider, Navigate, Outlet, useSearchParams } from "react-router-dom";
 import "./index.css";
 import { CMSApp } from "@cms-core";
+import type { CMSPage } from "@cms-core/types";
 import { CMSBuilder } from "@cms-core/CMSBuilder";
 import PreviewPage from "@cms-core/preview/PreviewPage";
 import CmsAuthGuard from "./cms-admin/CmsAuthGuard";
@@ -24,7 +25,81 @@ import NotAuthorizedPage from "./cms-admin/NotAuthorizedPage";
 import { blocks, overlays, layouts } from "./cms.config";
 import { savePage } from "./savePage";
 import userScopeCSS from "./user-scope.css?inline";
-import { isAdminMode } from "./lib/client-env";
+import { isAdminMode, cmsBase } from "./lib/client-env";
+
+/** localStorage key prefix: pageName → pageId 매핑 (savePage.ts와 동일) */
+const PAGE_ID_KEY_PREFIX = "cms_page_id_";
+
+/**
+ * pageId 쿼리 파라미터가 있으면 DB에서 해당 페이지를 조회해 편집 모드로 빌더를 시작합니다.
+ * pageId 없이 접근하면 신규 생성 모드로 빌더를 시작합니다.
+ */
+function BuilderPage() {
+  const [searchParams] = useSearchParams();
+  const pageId = searchParams.get("pageId");
+
+  const [initialPage, setInitialPage] = useState<CMSPage | undefined>(undefined);
+  const [initialPageName, setInitialPageName] = useState<string | undefined>(undefined);
+  const [loading, setLoading] = useState(!!pageId);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!pageId) return;
+
+    fetch(`${cmsBase}/api/load`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pageId }),
+    })
+      .then((r) => r.json())
+      .then((data: { page?: { PAGE_HTML?: string | null; PAGE_NAME?: string } | null }) => {
+        const row = data.page;
+        if (!row) {
+          setError("페이지를 찾을 수 없습니다.");
+          return;
+        }
+        // 재편집을 위해 pageId를 localStorage에 캐싱 — savePage.ts의 UPDATE 분기를 타도록 함
+        if (row.PAGE_NAME) {
+          localStorage.setItem(`${PAGE_ID_KEY_PREFIX}${row.PAGE_NAME}`, pageId);
+          setInitialPageName(row.PAGE_NAME);
+        }
+        if (row.PAGE_HTML) {
+          try {
+            setInitialPage(JSON.parse(row.PAGE_HTML) as CMSPage);
+          } catch {
+            setError("페이지 데이터를 불러올 수 없습니다.");
+          }
+        }
+      })
+      .catch(() => setError("페이지 불러오기 중 오류가 발생했습니다."))
+      .finally(() => setLoading(false));
+  }, [pageId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-screen text-sm text-gray-500">
+        페이지를 불러오는 중...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center h-screen text-sm text-red-500">
+        {error}
+      </div>
+    );
+  }
+
+  return (
+    <CMSBuilder
+      onSave={savePage}
+      initialPage={initialPage}
+      mode={pageId ? "edit" : "create"}
+      initialPageName={initialPageName}
+    />
+  );
+}
 
 // BASE_URL은 Vite가 vite.config.ts의 base 설정값으로 주입한다.
 // VITE_BASE=/react-cms/ 로 실행 시 '/react-cms/' — nginx 프록시를 거쳐 admin과 연동되는 모드.
@@ -49,7 +124,7 @@ const router = createBrowserRouter(
         { index: true, element: <Navigate to="/builder" replace /> },
         {
           path: "builder",
-          element: <CMSBuilder onSave={savePage} />,
+          element: <BuilderPage />,
         },
         {
           path: "preview",

--- a/react-cms/src/main.tsx
+++ b/react-cms/src/main.tsx
@@ -100,8 +100,22 @@ function BuilderPage() {
 
   if (error) {
     return (
-      <div className="flex items-center justify-center h-screen text-sm text-red-500">
-        {error}
+      <div className="flex flex-col items-center justify-center h-screen gap-4">
+        <p className="text-sm text-red-500">{error}</p>
+        <div className="flex gap-2">
+          <button
+            className="px-4 py-2 text-xs rounded-lg bg-primary text-white hover:bg-primary-dark transition-colors"
+            onClick={() => { window.location.href = window.location.pathname; }}
+          >
+            새 페이지 생성
+          </button>
+          <button
+            className="px-4 py-2 text-xs rounded-lg bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors"
+            onClick={() => window.history.back()}
+          >
+            돌아가기
+          </button>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

Closes #100

## ✨ 변경 사항 (Changes)

### React CMS 사용자 대시보드 구현
- `GET /api/react-cms-dashboard/pages` — 내 페이지 목록 조회 (페이징·검색·정렬)
- `DELETE /api/react-cms-dashboard/pages/{pageId}` — 소프트/하드 삭제 분기 처리
- `PATCH /api/react-cms-dashboard/pages/{pageId}/approve-request` — 승인 요청 (WORK/REJECTED/APPROVED → PENDING)
- Admin 대시보드 UI: 검색, 테이블, 모달(승인 요청·반려 사유 확인) 구현

### 빌더-어드민 승인 상태 연동
- `GET /api/react-cms-dashboard/pages/{pageId}/approval-status` — 승인 상태 조회 API 추가
- react-cms 빌더에서 편집 모드 진입 시 승인 상태 fetch 후 UI 제어
  - `PENDING`: 저장 버튼 비활성화 + 안내 배너
  - `APPROVED`: 저장 클릭 시 확인 모달
  - `REJECTED`: 반려 사유 배너 표시
- 빌더 저장 완료 시 `postMessage`로 Admin 팝업 자동 닫힘 + 목록 새로고침

### 승인자 목록 분리
- `GET /api/auth/react-cms-approvers` 추가 — `v3_react_cms_admin_approvals` 권한 기준 조회 (기존 CMS와 별도)

### 코드 리뷰 수정 (Critical·Warning)
- XSS: onclick 인라인 → `data-page-id` + 이벤트 위임 방식으로 교체
- 보안: `postMessage` Origin `'*'` → `window.location.origin` 제한
- Race Condition: `deleteSoft/deleteHard` void → int 반환, 삭제 결과 검증
- 검증: 날짜 필드 `String` → `LocalDate` 변환, 시작일/종료일 대소 검증, Mapper XML `TO_DATE` 제거
- 동적 정렬 `${orderDir}` 문자열 치환 → `<if>` 분기 교체 (SQL Injection 방지)
- 에러 메시지에서 내부 ID(`pageId`, `approverId`) 노출 제거
- 중복 클릭 방지: `_isSubmittingApproval` 플래그 + 버튼 비활성화
- 승인자 목록 세션 캐싱으로 모달 열 때마다 API 재호출 제거

## ⚠️ 고려 및 주의 사항 (선택)

- react-cms 빌더(`/react-cms/builder`)는 Admin에서 팝업으로 열리는 구조로, `window.opener.postMessage` 연동을 전제로 함
- `ReactCmsDashboardApproveRequestDto`의 날짜 타입이 `String → LocalDate`로 변경됨 — 기존 호출부 확인 필요

## 💬 리뷰 포인트 (선택)

- `deletePage` 소유권 검증을 `checkPageOwner` 분리 호출 대신 DELETE/UPDATE 결과값으로 검증하는 방식으로 변경한 부분
- MyBatis XML 동적 정렬을 `${orderDir}` → `<if>` 분기로 바꾼 방식이 적절한지