### PR TITLE
fix: #110 follow-up — 리뷰 반영 및 누락 커밋 병합

### DIFF
--- a/admin/src/main/java/com/example/admin_demo/infra/tcp/adapter/BatchManagementAdapter.java
+++ b/admin/src/main/java/com/example/admin_demo/infra/tcp/adapter/BatchManagementAdapter.java
@@ -58,9 +58,21 @@ public class BatchManagementAdapter implements ManagementAdapter<ManagementConte
                     .build();
         }
 
-        // FWK_WAS_INSTANCE.PORT는 HTTP 모니터링 포트(8081)를 저장하므로 TCP 포트로 사용하지 않는다.
-        // TCP 포트는 application.yml의 tcp.batch-was.port(기본값 9998) 설정값만 사용한다.
+        // FWK_WAS_INSTANCE.PORT는 TCP 관리 포트(9998)를 저장한다.
+        // 인스턴스별 포트가 설정된 경우 우선 사용, 없으면 전역 설정 포트로 폴백.
+        // (HTTP 모니터링 포트는 BatchRunningService가 별도 설정값 batch.was.http-port로 관리)
         int port = batchWasTcpPort;
+        if (instance.getPort() != null && !instance.getPort().isBlank()) {
+            try {
+                port = Integer.parseInt(instance.getPort().trim());
+            } catch (NumberFormatException e) {
+                log.warn(
+                        "[BatchManagementAdapter] 인스턴스 포트 파싱 실패, 전역 포트({}) 사용: instanceId={}, port={}",
+                        batchWasTcpPort,
+                        ctx.getInstanceId(),
+                        instance.getPort());
+            }
+        }
 
         try {
             log.info("[BatchManagementAdapter] TCP 전송: host={}, port={}, command={}", instance.getIp(), port, command);

--- a/admin/src/main/java/com/example/admin_demo/infra/tcp/adapter/DemoBackendAdapter.java
+++ b/admin/src/main/java/com/example/admin_demo/infra/tcp/adapter/DemoBackendAdapter.java
@@ -30,7 +30,7 @@ public class DemoBackendAdapter implements ManagementAdapter<JsonCommandRequest,
     @Value("${tcp.demo-backend.host:localhost}")
     private String demoBackendHost;
 
-    @Value("${tcp.demo-backend.port:9997}")
+    @Value("${tcp.demo-backend.port:9996}")
     private int demoBackendPort;
 
     /** spider-link는 항상 별도 프로세스이므로 로컬 실행 없음 */

--- a/admin/src/main/java/com/example/admin_demo/infra/tcp/client/TcpClientRunner.java
+++ b/admin/src/main/java/com/example/admin_demo/infra/tcp/client/TcpClientRunner.java
@@ -30,7 +30,7 @@ public class TcpClientRunner implements ApplicationRunner {
     @Value("${tcp.demo-backend.host:localhost}")
     private String demoHost;
 
-    @Value("${tcp.demo-backend.port:9997}")
+    @Value("${tcp.demo-backend.port:9996}")
     private int demoPort;
 
     @Override

--- a/batch-was/src/main/java/com/example/batchwas/domain/batch/service/BatchExecuteService.java
+++ b/batch-was/src/main/java/com/example/batchwas/domain/batch/service/BatchExecuteService.java
@@ -18,6 +18,7 @@ import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.configuration.JobRegistry;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.launch.NoSuchJobException;
@@ -120,7 +121,7 @@ public class BatchExecuteService {
 
         // 6. Job 완료 후 StepExecution 기준으로 처리 건수 집계 후 메트릭 기록
         long wc = jobExecution.getStepExecutions().stream()
-                .mapToLong(s -> s.getWriteCount())
+                .mapToLong(StepExecution::getWriteCount)
                 .sum();
         long sc = jobExecution.getStepExecutions().stream()
                 .mapToLong(s -> s.getReadSkipCount() + s.getProcessSkipCount() + s.getWriteSkipCount())

--- a/batch-was/src/main/java/com/example/batchwas/domain/batch/service/BatchMonitorService.java
+++ b/batch-was/src/main/java/com/example/batchwas/domain/batch/service/BatchMonitorService.java
@@ -75,8 +75,8 @@ public class BatchMonitorService {
     /**
      * 지정한 jobExecutionId의 배치 Job을 강제 종료한다.
      *
-     * <p>JobOperator.stop() 호출 전에 FWK_BATCH_HIS를 ABNORMAL 상태로 UPDATE하여
-     * stop() 이 예외를 던지더라도(이미 종료된 경우 등) DB 이력은 즉시 반영된다.</p>
+     * <p>JobOperator.stop() 성공 후 FWK_BATCH_HIS를 ABNORMAL로 UPDATE하여
+     * stop()이 실패(이미 종료 등)한 경우 DB 이력이 오염되지 않도록 한다.</p>
      *
      * @param jobExecutionId 종료할 JobExecution ID
      * @return 강제 종료 결과 (jobExecutionId + 메시지)
@@ -99,8 +99,26 @@ public class BatchMonitorService {
         boolean hasHisRecord = (batchAppId != null && batchDate != null && batchExecuteSeqLong != null);
         int batchExecuteSeq = hasHisRecord ? batchExecuteSeqLong.intValue() : 0;
 
-        // 3. FWK_BATCH_HIS UPDATE — UX 즉시 반영을 위해 JobOperator.stop() 보다 먼저 수행
-        if (hasHisRecord) {
+        // 3. Spring Batch Job 강제 종료 요청 — stop() 성공 확인 후 DB UPDATE
+        String message;
+        boolean stopSucceeded = false;
+        try {
+            jobOperator.stop(jobExecutionId);
+            stopSucceeded = true;
+            log.info("배치 강제 종료 요청 완료: jobExecutionId={}, batchAppId={}", jobExecutionId, batchAppId);
+            message = "강제 종료 요청이 완료되었습니다.";
+        } catch (NoSuchJobExecutionException e) {
+            // JobExplorer로는 존재하나 JobOperator 내부 상태와 불일치하는 극히 드문 케이스
+            log.warn("배치 강제 종료 - JobExecution을 찾을 수 없음 (이미 종료됐을 수 있음): jobExecutionId={}", jobExecutionId, e);
+            message = "이미 종료된 배치입니다.";
+        } catch (JobExecutionNotRunningException e) {
+            // 조회 시점과 종료 시점 사이에 배치가 완료된 경우
+            log.warn("배치 강제 종료 - 이미 실행 중이 아님: jobExecutionId={}", jobExecutionId, e);
+            message = "배치가 이미 실행 중이 아닙니다.";
+        }
+
+        // 4. stop() 성공한 경우에만 FWK_BATCH_HIS UPDATE — 정상 완료된 Job의 이력이 ABNORMAL로 오염되는 것을 방지
+        if (stopSucceeded && hasHisRecord) {
             String batchEndDtime = LocalDateTime.now().format(BatchConstants.END_DATE_TIME_FORMATTER);
             int updated = batchHisMapper.updateBatchHisResult(
                     batchAppId, instanceId, batchDate, batchExecuteSeq,
@@ -110,25 +128,9 @@ public class BatchMonitorService {
                     "ADMIN");
 
             if (updated == 0) {
-                // PK 불일치 시 경고만 남기고 강제 종료는 계속 진행
+                // PK 불일치 시 경고만 남기고 진행
                 log.warn("[WARN] FWK_BATCH_HIS UPDATE 0건 — batchAppId={}, seq={}", batchAppId, batchExecuteSeq);
             }
-        }
-
-        // 4. Spring Batch Job 강제 종료 요청
-        String message;
-        try {
-            jobOperator.stop(jobExecutionId);
-            log.info("배치 강제 종료 요청 완료: jobExecutionId={}, batchAppId={}", jobExecutionId, batchAppId);
-            message = "강제 종료 요청이 완료되었습니다.";
-        } catch (NoSuchJobExecutionException e) {
-            // JobExplorer로는 존재하나 JobOperator 내부 상태와 불일치하는 극히 드문 케이스
-            log.warn("배치 강제 종료 - JobExecution을 찾을 수 없음 (이미 종료됐을 수 있음): jobExecutionId={}", jobExecutionId, e);
-            message = "이미 종료된 배치입니다. (DB 이력은 강제 종료 처리됨)";
-        } catch (JobExecutionNotRunningException e) {
-            // 조회 시점과 종료 시점 사이에 배치가 완료된 경우
-            log.warn("배치 강제 종료 - 이미 실행 중이 아님: jobExecutionId={}", jobExecutionId, e);
-            message = "배치가 이미 실행 중이 아닙니다. (DB 이력은 강제 종료 처리됨)";
         }
 
         return BatchStopResponse.builder()

--- a/spider-link/pom.xml
+++ b/spider-link/pom.xml
@@ -97,9 +97,13 @@
                             <artifactId>lombok</artifactId>
                         </exclude>
                     </excludes>
+                    <jvmArguments>
+                        -Dfile.encoding=UTF-8
+                        -Dstdout.encoding=UTF-8
+                        -Dstderr.encoding=UTF-8
+                    </jvmArguments>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-
 </project>


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

- #110

## ✨ 변경 사항 (Changes)

PR #123이 머지된 이후 추가된 커밋 3건을 main에 반영한다.

### BatchManagementAdapter 포트 로직 복원
FWK_WAS_INSTANCE.PORT 컬럼값이 9998(TCP)로 수정됨에 따라, `instance.getPort()`를 TCP 포트로 읽는 원본 로직 복원. HTTP 모니터링 포트는 `BatchRunningService`가 별도 `batch.was.http-port` 설정값으로 관리한다.

### PR 리뷰 반영
- `DemoBackendAdapter`, `TcpClientRunner`: `@Value` 폴백 `9997` → `9996` (spider-link 포트)
- `BatchMonitorService`: `stop()` 성공 후 FWK_BATCH_HIS UPDATE로 순서 변경 (레이스 컨디션 해결)
- `BatchExecuteService`: 람다 → `StepExecution::getWriteCount` 메서드 레퍼런스

### spider-link pom.xml
JVM 인코딩 옵션(`-Dfile.encoding=UTF-8` 등) 추가.

## 🔗 참고 사항 (선택)

- 원본 PR: #123 (feat: spider-link 프로젝트 분리 및 배치 TCP 버그 수정)