### PR TITLE
fix: cms-approval 롤백 시 PAGE_HTML CLOB ClassCastException 수정 (#124)

### DIFF
--- a/admin/src/main/java/com/example/admin_demo/domain/cmsapproval/dto/CmsApprovalRollbackHistoryResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsapproval/dto/CmsApprovalRollbackHistoryResponse.java
@@ -1,0 +1,28 @@
+package com.example.admin_demo.domain.cmsapproval.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 롤백용 이력 스냅샷 조회 결과
+ *
+ * <p>resultType=map 으로 받으면 PAGE_HTML(CLOB)이 java.sql.Clob 으로 반환되어
+ * String 캐스트 시 ClassCastException 이 발생한다.
+ * 전용 DTO 를 사용하면 MyBatis 가 CLOB → String 자동 변환을 수행한다.</p>
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CmsApprovalRollbackHistoryResponse {
+
+    /** 복원할 페이지 HTML (CLOB) */
+    private String pageHtml;
+
+    /** 복원할 파일 경로 */
+    private String filePath;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsapproval/mapper/CmsApprovalMapper.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsapproval/mapper/CmsApprovalMapper.java
@@ -3,8 +3,8 @@ package com.example.admin_demo.domain.cmsapproval.mapper;
 import com.example.admin_demo.domain.cmsapproval.dto.CmsApprovalHistoryResponse;
 import com.example.admin_demo.domain.cmsapproval.dto.CmsApprovalListRequest;
 import com.example.admin_demo.domain.cmsapproval.dto.CmsApprovalPageResponse;
+import com.example.admin_demo.domain.cmsapproval.dto.CmsApprovalRollbackHistoryResponse;
 import java.util.List;
-import java.util.Map;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -58,7 +58,8 @@ public interface CmsApprovalMapper {
     List<CmsApprovalHistoryResponse> findHistoryList(@Param("pageId") String pageId);
 
     /** 특정 버전 이력 조회 (롤백용 PAGE_HTML, FILE_PATH) */
-    Map<String, Object> findHistoryByVersion(@Param("pageId") String pageId, @Param("version") int version);
+    CmsApprovalRollbackHistoryResponse findHistoryByVersion(
+            @Param("pageId") String pageId, @Param("version") int version);
 
     /** 롤백 — 지정 버전으로 복원 후 APPROVE_STATE → WORK */
     void rollback(

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsapproval/service/CmsApprovalService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsapproval/service/CmsApprovalService.java
@@ -3,6 +3,7 @@ package com.example.admin_demo.domain.cmsapproval.service;
 import com.example.admin_demo.domain.cmsapproval.dto.CmsApprovalHistoryResponse;
 import com.example.admin_demo.domain.cmsapproval.dto.CmsApprovalListRequest;
 import com.example.admin_demo.domain.cmsapproval.dto.CmsApprovalPageResponse;
+import com.example.admin_demo.domain.cmsapproval.dto.CmsApprovalRollbackHistoryResponse;
 import com.example.admin_demo.domain.cmsapproval.dto.CmsApproveRequest;
 import com.example.admin_demo.domain.cmsapproval.dto.CmsDisplayPeriodRequest;
 import com.example.admin_demo.domain.cmsapproval.dto.CmsPublicStateRequest;
@@ -16,7 +17,6 @@ import com.example.admin_demo.global.exception.NotFoundException;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -96,12 +96,12 @@ public class CmsApprovalService {
     @Transactional
     public void rollback(String pageId, CmsRollbackRequest req, String modifierId) {
         checkPageExists(pageId);
-        Map<String, Object> history = cmsApprovalMapper.findHistoryByVersion(pageId, req.getVersion());
+        CmsApprovalRollbackHistoryResponse history = cmsApprovalMapper.findHistoryByVersion(pageId, req.getVersion());
         if (history == null) {
             throw new NotFoundException("해당 버전의 이력을 찾을 수 없습니다. pageId=" + pageId + ", version=" + req.getVersion());
         }
-        String pageHtml = (String) history.get("PAGE_HTML");
-        String filePath = (String) history.get("FILE_PATH");
+        String pageHtml = history.getPageHtml();
+        String filePath = history.getFilePath();
         cmsApprovalMapper.rollback(pageId, pageHtml, filePath, modifierId);
         log.info("CMS 페이지 롤백 완료: pageId={}, version={}, modifierId={}", pageId, req.getVersion(), modifierId);
     }

--- a/admin/src/main/resources/mapper/oracle/cmsapproval/CmsApprovalMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/cmsapproval/CmsApprovalMapper.xml
@@ -213,10 +213,12 @@
         ORDER BY h.VERSION DESC
     </select>
 
-    <select id="findHistoryByVersion" resultType="map">
+    <!-- resultType=map 사용 시 PAGE_HTML(CLOB)이 java.sql.Clob 으로 반환되어 String 캐스트 시 ClassCastException 발생 → 전용 DTO 사용 -->
+    <select id="findHistoryByVersion"
+            resultType="com.example.admin_demo.domain.cmsapproval.dto.CmsApprovalRollbackHistoryResponse">
         SELECT
-            h.PAGE_HTML,
-            h.FILE_PATH
+            h.PAGE_HTML  AS pageHtml,
+            h.FILE_PATH  AS filePath
         FROM SPW_CMS_PAGE_HISTORY h
         WHERE h.PAGE_ID = #{pageId}
           AND h.VERSION  = #{version}

--- a/admin/src/test/java/com/example/admin_demo/domain/cmsapproval/service/CmsApprovalServiceTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/cmsapproval/service/CmsApprovalServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.BDDMockito.then;
 import com.example.admin_demo.domain.cmsapproval.dto.CmsApprovalHistoryResponse;
 import com.example.admin_demo.domain.cmsapproval.dto.CmsApprovalListRequest;
 import com.example.admin_demo.domain.cmsapproval.dto.CmsApprovalPageResponse;
+import com.example.admin_demo.domain.cmsapproval.dto.CmsApprovalRollbackHistoryResponse;
 import com.example.admin_demo.domain.cmsapproval.dto.CmsApproveRequest;
 import com.example.admin_demo.domain.cmsapproval.dto.CmsDisplayPeriodRequest;
 import com.example.admin_demo.domain.cmsapproval.dto.CmsPublicStateRequest;
@@ -22,7 +23,6 @@ import com.example.admin_demo.global.dto.PageResponse;
 import com.example.admin_demo.global.exception.NotFoundException;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -271,7 +271,10 @@ class CmsApprovalServiceTest {
     void rollback_normal_restoresVersion() {
         CmsRollbackRequest req = new CmsRollbackRequest();
         req.setVersion(1);
-        Map<String, Object> history = Map.of("PAGE_HTML", "<html/>", "FILE_PATH", "/path/to/file.html");
+        CmsApprovalRollbackHistoryResponse history = CmsApprovalRollbackHistoryResponse.builder()
+                .pageHtml("<html/>")
+                .filePath("/path/to/file.html")
+                .build();
 
         given(cmsApprovalMapper.existsByPageId(PAGE_ID)).willReturn(1);
         given(cmsApprovalMapper.findHistoryByVersion(PAGE_ID, 1)).willReturn(history);


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #124

## ✨ 변경 사항 (Changes)
- `CmsApprovalRollbackHistoryResponse` DTO 신규 생성 (`pageHtml`, `filePath`)
- `CmsApprovalMapper.xml` — `findHistoryByVersion` `resultType="map"` → 전용 DTO로 변경, 컬럼 alias 추가 (MyBatis가 CLOB → String 자동 변환 수행)
- `CmsApprovalMapper.java` — 반환 타입 `Map<String, Object>` → `CmsApprovalRollbackHistoryResponse`
- `CmsApprovalService.java` — `(String) history.get("PAGE_HTML")` 캐스트 제거, DTO getter 사용으로 전환

## ⚠️ 고려 및 주의 사항 (선택)
- `resultType=map` 사용 시 Oracle CLOB 컬럼이 `java.sql.Clob`으로 반환되어 `String` 캐스트 불가 — 동일한 패턴이 `CmsDeployMapper.xml:107-110` 주석에 이미 문서화되어 있음
- DTO 방식은 MyBatis 타입 핸들러가 CLOB → String 변환을 커넥션이 열려 있는 동안 처리하므로 안전

## 🔗 참고 사항 (선택)
- 버그 발생 위치: `CmsApprovalService.java:103`, `CmsApprovalMapper.xml:216`
- 동일 패턴 참고: `CmsDeployMapper.xml:107-110`