### PR TITLE
feat: Netty TCP 백엔드 신규 모듈 추가 및 프론트엔드 Vite 프록시 연동

### DIFF
--- a/demo/front/src/api/axiosInstance.ts
+++ b/demo/front/src/api/axiosInstance.ts
@@ -21,7 +21,9 @@ import axios, {
   type InternalAxiosRequestConfig,
 } from 'axios';
 
-export const API_BASE    = 'http://localhost:3001/api';
+// 상대 경로로 설정하여 Vite 개발 서버 프록시를 통해 요청이 전달되도록 한다.
+// 절대 URL 사용 시 브라우저가 프록시를 우회해 직접 백엔드로 요청하여 CORS 오류 발생.
+export const API_BASE    = '/api';
 const        STORAGE_KEY = 'hnc_auth';
 
 // ── 모듈 레벨 인증 콜백 ─────────────────────────────────────────────────────

--- a/demo/front/vite.config.ts
+++ b/demo/front/vite.config.ts
@@ -26,11 +26,11 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      /* /api/notices/* 요청을 Demo Backend로 프록시
-         SSE(EventSource)는 브라우저가 GET 요청을 직접 보내므로
-         CORS 없이 프록시를 통해 연결한다. */
-      '/api/notices': {
-        target:      'http://localhost:3001',
+      /* 모든 /api/* 요청을 Demo Backend로 프록시
+         - CORS 헤더 없이 브라우저 → Vite Dev Server → Backend 흐름으로 처리
+         - SSE(EventSource) 포함 모든 API 엔드포인트 커버 */
+      '/api': {
+        target:      'http://localhost:9998',
         changeOrigin: true,
       },
     },

--- a/demo/tcp-backend/.idea/.gitignore
+++ b/demo/tcp-backend/.idea/.gitignore
@@ -1,0 +1,10 @@
+# 디폴트 무시된 파일
+/shelf/
+/workspace.xml
+# 쿼리 파일을 포함한 무시된 디폴트 폴더
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# 에디터 기반 HTTP 클라이언트 요청
+/httpRequests/

--- a/demo/tcp-backend/.idea/compiler.xml
+++ b/demo/tcp-backend/.idea/compiler.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Maven default annotation processors profile" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <module name="tcp-backend" />
+      </profile>
+    </annotationProcessing>
+  </component>
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_OVERRIDE">
+      <module name="tcp-backend" options="-parameters" />
+    </option>
+  </component>
+</project>

--- a/demo/tcp-backend/.idea/encodings.xml
+++ b/demo/tcp-backend/.idea/encodings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
+  </component>
+</project>

--- a/demo/tcp-backend/.idea/jarRepositories.xml
+++ b/demo/tcp-backend/.idea/jarRepositories.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Central Repository" />
+      <option name="url" value="https://repo.maven.apache.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+  </component>
+</project>

--- a/demo/tcp-backend/.idea/misc.xml
+++ b/demo/tcp-backend/.idea/misc.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_19" default="true" project-jdk-name="19" project-jdk-type="JavaSDK" />
+</project>

--- a/demo/tcp-backend/.idea/vcs.xml
+++ b/demo/tcp-backend/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
+  </component>
+</project>

--- a/demo/tcp-backend/.mvn/wrapper/maven-wrapper.properties
+++ b/demo/tcp-backend/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip

--- a/demo/tcp-backend/README.md
+++ b/demo/tcp-backend/README.md
@@ -1,0 +1,271 @@
+# tcp-backend
+
+HNC POC Demo 백엔드 서버 — Netty 기반 TCP/IP 서버 (4바이트 길이 헤더 + JSON)
+
+---
+
+## 개요
+
+기존 HTTP REST API를 대체하는 TCP/IP 통신 기반 백엔드 POC 프로젝트입니다.  
+웹 브라우저 호환성을 위한 HTTP REST API도 선택적으로 제공합니다.
+
+| 항목 | 내용 |
+|---|---|
+| Java | 17 |
+| Spring Boot | 3.2.5 |
+| TCP 서버 | Netty |
+| DB | Oracle (ojdbc11) |
+| 빌드 | Maven |
+
+---
+
+## 포트
+
+| 포트 | 프로토콜 | 용도 |
+|---|---|---|
+| `19998` | TCP | Netty TCP 서버 (메인) |
+| `9998` | HTTP | Spring MVC REST API (보조, 웹 브라우저용) |
+
+---
+
+## 실행 방법
+
+### 사전 요구사항
+
+- Java 17+
+- Oracle DB 접근 가능 환경
+
+### 빌드 및 실행
+
+```bash
+./mvnw clean package -DskipTests
+java -jar target/tcp-backend-0.0.1-SNAPSHOT.jar
+```
+
+### 주요 설정 (application.yml)
+
+```yaml
+server:
+  port: 9998            # HTTP REST API 포트
+
+tcp:
+  port: 19998           # Netty TCP 포트
+  boss-threads: 1       # 연결 수락 스레드 수
+  worker-threads: 4     # I/O 처리 스레드 수
+  max-frame-length: 1048576  # 최대 메시지 크기 (1MB)
+
+auth:
+  pin-max-attempts: 3   # PIN 최대 오류 횟수
+  admin-secret: ...     # 관리자 명령 인증 시크릿
+```
+
+---
+
+## TCP 프로토콜
+
+### 프레임 구조
+
+```
+[ 4 bytes: 본문 길이 (big-endian) ] [ N bytes: UTF-8 JSON 본문 ]
+```
+
+- 길이 헤더는 헤더 자신(4바이트)을 포함하지 않음
+- 최대 프레임 크기: 1MB (설정 변경 가능)
+
+### 요청 형식 (Client → Server)
+
+```json
+{
+  "cmd": "LOGIN",
+  "sessionId": "uuid 또는 null",
+  "adminSecret": "관리자 시크릿 또는 null",
+  "payload": { }
+}
+```
+
+### 응답 형식 (Server → Client)
+
+```json
+{
+  "cmd": "LOGIN",
+  "success": true,
+  "sessionId": "uuid (로그인 응답에만 포함)",
+  "data": { },
+  "error": null
+}
+```
+
+---
+
+## TCP 명령어 목록
+
+### 인증 (Auth)
+
+| 명령 | 인증 필요 | 설명 |
+|---|---|---|
+| `LOGIN` | X | 로그인. `payload: { userId, password }` |
+| `LOGOUT` | O | 로그아웃. 세션 무효화 |
+| `GET_PROFILE` | O | 사용자 프로필 조회 |
+
+**LOGIN 응답 예시:**
+```json
+{
+  "cmd": "LOGIN",
+  "success": true,
+  "sessionId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "data": {
+    "userId": "user01",
+    "userName": "홍길동",
+    "userGrade": "A",
+    "lastLogin": "20240101120000"
+  }
+}
+```
+
+---
+
+### 카드 (Card)
+
+| 명령 | 설명 |
+|---|---|
+| `GET_CARDS` | 보유 카드 목록 조회 |
+| `GET_PAYABLE_AMOUNT` | 결제 가능 금액 조회. `payload: { cardId }` |
+| `IMMEDIATE_PAY` | 즉시 결제 실행. `payload: { cardId, pin, amount, accountNumber }` |
+| `RESET_PIN_ATTEMPTS` | PIN 오류 횟수 초기화. `payload: { cardId }` |
+
+**즉시 결제 참고사항:**
+- PIN은 오늘 날짜의 `MMDD` 형식 (예: 4월 21일 → `"0421"`)
+- PIN 오류 3회 시 잠금 처리 (`attemptsLeft` 포함하여 오류 반환)
+- 결제는 이용일자 순으로 순차 처리 (DB `FOR UPDATE` 락 사용)
+
+---
+
+### 거래내역 (Transaction)
+
+| 명령 | 설명 |
+|---|---|
+| `GET_TRANSACTIONS` | 카드 이용 내역 조회 |
+| `GET_PAYMENT_STATEMENT` | 청구서 조회 |
+
+**GET_TRANSACTIONS payload:**
+```json
+{
+  "cardId": "카드번호 또는 null (전체)",
+  "period": "thisMonth | 1month | 3months | custom",
+  "customMonth": "YYYYMM (period=custom일 때)",
+  "fromDate": "YYYYMMDD (period=custom일 때)",
+  "toDate": "YYYYMMDD (period=custom일 때)",
+  "usageType": "lump | installment | cancel (선택)"
+}
+```
+
+**GET_PAYMENT_STATEMENT payload:**
+```json
+{
+  "yearMonth": "YYYYMM",
+  "paymentDay": 15
+}
+```
+
+---
+
+### 긴급공지 (Notice)
+
+| 명령 | 관리자 필요 | 설명 |
+|---|---|---|
+| `NOTICE_SUBSCRIBE` | X | 공지 수신 채널 등록 (연결 유지) |
+| `NOTICE_SYNC` | O | 긴급공지 배포 (전체 구독자에게 브로드캐스트) |
+| `NOTICE_END` | O | 긴급공지 종료 |
+| `NOTICE_PREVIEW` | O | 현재 저장된 공지 내용 조회 |
+
+- 관리자 명령은 요청에 `adminSecret` 필드 필요
+- 브로드캐스트 대상: TCP 구독 채널 + HTTP SSE 구독자
+
+**NOTICE_SYNC payload:**
+```json
+{
+  "notices": [
+    { "lang": "ko", "title": "제목", "content": "내용" }
+  ],
+  "displayType": "A",
+  "closeableYn": "Y",
+  "hideTodayYn": "N"
+}
+```
+
+---
+
+## 세션 관리
+
+- 로그인 성공 시 서버에서 `sessionId` (UUID) 발급
+- 이후 모든 인증 필요 명령에 `sessionId` 포함하여 요청
+- TCP 연결 종료 시 세션 자동 무효화
+- 중복 로그인 방지: 동일 userId로 새로 로그인 시 기존 세션 무효화
+
+---
+
+## HTTP REST API (보조)
+
+웹 브라우저에서 직접 접근이 필요한 기능만 REST로 제공합니다.
+
+| 메서드 | 경로 | 설명 |
+|---|---|---|
+| `POST` | `/api/auth/login` | 로그인 |
+| `POST` | `/api/auth/refresh` | 액세스 토큰 갱신 (httpOnly 쿠키 사용) |
+| `POST` | `/api/auth/logout` | 로그아웃 |
+| `GET` | `/api/auth/me` | 현재 사용자 정보 |
+| `GET` | `/api/notices/sse` | 긴급공지 SSE 스트림 구독 |
+
+CORS 허용 출처: `http://localhost:5173`
+
+---
+
+## 프로젝트 구조
+
+```
+src/main/java/com/example/tcpbackend/
+├── TcpBackendApplication.java       # 애플리케이션 진입점
+├── config/
+│   ├── AppProperties.java           # 설정값 바인딩 (tcp.*, auth.*)
+│   ├── JacksonConfig.java           # ObjectMapper 전역 설정
+│   ├── NettyTcpServerConfig.java    # Netty 서버 생명주기 관리
+│   └── WebConfig.java               # CORS, 인터셉터 설정
+├── domain/
+│   ├── auth/                        # 인증 도메인
+│   ├── card/                        # 카드 도메인
+│   ├── transaction/                 # 거래내역 도메인
+│   └── notice/                      # 긴급공지 도메인
+├── handler/
+│   ├── AuthHandler.java             # 인증 명령 처리
+│   ├── CardHandler.java             # 카드 명령 처리
+│   ├── TransactionHandler.java      # 거래내역 명령 처리
+│   └── NoticeHandler.java           # 공지 명령 처리
+├── tcp/
+│   ├── TcpMessageHandler.java       # TCP 명령 라우터
+│   ├── TcpRequest.java              # 요청 DTO
+│   ├── TcpResponse.java             # 응답 DTO
+│   ├── TcpServerInitializer.java    # Netty 파이프라인 구성
+│   ├── codec/
+│   │   ├── LengthPrefixDecoder.java # 4바이트 길이 헤더 디코더
+│   │   └── LengthPrefixEncoder.java # 4바이트 길이 헤더 인코더
+│   └── session/
+│       ├── TcpSessionManager.java   # 세션 + 공지 구독자 관리
+│       └── SessionInfo.java         # 세션 데이터
+└── web/
+    ├── controller/                  # REST 컨트롤러
+    ├── filter/                      # 요청 로깅 필터
+    └── interceptor/                 # 세션 인증 인터셉터
+```
+
+---
+
+## 주요 DB 테이블
+
+| 테이블 | 설명 |
+|---|---|
+| `POC_USER` | 사용자 계정 및 프로필 |
+| `POC_카드리스트` | 카드 정보 |
+| `POC_카드사용내역` | 카드 이용 내역 |
+| `POC_뱅킹계좌정보` | 뱅킹 계좌 정보 |
+| `POC_뱅킹거래내역` | 뱅킹 거래 이력 |
+| `FWK_PROPERTY` | 시스템 설정 (긴급공지 상태 포함) |

--- a/demo/tcp-backend/mvnw
+++ b/demo/tcp-backend/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/demo/tcp-backend/mvnw.cmd
+++ b/demo/tcp-backend/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/demo/tcp-backend/pom.xml
+++ b/demo/tcp-backend/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.2.5</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>com.example</groupId>
+  <artifactId>tcp-backend</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>tcp-backend</name>
+  <description>HNC POC Demo Backend - TCP/IP Server (Netty 기반, 4바이트 길이 헤더 + JSON)</description>
+
+  <properties>
+    <java.version>17</java.version>
+    <!-- Spring Boot 3.2.5가 관리하는 Netty 버전(4.1.x)을 그대로 사용 -->
+  </properties>
+
+  <dependencies>
+
+    <!-- ── Spring Boot 기반 ─────────────────────────────────────────── -->
+    <!-- DI, 자동 설정, 라이프사이클 관리 (웹 서버 제외) -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+
+    <!-- Spring MVC + 내장 Tomcat: REST 컨트롤러 및 SSE 엔드포인트 제공 -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+
+    <!-- Spring JDBC + HikariCP 커넥션 풀 -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-jdbc</artifactId>
+    </dependency>
+
+    <!-- @ConfigurationProperties 메타데이터 생성 (IDE 자동완성) -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <!-- ── TCP 서버 ────────────────────────────────────────────────── -->
+    <!-- Netty: 고성능 비동기 TCP 서버 구현에 사용 -->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+    </dependency>
+
+    <!-- ── 데이터베이스 ────────────────────────────────────────────── -->
+    <!-- Oracle JDBC 11 (JDK 11+ / JDBC 4.3 지원) -->
+    <dependency>
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc11</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <!-- ── JSON 직렬화 ─────────────────────────────────────────────── -->
+    <!-- Jackson Databind: TCP 메시지 JSON ↔ Object 변환 -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <!-- ── 유틸리티 ───────────────────────────────────────────────── -->
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <!-- ── 테스트 ─────────────────────────────────────────────────── -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <!-- 런타임에 불필요한 Lombok 제거 -->
+            <exclude>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+            </exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/TcpBackendApplication.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/TcpBackendApplication.java
@@ -1,0 +1,35 @@
+/**
+ * @file TcpBackendApplication.java
+ * @description Spring Boot 애플리케이션 진입점.
+ *              Netty TCP 서버가 Spring 컨텍스트 초기화 완료 후 자동으로 기동된다.
+ *              웹 서버(Tomcat 등)는 사용하지 않으므로 spring-boot-starter-web 의존성이 없다.
+ */
+package com.example.tcpbackend;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * HNC POC Demo Backend — Netty 기반 TCP/IP 서버 애플리케이션.
+ *
+ * <p>기존 Node.js HTTP API(port 3001)를 TCP 소켓 통신으로 전환한 구현체다.
+ * 클라이언트는 4바이트 길이 헤더 + UTF-8 JSON 형식으로 메시지를 전송한다.
+ *
+ * <pre>{@code
+ * 메시지 프레임 구조:
+ *   [4 bytes: 전체 길이(big-endian)] [N bytes: UTF-8 JSON body]
+ *
+ * 요청 JSON 구조:
+ *   { "cmd": "LOGIN", "sessionId": null, "adminSecret": null, "payload": { ... } }
+ *
+ * 응답 JSON 구조:
+ *   { "cmd": "LOGIN", "success": true, "sessionId": "...", "data": { ... }, "error": null }
+ * }</pre>
+ */
+@SpringBootApplication
+public class TcpBackendApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(TcpBackendApplication.class, args);
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/config/AppProperties.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/config/AppProperties.java
@@ -1,0 +1,68 @@
+/**
+ * @file AppProperties.java
+ * @description application.yml의 커스텀 설정값을 바인딩하는 설정 속성 클래스.
+ *              tcp.* 및 auth.* 네임스페이스를 담당한다.
+ */
+package com.example.tcpbackend.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 애플리케이션 커스텀 설정 속성 컨테이너.
+ *
+ * <p>Tcp, Auth는 각각 독립적인 @ConfigurationProperties 빈으로 등록되고,
+ * AppProperties가 이를 @Autowired로 참조한다.
+ * 다른 빈은 AppProperties 하나만 주입받아 getTcp()/getAuth()로 접근한다.
+ */
+@Configuration
+public class AppProperties {
+
+    @Autowired
+    private Tcp tcp;
+
+    @Autowired
+    private Auth auth;
+
+    public Tcp getTcp() { return tcp; }
+    public Auth getAuth() { return auth; }
+
+    /** TCP 서버 관련 설정 — application.yml의 tcp.* 에 바인딩 */
+    @Configuration
+    @ConfigurationProperties(prefix = "tcp")
+    public static class Tcp {
+        /** TCP 서버가 수신 대기할 포트 번호 */
+        private int port = 9998;
+        /** Netty acceptor(boss) 스레드 수 */
+        private int bossThreads = 1;
+        /** Netty I/O(worker) 스레드 수 */
+        private int workerThreads = 4;
+        /** 단일 메시지 최대 바이트 수 (기본 1MB) */
+        private int maxFrameLength = 1_048_576;
+
+        public int getPort() { return port; }
+        public void setPort(int port) { this.port = port; }
+        public int getBossThreads() { return bossThreads; }
+        public void setBossThreads(int bossThreads) { this.bossThreads = bossThreads; }
+        public int getWorkerThreads() { return workerThreads; }
+        public void setWorkerThreads(int workerThreads) { this.workerThreads = workerThreads; }
+        public int getMaxFrameLength() { return maxFrameLength; }
+        public void setMaxFrameLength(int maxFrameLength) { this.maxFrameLength = maxFrameLength; }
+    }
+
+    /** 인증 관련 설정 — application.yml의 auth.* 에 바인딩 */
+    @Configuration
+    @ConfigurationProperties(prefix = "auth")
+    public static class Auth {
+        /** PIN 최대 허용 실패 횟수 */
+        private int pinMaxAttempts = 3;
+        /** Admin 전용 커맨드 인증 비밀 키 */
+        private String adminSecret = "admin-secret";
+
+        public int getPinMaxAttempts() { return pinMaxAttempts; }
+        public void setPinMaxAttempts(int pinMaxAttempts) { this.pinMaxAttempts = pinMaxAttempts; }
+        public String getAdminSecret() { return adminSecret; }
+        public void setAdminSecret(String adminSecret) { this.adminSecret = adminSecret; }
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/config/JacksonConfig.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/config/JacksonConfig.java
@@ -1,0 +1,38 @@
+/**
+ * @file JacksonConfig.java
+ * @description Jackson ObjectMapper 빈 등록.
+ *              spring-boot-starter-web 없이 TCP 서버만 사용하므로
+ *              JacksonAutoConfiguration이 활성화되지 않아 직접 등록한다.
+ */
+package com.example.tcpbackend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+/**
+ * Jackson 설정.
+ */
+@Configuration
+public class JacksonConfig {
+
+    /**
+     * TCP 메시지 직렬화/역직렬화에 사용할 ObjectMapper 빈.
+     *
+     * <ul>
+     *   <li>알 수 없는 필드 무시 — 클라이언트 버전 차이에 유연하게 대응</li>
+     *   <li>날짜를 타임스탬프 숫자 대신 ISO-8601 문자열로 출력</li>
+     * </ul>
+     */
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper()
+                // 역직렬화 시 JSON에 없는 필드가 있어도 예외 없이 무시
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                // 날짜를 숫자(epoch ms) 대신 ISO 문자열로 직렬화
+                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/config/NettyTcpServerConfig.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/config/NettyTcpServerConfig.java
@@ -1,0 +1,125 @@
+/**
+ * @file NettyTcpServerConfig.java
+ * @description Netty TCP 서버 기동 설정 클래스.
+ *              Spring 컨텍스트 초기화 완료 후 TCP 서버를 시작하고
+ *              종료 시 Netty EventLoopGroup을 안전하게 shutdown한다.
+ *
+ * @description Netty 서버 구성:
+ *   - BossGroup: 클라이언트 연결 수락 (boss 스레드 수 설정 가능)
+ *   - WorkerGroup: I/O 처리 (worker 스레드 수 설정 가능)
+ *   - SO_BACKLOG: 연결 대기 큐 크기
+ *   - SO_KEEPALIVE: TCP keepalive 활성화 (유휴 연결 자동 정리)
+ */
+package com.example.tcpbackend.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.example.tcpbackend.domain.notice.NoticeService;
+import com.example.tcpbackend.tcp.TcpServerInitializer;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+
+/**
+ * Netty TCP 서버 생명주기 관리자.
+ *
+ * <p>Spring 빈으로 등록되어 애플리케이션 기동 시 TCP 서버를 시작하고
+ * 종료 시 Netty 자원을 안전하게 해제한다.
+ */
+@Component
+public class NettyTcpServerConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(NettyTcpServerConfig.class);
+
+    private final AppProperties appProperties;
+    private final TcpServerInitializer serverInitializer;
+    private final NoticeService noticeService;
+
+    /** Netty acceptor 스레드 그룹 (연결 수락 전용) */
+    private EventLoopGroup bossGroup;
+
+    /** Netty I/O 처리 스레드 그룹 */
+    private EventLoopGroup workerGroup;
+
+    /** 서버 채널 참조 (shutdown 시 close에 사용) */
+    private Channel serverChannel;
+
+    public NettyTcpServerConfig(AppProperties appProperties,
+                                TcpServerInitializer serverInitializer,
+                                NoticeService noticeService) {
+        this.appProperties   = appProperties;
+        this.serverInitializer = serverInitializer;
+        this.noticeService   = noticeService;
+    }
+
+    /**
+     * Spring 컨텍스트 초기화 완료 후 TCP 서버를 기동한다.
+     *
+     * <ul>
+     *   <li>DB에서 긴급공지 배포 상태를 복구한다 (재기동 시 공지 유지).</li>
+     *   <li>Netty ServerBootstrap을 구성하고 설정된 포트에서 수신 대기를 시작한다.</li>
+     * </ul>
+     *
+     * @throws InterruptedException 서버 bind 중 인터럽트 발생 시
+     */
+    @PostConstruct
+    public void start() throws InterruptedException {
+        // ① 재기동 시 배포 중인 긴급공지 상태 복구
+        noticeService.restoreFromDb();
+
+        AppProperties.Tcp tcpProps = appProperties.getTcp();
+
+        bossGroup   = new NioEventLoopGroup(tcpProps.getBossThreads());
+        workerGroup = new NioEventLoopGroup(tcpProps.getWorkerThreads());
+
+        ServerBootstrap bootstrap = new ServerBootstrap()
+                .group(bossGroup, workerGroup)
+                .channel(NioServerSocketChannel.class)
+                // 연결 요청이 몰릴 때 대기할 수 있는 큐 크기 (OS TCP backlog)
+                .option(ChannelOption.SO_BACKLOG, 128)
+                // TCP keepalive: 유휴 상태의 연결을 OS가 주기적으로 확인해 자동 정리
+                .childOption(ChannelOption.SO_KEEPALIVE, true)
+                .childHandler(serverInitializer);
+
+        ChannelFuture future = bootstrap.bind(tcpProps.getPort()).sync();
+        serverChannel = future.channel();
+
+        log.info("[TCP Server] Netty TCP 서버 기동 완료 — port: {}, boss: {}, worker: {}",
+                tcpProps.getPort(), tcpProps.getBossThreads(), tcpProps.getWorkerThreads());
+
+        // 서버 채널을 논블로킹으로 감시 (비동기 — 메인 스레드 블로킹 없음)
+        future.channel().closeFuture().addListener(f ->
+                log.info("[TCP Server] 서버 채널 종료 감지"));
+    }
+
+    /**
+     * Spring 컨텍스트 종료 시 Netty 자원을 안전하게 해제한다.
+     *
+     * <p>진행 중인 I/O 처리가 완료될 때까지 graceful shutdown을 시도한다.
+     */
+    @PreDestroy
+    public void stop() {
+        log.info("[TCP Server] Netty TCP 서버 정상 종료 시작...");
+        try {
+            if (serverChannel != null) {
+                serverChannel.close().sync();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            if (workerGroup != null) workerGroup.shutdownGracefully();
+            if (bossGroup   != null) bossGroup.shutdownGracefully();
+            log.info("[TCP Server] Netty TCP 서버 종료 완료");
+        }
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/config/WebConfig.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/config/WebConfig.java
@@ -1,0 +1,64 @@
+/**
+ * @file WebConfig.java
+ * @description Spring MVC 웹 설정 — CORS 및 세션 인증 인터셉터를 등록한다.
+ *
+ * <p>CORS: 프론트엔드(http://localhost:5173)에서 직접 호출하는 Axios 요청을 허용한다.
+ * <p>인터셉터: /api/auth/login, /api/auth/refresh, /api/notices/sse 를 제외한
+ *             모든 /api/** 경로에 세션 인증 인터셉터를 적용한다.
+ */
+package com.example.tcpbackend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.example.tcpbackend.web.interceptor.SessionAuthInterceptor;
+
+/**
+ * Spring MVC 웹 설정.
+ *
+ * <pre>{@code
+ * 프론트엔드 → (직접 HTTP) → localhost:9998/api/**  — CORS 필요
+ * 프론트엔드 → (Vite 프록시) → localhost:9998/api/notices/sse  — 프록시 경유로 CORS 불필요
+ * }</pre>
+ */
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final SessionAuthInterceptor sessionAuthInterceptor;
+
+    public WebConfig(SessionAuthInterceptor sessionAuthInterceptor) {
+        this.sessionAuthInterceptor = sessionAuthInterceptor;
+    }
+
+    /**
+     * 프론트엔드(5173)에서 직접 호출하는 Axios 요청에 대해 CORS를 허용한다.
+     * withCredentials: true 사용 시 allowedOrigins를 와일드카드로 설정할 수 없다.
+     */
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                // Axios withCredentials: true → 쿠키(Refresh Token) 자동 전송 허용
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+
+    /**
+     * 세션 인증 인터셉터 등록.
+     * 로그인·토큰 갱신·SSE 구독 경로는 인증 없이 접근 가능하도록 제외한다.
+     */
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(sessionAuthInterceptor)
+                .addPathPatterns("/api/**")
+                .excludePathPatterns(
+                        "/api/auth/login",
+                        "/api/auth/refresh",
+                        "/api/notices/sse"
+                );
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/auth/AuthRepository.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/auth/AuthRepository.java
@@ -53,7 +53,7 @@ public class AuthRepository {
     }
 
     /**
-     * 사용자 프로필과 현재 시각을 조회한다.
+     * 사용자 프로필을 조회한다.
      * (TCP에서는 JWT 대신 세션에 사용자 정보가 있으므로
      *  GET_PROFILE 커맨드 시 최신 DB 값을 확인할 때 사용)
      *
@@ -63,7 +63,7 @@ public class AuthRepository {
     public Optional<UserRow> findById(String userId) {
         String sql = """
                 SELECT USER_ID, USER_NAME, USER_GRADE, LOG_YN,
-                       TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS') AS LAST_LOGIN_DTIME
+                       LAST_LOGIN_DTIME
                   FROM D_SPIDERLINK.POC_USER
                  WHERE USER_ID = ?
                 """;

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/auth/AuthRepository.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/auth/AuthRepository.java
@@ -1,0 +1,96 @@
+/**
+ * @file AuthRepository.java
+ * @description 인증 도메인 DB 접근 계층.
+ *              POC_USER 테이블을 대상으로 로그인 검증 및 최근 접속 일시 갱신을 처리한다.
+ */
+package com.example.tcpbackend.domain.auth;
+
+import java.util.Optional;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.example.tcpbackend.domain.auth.dto.UserRow;
+
+/**
+ * 인증 관련 DB 접근 객체.
+ */
+@Repository
+public class AuthRepository {
+
+    private final JdbcTemplate jdbc;
+
+    public AuthRepository(JdbcTemplate jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    /**
+     * 아이디/비밀번호로 사용자를 조회한다.
+     * 일치하는 사용자가 없으면 Optional.empty()를 반환한다.
+     *
+     * @param userId   로그인 아이디
+     * @param password 평문 비밀번호 (POC: 해싱 미적용)
+     * @return 사용자 정보 또는 empty
+     */
+    public Optional<UserRow> findByCredentials(String userId, String password) {
+        // LAST_LOGIN_DTIME 컬럼은 VARCHAR2로 'YYYYMMDDHH24MISS' 형식이 이미 저장되어 있으므로
+        // TO_CHAR 변환 없이 직접 조회한다 (DATE 타입이 아니므로 날짜 포맷 적용 시 ORA-01481 발생)
+        String sql = """
+                SELECT USER_ID, USER_NAME, USER_GRADE, LOG_YN, LAST_LOGIN_DTIME
+                  FROM D_SPIDERLINK.POC_USER
+                 WHERE USER_ID = ? AND PASSWORD = ?
+                """;
+
+        var rows = jdbc.query(sql, (rs, i) -> new UserRow(
+                rs.getString("USER_ID"),
+                rs.getString("USER_NAME"),
+                rs.getString("USER_GRADE"),
+                rs.getString("LOG_YN"),
+                rs.getString("LAST_LOGIN_DTIME")
+        ), userId, password);
+
+        return rows.isEmpty() ? Optional.empty() : Optional.of(rows.get(0));
+    }
+
+    /**
+     * 사용자 프로필과 현재 시각을 조회한다.
+     * (TCP에서는 JWT 대신 세션에 사용자 정보가 있으므로
+     *  GET_PROFILE 커맨드 시 최신 DB 값을 확인할 때 사용)
+     *
+     * @param userId 조회할 사용자 ID
+     * @return 사용자 정보 또는 empty
+     */
+    public Optional<UserRow> findById(String userId) {
+        String sql = """
+                SELECT USER_ID, USER_NAME, USER_GRADE, LOG_YN,
+                       TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS') AS LAST_LOGIN_DTIME
+                  FROM D_SPIDERLINK.POC_USER
+                 WHERE USER_ID = ?
+                """;
+
+        var rows = jdbc.query(sql, (rs, i) -> new UserRow(
+                rs.getString("USER_ID"),
+                rs.getString("USER_NAME"),
+                rs.getString("USER_GRADE"),
+                rs.getString("LOG_YN"),
+                rs.getString("LAST_LOGIN_DTIME")
+        ), userId);
+
+        return rows.isEmpty() ? Optional.empty() : Optional.of(rows.get(0));
+    }
+
+    /**
+     * 로그인 성공 시 LAST_LOGIN_DTIME을 현재 시각으로 갱신한다.
+     * 실패해도 로그인 처리에는 영향을 주지 않으므로 예외를 전파하지 않는다.
+     *
+     * @param userId 갱신할 사용자 ID
+     */
+    public void updateLastLoginTime(String userId) {
+        String sql = """
+                UPDATE D_SPIDERLINK.POC_USER
+                   SET LAST_LOGIN_DTIME = TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS')
+                 WHERE USER_ID = ?
+                """;
+        jdbc.update(sql, userId);
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/auth/AuthService.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/auth/AuthService.java
@@ -1,0 +1,94 @@
+/**
+ * @file AuthService.java
+ * @description 인증 비즈니스 로직 서비스.
+ *              로그인 검증, 사용자 프로필 조회를 담당한다.
+ *              HTTP JWT와 달리 TCP에서는 세션 관리를 TcpSessionManager가 처리한다.
+ */
+package com.example.tcpbackend.domain.auth;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.example.tcpbackend.domain.auth.dto.UserRow;
+
+/**
+ * 인증 서비스.
+ *
+ * <p>반환값은 TCP 응답 data 필드에 그대로 직렬화될 Map 형태를 사용한다.
+ */
+@Service
+public class AuthService {
+
+    private static final Logger log = LoggerFactory.getLogger(AuthService.class);
+
+    private final AuthRepository authRepository;
+
+    public AuthService(AuthRepository authRepository) {
+        this.authRepository = authRepository;
+    }
+
+    /**
+     * 로그인 검증을 수행한다.
+     *
+     * @param userId   로그인 아이디
+     * @param password 비밀번호
+     * @return 로그인 성공 시 사용자 정보 Map, 실패 시 예외 발생
+     * @throws IllegalArgumentException 아이디/비밀번호 불일치
+     * @throws IllegalStateException    비활성 계정
+     */
+    public UserRow login(String userId, String password) {
+        UserRow user = authRepository.findByCredentials(userId, password)
+                .orElseThrow(() -> new IllegalArgumentException("아이디 또는 비밀번호가 틀렸습니다."));
+
+        // LOG_YN = 'N' 계정은 사용 정지 처리
+        if (!"Y".equals(user.logYn())) {
+            throw new IllegalStateException("사용이 정지된 계정입니다. 관리자에게 문의하세요.");
+        }
+
+        // 최근 로그인 시각 갱신 (실패해도 로그인은 허용)
+        try {
+            authRepository.updateLastLoginTime(userId);
+        } catch (Exception e) {
+            log.warn("[Auth] LAST_LOGIN_DTIME 갱신 실패 (userId={}): {}", userId, e.getMessage());
+        }
+
+        return user;
+    }
+
+    /**
+     * 사용자 프로필을 조회한다.
+     * 현재 시각(SYSDATE)을 lastLogin으로 반환해 최근 접속 일시를 즉시 반영한다.
+     *
+     * @param userId 조회할 사용자 ID
+     * @return 프로필 정보 Map
+     * @throws IllegalArgumentException 사용자 미존재
+     */
+    public Map<String, Object> getProfile(String userId) {
+        UserRow user = authRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("userId", user.userId());
+        data.put("userName", user.userName());
+        data.put("userGrade", user.userGrade());
+        data.put("lastLogin", formatLoginDtime(user.lastLoginDtime()));
+        return data;
+    }
+
+    /**
+     * LAST_LOGIN_DTIME(YYYYMMDDHH24MISS 14자리) → 'YYYY.MM.DD HH:MM:SS' 변환.
+     *
+     * @param raw 14자리 숫자 문자열 또는 null
+     * @return 포맷된 문자열, 변환 불가 시 원본 반환
+     */
+    public static String formatLoginDtime(String raw) {
+        String s = raw == null ? "" : raw.replaceAll("\\D", "");
+        if (s.length() != 14) return raw == null ? "" : raw;
+        return s.substring(0, 4) + "." + s.substring(4, 6) + "." + s.substring(6, 8)
+                + " " + s.substring(8, 10) + ":" + s.substring(10, 12) + ":" + s.substring(12, 14);
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/auth/dto/UserRow.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/auth/dto/UserRow.java
@@ -1,0 +1,22 @@
+/**
+ * @file UserRow.java
+ * @description POC_USER 테이블 조회 결과를 담는 DTO.
+ */
+package com.example.tcpbackend.domain.auth.dto;
+
+/**
+ * POC_USER DB 로우 매핑 객체.
+ *
+ * @param userId         사용자 ID
+ * @param userName       사용자 이름
+ * @param userGrade      사용자 등급
+ * @param logYn          로그인 허용 여부 ('Y' = 정상, 'N' = 비활성)
+ * @param lastLoginDtime 최근 로그인 일시 (YYYYMMDDHH24MISS 14자리 문자열)
+ */
+public record UserRow(
+        String userId,
+        String userName,
+        String userGrade,
+        String logYn,
+        String lastLoginDtime
+) {}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/card/BankingRepository.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/card/BankingRepository.java
@@ -1,0 +1,90 @@
+/**
+ * @file BankingRepository.java
+ * @description 뱅킹 계좌 DB 접근 계층.
+ *              즉시결제 시 계좌 잔액 확인, 차감, 거래내역 기록을 담당한다.
+ */
+package com.example.tcpbackend.domain.card;
+
+import java.util.Map;
+
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.example.tcpbackend.domain.card.CardService.BusinessException;
+
+/**
+ * 뱅킹 계좌 관련 DB 접근 객체.
+ */
+@Repository
+public class BankingRepository {
+
+    private final JdbcTemplate jdbc;
+
+    public BankingRepository(JdbcTemplate jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    /**
+     * 계좌 잔액을 조회한다 (FOR UPDATE — 동시 출금 방지).
+     * 계좌가 존재하지 않으면 BusinessException을 던진다.
+     *
+     * @param accountNumber 계좌번호
+     * @param userId        사용자 ID
+     * @return 현재 계좌 잔액
+     * @throws BusinessException 계좌 미존재
+     */
+    public long getBalanceForUpdate(String accountNumber, String userId) {
+        String sql = """
+                SELECT "계좌잔액"
+                  FROM D_SPIDERLINK.POC_뱅킹계좌정보
+                 WHERE "계좌번호" = ? AND "사용자아이디" = ?
+                   FOR UPDATE
+                """;
+        try {
+            Long balance = jdbc.queryForObject(sql, Long.class, accountNumber, userId);
+            return balance == null ? 0L : balance;
+        } catch (EmptyResultDataAccessException e) {
+            throw new BusinessException("출금 계좌를 찾을 수 없습니다.");
+        }
+    }
+
+    /**
+     * 계좌 잔액을 차감한다.
+     *
+     * @param finalBalance  차감 후 잔액
+     * @param accountNumber 계좌번호
+     * @param userId        사용자 ID
+     */
+    public void deductBalance(long finalBalance, String accountNumber, String userId) {
+        String sql = """
+                UPDATE D_SPIDERLINK.POC_뱅킹계좌정보
+                   SET "계좌잔액" = ?
+                 WHERE "계좌번호" = ? AND "사용자아이디" = ?
+                """;
+        jdbc.update(sql, finalBalance, accountNumber, userId);
+    }
+
+    /**
+     * 카드 즉시결제 거래내역을 삽입한다.
+     *
+     * @param accountNumber 출금 계좌번호
+     * @param txDateTime    거래 일시 (YYYYMMDDHH24MISS)
+     * @param totalPaid     출금액
+     * @param finalBalance  거래 후 잔액
+     * @param cardId        결제 카드번호 (입금계좌번호 필드에 기록)
+     * @param userId        사용자 ID
+     */
+    public void insertTransaction(String accountNumber, String txDateTime,
+                                  long totalPaid, long finalBalance,
+                                  String cardId, String userId) {
+        String sql = """
+                INSERT INTO D_SPIDERLINK.POC_뱅킹거래내역
+                  ("계좌번호", "거래일시", "거래점", "출금액", "입금액", "잔액",
+                   "보낸분받는분", "적요", "송금메모", "입금계좌번호", "사용자아이디")
+                VALUES
+                  (?, ?, '하나카드', ?, 0, ?, '하나카드사', '카드즉시결제', NULL, ?, ?)
+                """;
+        jdbc.update(sql, accountNumber, txDateTime, totalPaid, finalBalance, cardId, userId);
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/card/CardRepository.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/card/CardRepository.java
@@ -1,0 +1,141 @@
+/**
+ * @file CardRepository.java
+ * @description 카드 도메인 DB 접근 계층.
+ *              POC_카드리스트, POC_카드사용내역, POC_뱅킹계좌정보, POC_뱅킹거래내역 테이블을 다룬다.
+ */
+package com.example.tcpbackend.domain.card;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 카드 관련 DB 접근 객체.
+ *
+ * <p>Oracle 한글 컬럼명을 그대로 사용한다.
+ * JdbcTemplate은 columnLabel 기준으로 ResultSet을 매핑하므로 큰따옴표 없이도 동작하지만,
+ * SQL 내에서는 Oracle 예약어와 충돌 방지를 위해 한글 컬럼명에 큰따옴표를 유지한다.
+ */
+@Repository
+public class CardRepository {
+
+    private final JdbcTemplate jdbc;
+
+    public CardRepository(JdbcTemplate jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    /**
+     * 사용자가 보유한 카드 목록을 조회한다.
+     *
+     * @param userId 로그인 사용자 ID
+     * @return 카드 정보 Map 목록 (컬럼명 → 값)
+     */
+    public List<Map<String, Object>> findCardsByUserId(String userId) {
+        String sql = """
+                SELECT "카드번호", "카드구분", "유효기간", "결제은행명",
+                       "결제계좌", "결제일", "한도금액", "사용금액"
+                  FROM D_SPIDERLINK.POC_카드리스트
+                 WHERE "사용자아이디" = ?
+                 ORDER BY "결제순번" NULLS LAST
+                """;
+        return jdbc.queryForList(sql, userId);
+    }
+
+    /**
+     * 즉시결제 가능금액(미결제 잔액 합산)을 조회한다.
+     *
+     * @param userId 사용자 ID
+     * @param cardId 카드번호
+     * @return 미결제 잔액 총합
+     */
+    public long getPayableAmount(String userId, String cardId) {
+        String sql = """
+                SELECT NVL(SUM("이용금액" - "누적결제금액"), 0)
+                  FROM D_SPIDERLINK.POC_카드사용내역
+                 WHERE "이용자" = ? AND "카드번호" = ?
+                   AND "누적결제금액" < "이용금액"
+                   AND "결제상태코드" <> '9'
+                """;
+        // 결제상태코드 9 = 취소건 (즉시결제 대상 제외)
+        Long result = jdbc.queryForObject(sql, Long.class, userId, cardId);
+        return result == null ? 0L : result;
+    }
+
+    /**
+     * 카드 한도금액을 조회한다.
+     *
+     * @param userId 사용자 ID
+     * @param cardId 카드번호
+     * @return 한도금액
+     */
+    public long getCreditLimit(String userId, String cardId) {
+        String sql = """
+                SELECT NVL("한도금액", 0)
+                  FROM D_SPIDERLINK.POC_카드리스트
+                 WHERE "사용자아이디" = ? AND "카드번호" = ?
+                """;
+        Long result = jdbc.queryForObject(sql, Long.class, userId, cardId);
+        return result == null ? 0L : result;
+    }
+
+    /**
+     * 미결제 내역을 이용일자 오름차순으로 조회한다 (FOR UPDATE 행 잠금).
+     * 즉시결제 트랜잭션 내에서만 호출해야 한다.
+     *
+     * @param userId 사용자 ID
+     * @param cardId 카드번호
+     * @return ROWID, 결제잔액, 누적결제금액을 포함한 미결제 내역 목록
+     */
+    public List<Map<String, Object>> findUnpaidRowsForUpdate(String userId, String cardId) {
+        String sql = """
+                SELECT ROWID AS RID, "결제잔액", "누적결제금액"
+                  FROM D_SPIDERLINK.POC_카드사용내역
+                 WHERE "이용자" = ? AND "카드번호" = ?
+                   AND "결제잔액" > 0 AND "결제상태코드" <> '9'
+                 ORDER BY "이용일자" ASC
+                   FOR UPDATE
+                """;
+        return jdbc.queryForList(sql, userId, cardId);
+    }
+
+    /**
+     * 카드 사용내역 1건을 결제 처리로 업데이트한다.
+     *
+     * @param newBalance     남은 결제잔액
+     * @param newAccumulated 갱신된 누적결제금액
+     * @param newStatusCode  결제상태코드 ('1'=완납, '2'=부분결제)
+     * @param txDate         결제 처리일자 (YYYYMMDD)
+     * @param rowId          대상 행의 Oracle ROWID
+     */
+    public void updatePaymentRow(long newBalance, long newAccumulated,
+                                 String newStatusCode, String txDate, String rowId) {
+        String sql = """
+                UPDATE D_SPIDERLINK.POC_카드사용내역
+                   SET "결제잔액"     = ?,
+                       "누적결제금액" = ?,
+                       "결제상태코드" = ?,
+                       "최종결제일자" = ?
+                 WHERE ROWID = ?
+                """;
+        jdbc.update(sql, newBalance, newAccumulated, newStatusCode, txDate, rowId);
+    }
+
+    /**
+     * 즉시결제 후 카드 사용금액을 차감해 이용 가능한도를 복원한다.
+     *
+     * @param totalPaid 이번 결제로 차감된 총 금액
+     * @param userId    사용자 ID
+     * @param cardId    카드번호
+     */
+    public void deductUsedAmount(long totalPaid, String userId, String cardId) {
+        String sql = """
+                UPDATE D_SPIDERLINK.POC_카드리스트
+                   SET "사용금액" = "사용금액" - ?
+                 WHERE "사용자아이디" = ? AND "카드번호" = ?
+                """;
+        jdbc.update(sql, totalPaid, userId, cardId);
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/card/CardService.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/card/CardService.java
@@ -1,0 +1,290 @@
+/**
+ * @file CardService.java
+ * @description 카드 도메인 비즈니스 로직 서비스.
+ *              카드 목록 조회, 즉시결제(PIN 검증 포함), 가능금액 조회를 처리한다.
+ */
+package com.example.tcpbackend.domain.card;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.tcpbackend.config.AppProperties;
+
+/**
+ * 카드 서비스.
+ *
+ * <p>즉시결제는 DB 트랜잭션(FOR UPDATE + COMMIT/ROLLBACK)을 사용하므로
+ * {@code @Transactional}을 적용한다.
+ * PIN 시도 횟수는 인메모리 Map으로 관리한다 (Node.js pinAttemptStore 동일 방식).
+ */
+@Service
+public class CardService {
+
+    private static final Logger log = LoggerFactory.getLogger(CardService.class);
+
+    private final CardRepository cardRepository;
+    private final BankingRepository bankingRepository;
+    private final AppProperties appProperties;
+    private final JdbcTemplate jdbc;
+
+    /**
+     * POC용 인메모리 PIN 시도 횟수 저장소.
+     * 키: "userId:cardId", 값: 실패 횟수
+     * 프로덕션에서는 Redis 또는 DB 테이블로 교체해야 한다.
+     */
+    private final ConcurrentHashMap<String, Integer> pinAttemptStore = new ConcurrentHashMap<>();
+
+    public CardService(CardRepository cardRepository,
+                       BankingRepository bankingRepository,
+                       AppProperties appProperties,
+                       JdbcTemplate jdbc) {
+        this.cardRepository = cardRepository;
+        this.bankingRepository = bankingRepository;
+        this.appProperties = appProperties;
+        this.jdbc = jdbc;
+    }
+
+    /**
+     * 사용자가 보유한 카드 목록을 반환한다.
+     *
+     * @param userId 로그인 사용자 ID
+     * @return 카드 정보 Map 목록
+     */
+    public List<Map<String, Object>> getCards(String userId) {
+        List<Map<String, Object>> rows = cardRepository.findCardsByUserId(userId);
+        List<Map<String, Object>> result = new ArrayList<>();
+        for (Map<String, Object> row : rows) {
+            result.add(mapCard(row));
+        }
+        return result;
+    }
+
+    /**
+     * 즉시결제 가능금액 및 한도금액을 조회한다.
+     *
+     * @param userId 사용자 ID
+     * @param cardId 카드번호
+     * @return { payableAmount, creditLimit }
+     */
+    public Map<String, Object> getPayableAmount(String userId, String cardId) {
+        long payable = cardRepository.getPayableAmount(userId, cardId);
+        long limit = cardRepository.getCreditLimit(userId, cardId);
+        return Map.of("payableAmount", payable, "creditLimit", limit);
+    }
+
+    /**
+     * 즉시결제를 처리한다.
+     *
+     * <p>처리 흐름:
+     * <ol>
+     *   <li>PIN 검증 (오늘 날짜 MMDD 방식, 3회 실패 시 잠금)</li>
+     *   <li>미결제 내역 조회 (FOR UPDATE 행 잠금)</li>
+     *   <li>뱅킹 계좌 잔액 확인 (FOR UPDATE)</li>
+     *   <li>이용일자 오름차순으로 순차 차감 (완납/부분결제)</li>
+     *   <li>뱅킹 계좌 잔액 차감 및 거래내역 INSERT</li>
+     *   <li>카드 사용금액 복원 (이용 가능한도 회복)</li>
+     * </ol>
+     *
+     * @param userId        사용자 ID
+     * @param cardId        카드번호
+     * @param pin           사용자가 입력한 PIN
+     * @param amount        결제 요청 금액
+     * @param accountNumber 출금 계좌번호
+     * @return { paidAmount, processedCount, completedAt }
+     * @throws PinException          PIN 오류 또는 횟수 초과
+     * @throws BusinessException     잔액 부족, 계좌 미존재 등 비즈니스 오류
+     */
+    @Transactional
+    public Map<String, Object> immediatePay(String userId, String cardId,
+                                            String pin, long amount, String accountNumber) {
+        // ── 1. PIN 검증 ──────────────────────────────────────────────────
+        int maxAttempts = appProperties.getAuth().getPinMaxAttempts();
+        String pinKey = userId + ":" + cardId;
+        int attempts = pinAttemptStore.getOrDefault(pinKey, 0);
+
+        if (attempts >= maxAttempts) {
+            throw new PinException("PIN 입력 횟수를 초과하였습니다.", 0);
+        }
+
+        // PIN = 오늘 날짜의 MMDD (예: 4월 21일 → "0421")
+        String validPin = LocalDate.now().format(DateTimeFormatter.ofPattern("MMdd"));
+        if (!validPin.equals(String.valueOf(pin))) {
+            int next = attempts + 1;
+            pinAttemptStore.put(pinKey, next);
+            int left = maxAttempts - next;
+            throw new PinException("PIN 번호가 올바르지 않습니다.", left);
+        }
+
+        // PIN 성공 → 실패 횟수 초기화
+        pinAttemptStore.remove(pinKey);
+
+        // ── 2. 트랜잭션 기준 시각 조회 ──────────────────────────────────
+        // 복수 UPDATE/INSERT에 동일 시각을 사용해야 데이터 일관성이 보장된다.
+        Map<String, Object> txTime = jdbc.queryForMap(
+                "SELECT TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS') AS TX_DATETIME," +
+                "       TO_CHAR(SYSDATE, 'YYYYMMDD')         AS TX_DATE," +
+                "       TO_CHAR(SYSDATE, 'YYYY.MM.DD HH24:MI') AS COMPLETED_AT" +
+                "  FROM DUAL");
+        String txDateTime  = (String) txTime.get("TX_DATETIME");
+        String txDate      = (String) txTime.get("TX_DATE");
+        String completedAt = (String) txTime.get("COMPLETED_AT");
+
+        // ── 3. 미결제 내역 조회 (FOR UPDATE) ────────────────────────────
+        List<Map<String, Object>> unpaidRows = cardRepository.findUnpaidRowsForUpdate(userId, cardId);
+
+        long totalDebt = unpaidRows.stream()
+                .mapToLong(r -> toLong(r.get("결제잔액")))
+                .sum();
+
+        // 요청 금액이 미결제 잔액 총합보다 크면 초과분은 차감하지 않는다 (잔액 소실 방지)
+        long actualDeduct = Math.min(amount, totalDebt);
+
+        // ── 4. 뱅킹 계좌 잔액 확인 (FOR UPDATE) ─────────────────────────
+        long currentBalance = bankingRepository.getBalanceForUpdate(accountNumber, userId);
+        if (currentBalance < actualDeduct) {
+            throw new BusinessException("잔액이 부족합니다.");
+        }
+
+        // ── 5. 이용일자 오름차순으로 순차 차감 ──────────────────────────
+        long remaining = actualDeduct;
+        long totalPaid = 0;
+        int processedCount = 0;
+
+        for (Map<String, Object> row : unpaidRows) {
+            if (remaining <= 0) break;
+
+            long 결제잔액     = toLong(row.get("결제잔액"));
+            long 누적결제금액 = toLong(row.get("누적결제금액"));
+            // oracle.sql.ROWID는 String으로 직접 캐스팅 불가 → toString() 경유
+            String rowId      = String.valueOf(row.get("RID"));
+
+            long deducted, newBalance;
+            String statusCode;
+
+            if (remaining >= 결제잔액) {
+                // 완납: 이 내역의 잔액 전부 결제, 잔여 금액을 다음 건으로 이월
+                deducted    = 결제잔액;
+                newBalance  = 0;
+                statusCode  = "1"; // 1 = 완납
+            } else {
+                // 부분결제: 남은 요청 금액만큼만 차감하고 루프 종료
+                deducted    = remaining;
+                newBalance  = 결제잔액 - remaining;
+                statusCode  = "2"; // 2 = 부분결제
+            }
+
+            cardRepository.updatePaymentRow(newBalance, 누적결제금액 + deducted, statusCode, txDate, rowId);
+
+            remaining -= deducted;
+            totalPaid += deducted;
+            processedCount++;
+        }
+
+        long finalBalance = currentBalance - totalPaid;
+
+        // ── 6. 뱅킹 계좌 잔액 차감 ─────────────────────────────────────
+        bankingRepository.deductBalance(finalBalance, accountNumber, userId);
+
+        // ── 7. 뱅킹 거래내역 INSERT ─────────────────────────────────────
+        bankingRepository.insertTransaction(accountNumber, txDateTime, totalPaid, finalBalance, cardId, userId);
+
+        // ── 8. 카드 사용금액 복원 (이용 가능한도 회복) ──────────────────
+        if (totalPaid > 0) {
+            cardRepository.deductUsedAmount(totalPaid, userId, cardId);
+        }
+
+        return Map.of("paidAmount", totalPaid, "processedCount", processedCount, "completedAt", completedAt);
+    }
+
+    /**
+     * PIN 시도 횟수를 초기화한다.
+     *
+     * @param userId 사용자 ID
+     * @param cardId 카드번호
+     */
+    public void resetPinAttempts(String userId, String cardId) {
+        pinAttemptStore.remove(userId + ":" + cardId);
+    }
+
+    // ── 내부 유틸 ───────────────────────────────────────────────────────────
+
+    /** DB 조회 결과의 숫자 컬럼을 안전하게 long으로 변환한다. */
+    private long toLong(Object value) {
+        if (value == null) return 0L;
+        if (value instanceof Number n) return n.longValue();
+        return Long.parseLong(value.toString());
+    }
+
+    /** DB 로우 → 프론트 카드 객체 변환 */
+    private Map<String, Object> mapCard(Map<String, Object> row) {
+        String cardNo = String.valueOf(row.getOrDefault("카드번호", ""));
+        long limit = toLong(row.get("한도금액"));
+        long used  = toLong(row.get("사용금액"));
+
+        Map<String, Object> card = new LinkedHashMap<>();
+        card.put("id", cardNo);
+        card.put("name", row.getOrDefault("카드구분", ""));
+        card.put("brand", detectBrand(cardNo));
+        card.put("maskedNumber", maskCardNumber(cardNo));
+        card.put("balance", limit - used);
+        card.put("expiry", row.getOrDefault("유효기간", ""));
+        card.put("paymentBank", row.getOrDefault("결제은행명", ""));
+        card.put("paymentAccount", String.valueOf(row.getOrDefault("결제계좌", "")));
+        card.put("paymentDay", row.getOrDefault("결제일", ""));
+        card.put("limitAmount", limit);
+        card.put("usedAmount", used);
+        return card;
+    }
+
+    /**
+     * 카드번호 앞 자리로 브랜드를 감지한다.
+     * VISA: 4로 시작, Mastercard: 51~55 또는 2221~2720
+     */
+    private String detectBrand(String cardNo) {
+        if (cardNo == null || cardNo.length() < 4) return "Unknown";
+        if (cardNo.startsWith("4")) return "VISA";
+        int prefix2 = Integer.parseInt(cardNo.substring(0, 2));
+        if (prefix2 >= 51 && prefix2 <= 55) return "Mastercard";
+        int prefix4 = Integer.parseInt(cardNo.substring(0, 4));
+        if (prefix4 >= 2221 && prefix4 <= 2720) return "Mastercard";
+        return "Unknown";
+    }
+
+    /**
+     * 카드번호를 마스킹한다. 예: 1234-****-****-5678
+     */
+    private String maskCardNumber(String cardNo) {
+        if (cardNo == null || cardNo.length() < 8) return cardNo;
+        String digits = cardNo.replaceAll("\\D", "");
+        if (digits.length() != 16) return cardNo;
+        return digits.substring(0, 4) + "-****-****-" + digits.substring(12);
+    }
+
+    // ── 중첩 예외 클래스 ────────────────────────────────────────────────────
+
+    /** PIN 오류 전용 예외 (HTTP 403에 해당, 인터셉터 재시도 방지용으로 구분) */
+    public static class PinException extends RuntimeException {
+        private final int attemptsLeft;
+        public PinException(String message, int attemptsLeft) {
+            super(message);
+            this.attemptsLeft = attemptsLeft;
+        }
+        public int getAttemptsLeft() { return attemptsLeft; }
+    }
+
+    /** 잔액 부족, 계좌 미존재 등 비즈니스 오류 전용 예외 */
+    public static class BusinessException extends RuntimeException {
+        public BusinessException(String message) { super(message); }
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/card/CardService.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/card/CardService.java
@@ -6,6 +6,7 @@
 package com.example.tcpbackend.domain.card;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -15,7 +16,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,7 +36,6 @@ public class CardService {
     private final CardRepository cardRepository;
     private final BankingRepository bankingRepository;
     private final AppProperties appProperties;
-    private final JdbcTemplate jdbc;
 
     /**
      * POC용 인메모리 PIN 시도 횟수 저장소.
@@ -47,12 +46,10 @@ public class CardService {
 
     public CardService(CardRepository cardRepository,
                        BankingRepository bankingRepository,
-                       AppProperties appProperties,
-                       JdbcTemplate jdbc) {
+                       AppProperties appProperties) {
         this.cardRepository = cardRepository;
         this.bankingRepository = bankingRepository;
         this.appProperties = appProperties;
-        this.jdbc = jdbc;
     }
 
     /**
@@ -131,14 +128,12 @@ public class CardService {
 
         // ── 2. 트랜잭션 기준 시각 조회 ──────────────────────────────────
         // 복수 UPDATE/INSERT에 동일 시각을 사용해야 데이터 일관성이 보장된다.
-        Map<String, Object> txTime = jdbc.queryForMap(
-                "SELECT TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS') AS TX_DATETIME," +
-                "       TO_CHAR(SYSDATE, 'YYYYMMDD')         AS TX_DATE," +
-                "       TO_CHAR(SYSDATE, 'YYYY.MM.DD HH24:MI') AS COMPLETED_AT" +
-                "  FROM DUAL");
-        String txDateTime  = (String) txTime.get("TX_DATETIME");
-        String txDate      = (String) txTime.get("TX_DATE");
-        String completedAt = (String) txTime.get("COMPLETED_AT");
+        // DB DUAL 조회 대신 애플리케이션 시각을 사용해 불필요한 네트워크 왕복을 제거한다.
+        // (DB 서버와 애플리케이션 서버 시간이 동기화되어 있다는 전제)
+        LocalDateTime now      = LocalDateTime.now();
+        String txDateTime  = now.format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        String txDate      = now.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String completedAt = now.format(DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm"));
 
         // ── 3. 미결제 내역 조회 (FOR UPDATE) ────────────────────────────
         List<Map<String, Object>> unpaidRows = cardRepository.findUnpaidRowsForUpdate(userId, cardId);

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/notice/NoticeService.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/notice/NoticeService.java
@@ -1,0 +1,287 @@
+/**
+ * @file NoticeService.java
+ * @description 긴급공지 비즈니스 로직 서비스.
+ *              Node.js SSE 브로드캐스트를 TCP 채널 그룹 브로드캐스트로 전환한다.
+ *              인메모리 공지 상태는 서버 재기동 시 DB(FWK_PROPERTY)에서 복구한다.
+ */
+package com.example.tcpbackend.domain.notice;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.example.tcpbackend.domain.notice.dto.NoticeState;
+import com.example.tcpbackend.tcp.TcpResponse;
+import com.example.tcpbackend.tcp.session.TcpSessionManager;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.ChannelGroupFuture;
+
+/**
+ * 긴급공지 서비스.
+ *
+ * <p>공지 상태는 인메모리({@code currentNotice})에 보관하며,
+ * 변경 시 구독 채널 그룹({@link TcpSessionManager#getNoticeSubscribers()})에 브로드캐스트한다.
+ */
+@Service
+public class NoticeService {
+
+    private static final Logger log = LoggerFactory.getLogger(NoticeService.class);
+
+    private final JdbcTemplate jdbc;
+    private final TcpSessionManager sessionManager;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 현재 배포 중인 긴급공지 인메모리 상태.
+     * null이면 배포 중인 공지 없음.
+     */
+    private volatile NoticeState currentNotice = null;
+
+    /**
+     * HTTP SSE 구독자 목록.
+     * CopyOnWriteArrayList: 브로드캐스트 중 동시 구독/해지가 발생해도 안전하다.
+     */
+    private final List<SseEmitter> sseEmitters = new CopyOnWriteArrayList<>();
+
+    public NoticeService(JdbcTemplate jdbc, TcpSessionManager sessionManager, ObjectMapper objectMapper) {
+        this.jdbc = jdbc;
+        this.sessionManager = sessionManager;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * 서버 재기동 시 FWK_PROPERTY에서 공지 상태를 복구한다.
+     * 복구 실패 시 경고 로그만 출력하고 공지 없이 기동한다.
+     */
+    public void restoreFromDb() {
+        try {
+            List<Map<String, Object>> statusRows = jdbc.queryForList(
+                    """
+                    SELECT DEFAULT_VALUE AS DISPLAY_TYPE,
+                           (SELECT DEFAULT_VALUE FROM FWK_PROPERTY
+                             WHERE PROPERTY_GROUP_ID = 'notice'
+                               AND PROPERTY_ID = 'DEPLOY_STATUS') AS DEPLOY_STATUS
+                      FROM FWK_PROPERTY
+                     WHERE PROPERTY_GROUP_ID = 'notice'
+                       AND PROPERTY_ID = 'USE_YN'
+                    """
+            );
+
+            if (statusRows.isEmpty() || !"DEPLOYED".equals(statusRows.get(0).get("DEPLOY_STATUS"))) {
+                log.info("[Notice] 배포 중인 긴급공지 없음 — 초기 상태로 기동");
+                return;
+            }
+
+            String displayType = String.valueOf(statusRows.get(0).get("DISPLAY_TYPE"));
+            List<Map<String, Object>> noticeRows = jdbc.queryForList(
+                    """
+                    SELECT PROPERTY_ID AS LANG, PROPERTY_DESC AS TITLE, DEFAULT_VALUE AS CONTENT
+                      FROM FWK_PROPERTY
+                     WHERE PROPERTY_GROUP_ID = 'notice'
+                       AND PROPERTY_ID IN ('EMERGENCY_KO', 'EMERGENCY_EN')
+                     ORDER BY PROPERTY_ID
+                    """
+            );
+
+            List<Map<String, Object>> settingRows = jdbc.queryForList(
+                    """
+                    SELECT PROPERTY_ID, DEFAULT_VALUE
+                      FROM FWK_PROPERTY
+                     WHERE PROPERTY_GROUP_ID = 'notice'
+                       AND PROPERTY_ID IN ('CLOSEABLE_YN', 'HIDE_TODAY_YN')
+                    """
+            );
+
+            Map<String, String> settings = new java.util.HashMap<>();
+            settingRows.forEach(r -> settings.put(
+                    String.valueOf(r.get("PROPERTY_ID")),
+                    String.valueOf(r.get("DEFAULT_VALUE"))));
+
+            List<Map<String, Object>> notices = new ArrayList<>();
+            noticeRows.forEach(r -> {
+                notices.add(Map.of(
+                        "lang",    String.valueOf(r.get("LANG")),
+                        "title",   String.valueOf(r.getOrDefault("TITLE", "")),
+                        "content", String.valueOf(r.getOrDefault("CONTENT", ""))
+                ));
+            });
+
+            currentNotice = new NoticeState(
+                    notices, displayType,
+                    settings.getOrDefault("CLOSEABLE_YN", "Y"),
+                    settings.getOrDefault("HIDE_TODAY_YN", "Y")
+            );
+
+            log.info("[Notice] 긴급공지 상태 복구 완료: displayType={}", displayType);
+
+        } catch (Exception e) {
+            log.warn("[Notice] 긴급공지 상태 복구 실패 (비치명적): {}", e.getMessage());
+        }
+    }
+
+    /**
+     * 공지 배포 동기화 처리 — Admin NOTICE_SYNC 커맨드 수신 시 호출.
+     * 인메모리 상태를 갱신하고 구독 채널 전체에 브로드캐스트한다.
+     *
+     * @param notices     언어별 공지 목록
+     * @param displayType 노출 타입
+     * @param closeableYn 닫기 버튼 여부
+     * @param hideTodayYn 오늘 하루 보지 않기 여부
+     */
+    public void sync(List<Map<String, Object>> notices, String displayType,
+                     String closeableYn, String hideTodayYn) {
+        currentNotice = new NoticeState(notices, displayType, closeableYn, hideTodayYn);
+        broadcast(currentNotice);
+        log.info("[Notice] 긴급공지 TCP 동기화: displayType={}, 구독자={}명",
+                displayType, sessionManager.getSubscriberCount());
+    }
+
+    /**
+     * 공지 배포 종료 처리 — Admin NOTICE_END 커맨드 수신 시 호출.
+     * 인메모리 상태를 null로 초기화하고 브로드캐스트한다.
+     */
+    public void end() {
+        currentNotice = null;
+        broadcast(null);
+        log.info("[Notice] 긴급공지 TCP 배포 종료: 구독자={}명", sessionManager.getSubscriberCount());
+    }
+
+    /**
+     * 신규 구독자에게 현재 공지 상태를 즉시 전송한다.
+     * NOTICE_SUBSCRIBE 커맨드 처리 시 호출한다.
+     *
+     * @return 현재 공지 상태 (null이면 공지 없음)
+     */
+    public NoticeState getCurrentNotice() {
+        return currentNotice;
+    }
+
+    /**
+     * HTTP SSE 구독 등록 — GET /api/notices/sse 요청 시 호출한다.
+     * 현재 공지 상태를 즉시 전송하고, 이후 변경 시 이벤트를 푸시한다.
+     *
+     * @return SseEmitter (Spring이 응답 스트림으로 유지)
+     */
+    public SseEmitter subscribe() {
+        SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+
+        // 연결 종료(완료·타임아웃·오류) 시 목록에서 제거
+        emitter.onCompletion(() -> sseEmitters.remove(emitter));
+        emitter.onTimeout(() -> sseEmitters.remove(emitter));
+        emitter.onError(e -> sseEmitters.remove(emitter));
+
+        sseEmitters.add(emitter);
+
+        // 재접속 시 최신 상태를 즉시 수신할 수 있도록 현재 공지를 바로 전송
+        try {
+            sendToSseEmitter(emitter, currentNotice);
+        } catch (IOException e) {
+            sseEmitters.remove(emitter);
+            emitter.completeWithError(e);
+        }
+
+        log.info("[Notice] SSE 구독 등록 (총 SSE 구독자={})", sseEmitters.size());
+        return emitter;
+    }
+
+    /**
+     * DB 미리보기용 공지 조회 — DEPLOY_STATUS 무관하게 최신 저장값 반환.
+     *
+     * @return { notices, displayType }
+     */
+    public Map<String, Object> preview() {
+        List<Map<String, Object>> statusRows = jdbc.queryForList(
+                """
+                SELECT DEFAULT_VALUE AS DISPLAY_TYPE
+                  FROM FWK_PROPERTY
+                 WHERE PROPERTY_GROUP_ID = 'notice' AND PROPERTY_ID = 'USE_YN'
+                """
+        );
+        String displayType = statusRows.isEmpty() ? "N"
+                : String.valueOf(statusRows.get(0).get("DISPLAY_TYPE"));
+
+        List<Map<String, Object>> noticeRows = jdbc.queryForList(
+                """
+                SELECT PROPERTY_ID AS LANG, PROPERTY_DESC AS TITLE, DEFAULT_VALUE AS CONTENT
+                  FROM FWK_PROPERTY
+                 WHERE PROPERTY_GROUP_ID = 'notice'
+                   AND PROPERTY_ID IN ('EMERGENCY_KO', 'EMERGENCY_EN')
+                 ORDER BY PROPERTY_ID
+                """
+        );
+
+        List<Map<String, Object>> notices = new ArrayList<>();
+        noticeRows.forEach(r -> notices.add(Map.of(
+                "lang",    String.valueOf(r.get("LANG")),
+                "title",   String.valueOf(r.getOrDefault("TITLE", "")),
+                "content", String.valueOf(r.getOrDefault("CONTENT", ""))
+        )));
+
+        return Map.of("notices", notices, "displayType", displayType);
+    }
+
+    // ── 내부 유틸 ───────────────────────────────────────────────────────────
+
+    /**
+     * 모든 구독자(TCP 채널 + HTTP SSE)에 현재 공지 상태를 전송한다.
+     *
+     * @param state 전송할 공지 상태 (null이면 "공지 없음" 전달)
+     */
+    private void broadcast(NoticeState state) {
+        broadcastToTcp(state);
+        broadcastToSse(state);
+    }
+
+    /** TCP 채널 구독자에게 브로드캐스트 */
+    private void broadcastToTcp(NoticeState state) {
+        ChannelGroup subscribers = sessionManager.getNoticeSubscribers();
+        if (subscribers.isEmpty()) return;
+
+        TcpResponse response = TcpResponse.ok("NOTICE_BROADCAST", state);
+        ChannelGroupFuture future = subscribers.writeAndFlush(response);
+        future.addListener(f -> {
+            if (!f.isSuccess()) {
+                log.warn("[Notice] TCP 브로드캐스트 실패 일부 발생: {}", f.cause().getMessage());
+            }
+        });
+    }
+
+    /** HTTP SSE 구독자에게 브로드캐스트 */
+    private void broadcastToSse(NoticeState state) {
+        if (sseEmitters.isEmpty()) return;
+
+        for (SseEmitter emitter : sseEmitters) {
+            try {
+                sendToSseEmitter(emitter, state);
+            } catch (IOException e) {
+                // 전송 실패한 emitter는 연결이 끊긴 것이므로 제거
+                sseEmitters.remove(emitter);
+                log.debug("[Notice] SSE 구독자 전송 실패 — 제거 처리");
+            }
+        }
+        log.info("[Notice] SSE 브로드캐스트 완료 (SSE 구독자={}명)", sseEmitters.size());
+    }
+
+    /**
+     * 단일 SseEmitter에 공지 이벤트를 전송한다.
+     * 프론트엔드는 "notice" 이벤트를 수신해 공지 상태를 갱신한다.
+     *
+     * @param emitter 전송 대상 emitter
+     * @param state   전송할 공지 상태 (null → JSON "null" 전송)
+     */
+    private void sendToSseEmitter(SseEmitter emitter, NoticeState state) throws IOException {
+        String json = objectMapper.writeValueAsString(state);
+        emitter.send(SseEmitter.event().name("notice").data(json));
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/notice/dto/NoticeState.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/notice/dto/NoticeState.java
@@ -1,0 +1,28 @@
+/**
+ * @file NoticeState.java
+ * @description 현재 배포 중인 긴급공지 상태를 담는 DTO.
+ *              TCP 브로드캐스트 응답의 data 필드에 직렬화된다.
+ */
+package com.example.tcpbackend.domain.notice.dto;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * 긴급공지 상태.
+ * null 필드는 JSON 직렬화에서 제외한다.
+ *
+ * @param notices     언어별 공지 목록 [{ lang, title, content }]
+ * @param displayType 노출 타입 ('A'|'B'|'C'|'N')
+ * @param closeableYn 닫기 버튼 노출 여부 ('Y'|'N')
+ * @param hideTodayYn 오늘 하루 보지 않기 체크박스 노출 여부 ('Y'|'N')
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record NoticeState(
+        List<Map<String, Object>> notices,
+        String displayType,
+        String closeableYn,
+        String hideTodayYn
+) {}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/transaction/BillingPeriod.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/transaction/BillingPeriod.java
@@ -1,0 +1,190 @@
+/**
+ * @file BillingPeriod.java
+ * @description 하나카드 공식 결제일별 신용공여기간 계산 유틸리티.
+ *              billingPeriod.js의 getBillingPeriod()를 Java로 이식한다.
+ *
+ * <p>공식 규칙 (결제일 D, 결제월 M 기준):
+ *
+ * <pre>
+ *   [D ≤ 12]
+ *     이용 시작 : (M-2)월 (D+18)일
+ *     이용 종료 : (M-1)월 (D+17)일
+ *     결제 예정 :  M월     D일
+ *     cutoff   : D+17일 — baseDay ≤ D+17 → 결제월=당월, 초과 → 결제월=익월
+ *
+ *   [D = 13]
+ *     이용 시작 : (M-1)월 1일
+ *     이용 종료 : (M-1)월 말일
+ *     결제 예정 :  M월 13일
+ *     (baseDate가 어느 날이든 결제월은 항상 익월)
+ *
+ *   [D ≥ 14]
+ *     이용 시작 : (M-1)월 (D-12)일
+ *     이용 종료 :  M월    (D-13)일
+ *     결제 예정 :  M월     D일
+ *     cutoff   : D-13일 — baseDay ≤ D-13 → 결제월=당월, 초과 → 결제월=익월
+ * </pre>
+ *
+ * <p>예: 결제일 25일, 오늘이 4월 10일(baseDay=10 ≤ cutoff=12) → 결제월=4월
+ * <br>이용기간 = 3월 13일 ~ 4월 12일, 결제일 = 4월 25일
+ *
+ * <p>예: 결제일 25일, 오늘이 4월 21일(baseDay=21 > cutoff=12) → 결제월=5월
+ * <br>이용기간 = 4월 13일 ~ 5월 12일, 결제일 = 5월 25일
+ */
+package com.example.tcpbackend.domain.transaction;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * 공여기간 계산 결과.
+ *
+ * @param fromDate   이용 시작일 (YYYYMMDD, DB 조회 범위에 사용)
+ * @param toDate     이용 종료일 (YYYYMMDD, DB 조회 범위에 사용)
+ * @param usageStart 이용 시작일 표시용 ('YYYY.MM.DD')
+ * @param usageEnd   이용 종료일 표시용 ('YYYY.MM.DD')
+ * @param dueDate    결제일 표시용 ('YYYY.MM.DD')
+ */
+public record BillingPeriod(
+        String fromDate,
+        String toDate,
+        String usageStart,
+        String usageEnd,
+        String dueDate
+) {
+
+    private static final DateTimeFormatter YMD     = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final DateTimeFormatter DISPLAY = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+    /**
+     * 기준일(today)과 결제일(paymentDay)을 받아 공여기간을 계산한다.
+     * billingPeriod.js의 getBillingPeriod() 로직과 동일하게 동작한다.
+     *
+     * @param today      기준일 (오늘 또는 이용일)
+     * @param paymentDay 카드 결제일 (1~31)
+     * @return 공여기간 정보
+     * @throws IllegalArgumentException paymentDay가 1~31 범위를 벗어날 때
+     */
+    public static BillingPeriod of(LocalDate today, int paymentDay) {
+        if (paymentDay < 1 || paymentDay > 31) {
+            throw new IllegalArgumentException("결제일은 1~31 사이여야 합니다: " + paymentDay);
+        }
+
+        int D        = paymentDay;
+        int baseYear = today.getYear();
+        int baseMonth = today.getMonthValue();
+        int baseDay  = today.getDayOfMonth();
+
+        LocalDate usageStartDate, usageEndDate, dueDateVal;
+
+        if (D <= 12) {
+            // ── [D ≤ 12] ───────────────────────────────────────────────────────
+            // cutoff = D+17: baseDay ≤ D+17 → 결제월=당월, 초과 → 결제월=익월
+            YearMonth payPart   = baseDay <= D + 17
+                    ? YearMonth.of(baseYear, baseMonth)
+                    : YearMonth.of(baseYear, baseMonth).plusMonths(1);
+            YearMonth endPart   = payPart.minusMonths(1); // M-1
+            YearMonth startPart = payPart.minusMonths(2); // M-2
+
+            usageEndDate   = clampToLastDay(endPart.getYear(),   endPart.getMonthValue(),   D + 17);
+            usageStartDate = clampToLastDay(startPart.getYear(), startPart.getMonthValue(), D + 18);
+            dueDateVal     = clampToLastDay(payPart.getYear(),   payPart.getMonthValue(),   D);
+
+        } else if (D == 13) {
+            // ── [D = 13] ───────────────────────────────────────────────────────
+            // 결제월 = 항상 익월 / 이용 기간 = 당월 1일 ~ 당월 말일
+            YearMonth payPart = YearMonth.of(baseYear, baseMonth).plusMonths(1);
+            YearMonth endPart = YearMonth.of(baseYear, baseMonth); // 이용 종료월 = 당월
+
+            usageStartDate = LocalDate.of(endPart.getYear(), endPart.getMonthValue(), 1);
+            usageEndDate   = LocalDate.of(endPart.getYear(), endPart.getMonthValue(), endPart.lengthOfMonth());
+            dueDateVal     = clampToLastDay(payPart.getYear(), payPart.getMonthValue(), 13);
+
+        } else {
+            // ── [D ≥ 14] ───────────────────────────────────────────────────────
+            // cutoff = D-13: baseDay ≤ D-13 → 결제월=당월, 초과 → 결제월=익월
+            YearMonth payPart   = baseDay <= D - 13
+                    ? YearMonth.of(baseYear, baseMonth)
+                    : YearMonth.of(baseYear, baseMonth).plusMonths(1);
+            YearMonth startPart = payPart.minusMonths(1); // M-1
+
+            usageEndDate   = clampToLastDay(payPart.getYear(),   payPart.getMonthValue(),   D - 13);
+            usageStartDate = clampToLastDay(startPart.getYear(), startPart.getMonthValue(), D - 12);
+            dueDateVal     = clampToLastDay(payPart.getYear(),   payPart.getMonthValue(),   D);
+        }
+
+        return new BillingPeriod(
+                usageStartDate.format(YMD),
+                usageEndDate.format(YMD),
+                usageStartDate.format(DISPLAY),
+                usageEndDate.format(DISPLAY),
+                dueDateVal.format(DISPLAY)
+        );
+    }
+
+    /**
+     * 청구월(targetMonth)과 결제일(paymentDay)로부터 해당 청구월의 이용 기간을 역산한다.
+     * billingPeriod.js의 getBillingPeriodForMonth() 로직과 동일하게 동작한다.
+     *
+     * <pre>
+     *   [D ≤ 12]  이용 시작: (M-2)월 (D+18)일  /  이용 종료: (M-1)월 (D+17)일
+     *   [D = 13]  이용 시작: (M-1)월  1일       /  이용 종료: (M-1)월 말일
+     *   [D ≥ 14]  이용 시작: (M-1)월 (D-12)일  /  이용 종료:  M월   (D-13)일
+     * </pre>
+     *
+     * @param targetMonth 청구월 "YYYY-MM"
+     * @param paymentDay  카드 결제일 (1~31)
+     * @return 이용 기간 정보
+     * @throws IllegalArgumentException paymentDay가 1~31 범위를 벗어날 때
+     */
+    public static BillingPeriod forMonth(String targetMonth, int paymentDay) {
+        String[] parts = targetMonth.split("-");
+        int y = Integer.parseInt(parts[0]);
+        int m = Integer.parseInt(parts[1]);
+        int D = paymentDay;
+
+        if (D < 1 || D > 31) {
+            throw new IllegalArgumentException("결제일은 1~31 사이여야 합니다: " + D);
+        }
+
+        LocalDate usageStartDate, usageEndDate;
+
+        if (D <= 12) {
+            // 이용 시작: (M-2)월 (D+18)일  /  이용 종료: (M-1)월 (D+17)일
+            YearMonth startPart = YearMonth.of(y, m).minusMonths(2);
+            YearMonth endPart   = YearMonth.of(y, m).minusMonths(1);
+            usageStartDate = clampToLastDay(startPart.getYear(), startPart.getMonthValue(), D + 18);
+            usageEndDate   = clampToLastDay(endPart.getYear(),   endPart.getMonthValue(),   D + 17);
+        } else if (D == 13) {
+            // 이용 시작: (M-1)월 1일  /  이용 종료: (M-1)월 말일
+            YearMonth prevPart = YearMonth.of(y, m).minusMonths(1);
+            usageStartDate = LocalDate.of(prevPart.getYear(), prevPart.getMonthValue(), 1);
+            usageEndDate   = LocalDate.of(prevPart.getYear(), prevPart.getMonthValue(), prevPart.lengthOfMonth());
+        } else {
+            // D ≥ 14: 이용 시작: (M-1)월 (D-12)일  /  이용 종료: M월 (D-13)일
+            YearMonth prevPart = YearMonth.of(y, m).minusMonths(1);
+            usageStartDate = clampToLastDay(prevPart.getYear(), prevPart.getMonthValue(), D - 12);
+            usageEndDate   = clampToLastDay(y, m, D - 13);
+        }
+
+        LocalDate dueDateVal = clampToLastDay(y, m, D);
+
+        return new BillingPeriod(
+                usageStartDate.format(YMD),
+                usageEndDate.format(YMD),
+                usageStartDate.format(DISPLAY),
+                usageEndDate.format(DISPLAY),
+                dueDateVal.format(DISPLAY)
+        );
+    }
+
+    /**
+     * 해당 월의 말일을 초과하는 날짜를 말일로 클램프한다.
+     * e.g. clampToLastDay(2026, 2, 30) → 2026-02-28
+     */
+    private static LocalDate clampToLastDay(int year, int month, int day) {
+        int lastDay = YearMonth.of(year, month).lengthOfMonth();
+        return LocalDate.of(year, month, Math.min(day, lastDay));
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/transaction/TransactionRepository.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/transaction/TransactionRepository.java
@@ -1,0 +1,126 @@
+/**
+ * @file TransactionRepository.java
+ * @description 이용내역/결제명세서 도메인 DB 접근 계층.
+ *              POC_카드사용내역, POC_카드리스트 테이블을 대상으로 한다.
+ */
+package com.example.tcpbackend.domain.transaction;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 이용내역 관련 DB 접근 객체.
+ *
+ * <p>동적 WHERE 절이 필요한 쿼리는 StringBuilder로 SQL을 조합하고
+ * 바인드 변수는 List로 관리한다.
+ */
+@Repository
+public class TransactionRepository {
+
+    private final JdbcTemplate jdbc;
+
+    public TransactionRepository(JdbcTemplate jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    /**
+     * 이용내역을 조건에 따라 조회한다.
+     *
+     * @param userId      사용자 ID
+     * @param cardId      카드번호 필터 (null 또는 "all" → 전체)
+     * @param fromDate    조회 시작일 YYYYMMDD (null → 조건 없음)
+     * @param toDate      조회 종료일 YYYYMMDD (null → 조건 없음)
+     * @param usageType   "lump"=일시불, "installment"=할부, "cancel"=취소 (null → 전체)
+     * @return 이용내역 Map 목록
+     */
+    public List<Map<String, Object>> findTransactions(String userId, String cardId,
+                                                       String fromDate, String toDate,
+                                                       String usageType) {
+        StringBuilder sql = new StringBuilder("""
+                SELECT "카드번호", "이용일자", "이용가맹점", "이용금액",
+                       "할부개월", "승인여부", "카드명", "승인시각", "결제예정일", "승인번호"
+                  FROM D_SPIDERLINK.POC_카드사용내역
+                 WHERE "이용자" = ?
+                """);
+
+        List<Object> params = new ArrayList<>();
+        params.add(userId);
+
+        if (cardId != null && !"all".equals(cardId)) {
+            sql.append(" AND \"카드번호\" = ?");
+            params.add(cardId);
+        }
+        if (fromDate != null) {
+            sql.append(" AND \"이용일자\" >= ?");
+            params.add(fromDate);
+        }
+        if (toDate != null) {
+            sql.append(" AND \"이용일자\" <= ?");
+            params.add(toDate);
+        }
+        if ("lump".equals(usageType)) {
+            // 일시불: 할부개월 0 또는 1, 승인건만
+            sql.append(" AND \"할부개월\" <= 1 AND \"승인여부\" = 'Y'");
+        } else if ("installment".equals(usageType)) {
+            // 할부: 할부개월 2 이상, 승인건만
+            sql.append(" AND \"할부개월\" > 1 AND \"승인여부\" = 'Y'");
+        } else if ("cancel".equals(usageType)) {
+            sql.append(" AND \"승인여부\" = 'N'");
+        }
+
+        sql.append(" ORDER BY \"이용일자\" DESC, \"승인시각\" DESC");
+
+        return jdbc.queryForList(sql.toString(), params.toArray());
+    }
+
+    /**
+     * 결제예정금액 조회용 이용내역을 기간 필터로 조회한다.
+     * 승인건만 포함하고 이용일자, 결제예정일 정보를 함께 반환한다.
+     *
+     * @param userId    사용자 ID
+     * @param fromDate  조회 시작일 (null → 조건 없음)
+     * @param toDate    조회 종료일 (null → 조건 없음)
+     * @return 이용내역 Map 목록
+     */
+    public List<Map<String, Object>> findForPaymentStatement(String userId, String fromDate, String toDate) {
+        StringBuilder sql = new StringBuilder("""
+                SELECT "카드번호", "카드명", "이용금액", "결제예정일", "이용일자"
+                  FROM D_SPIDERLINK.POC_카드사용내역
+                 WHERE "이용자" = ? AND "승인여부" = 'Y'
+                """);
+
+        List<Object> params = new ArrayList<>();
+        params.add(userId);
+
+        if (fromDate != null) {
+            sql.append(" AND \"이용일자\" >= ?");
+            params.add(fromDate);
+        }
+        if (toDate != null) {
+            sql.append(" AND \"이용일자\" <= ?");
+            params.add(toDate);
+        }
+
+        return jdbc.queryForList(sql.toString(), params.toArray());
+    }
+
+    /**
+     * 사용자 카드의 결제 관련 정보(결제은행, 계좌, 결제일)를 조회한다.
+     *
+     * @param userId 사용자 ID
+     * @return 카드 정보 Map 목록 (카드번호, 결제은행명, 결제계좌, 결제일)
+     */
+    public List<Map<String, Object>> findCardPaymentSettings(String userId) {
+        String sql = """
+                SELECT "카드번호", "결제은행명", "결제계좌", "결제일"
+                  FROM D_SPIDERLINK.POC_카드리스트
+                 WHERE "사용자아이디" = ?
+                 ORDER BY "결제순번" NULLS LAST
+                """;
+        return jdbc.queryForList(sql, userId);
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/transaction/TransactionService.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/domain/transaction/TransactionService.java
@@ -1,0 +1,308 @@
+/**
+ * @file TransactionService.java
+ * @description 이용내역 및 결제예정금액/이용대금명세서 비즈니스 로직 서비스.
+ *              Node.js의 /api/transactions, /api/payment-statement 엔드포인트 로직을 이식한다.
+ */
+package com.example.tcpbackend.domain.transaction;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * 이용내역 서비스.
+ */
+@Service
+public class TransactionService {
+
+    private final TransactionRepository transactionRepository;
+
+    public TransactionService(TransactionRepository transactionRepository) {
+        this.transactionRepository = transactionRepository;
+    }
+
+    /**
+     * 카드 이용내역을 조회한다.
+     *
+     * @param userId      사용자 ID
+     * @param cardId      카드번호 필터 (null/"all" → 전체)
+     * @param period      기간 타입 ("thisMonth", "1month", "3months", "custom")
+     * @param customMonth 커스텀 월 "YYYY-MM" (period="custom" 시 사용)
+     * @param fromDate    직접 지정 시작일 YYYYMMDD (period보다 우선)
+     * @param toDate      직접 지정 종료일 YYYYMMDD
+     * @param usageType   "lump"/"installment"/"cancel" (null → 전체)
+     * @return { transactions, totalCount, paymentSummary }
+     */
+    public Map<String, Object> getTransactions(String userId, String cardId,
+                                                String period, String customMonth,
+                                                String fromDate, String toDate,
+                                                String usageType) {
+        DateRange range = getDateRange(period, customMonth);
+        String effectiveFrom = fromDate != null ? fromDate : range.from;
+        String effectiveTo   = toDate   != null ? toDate   : range.to;
+
+        List<Map<String, Object>> rows = transactionRepository.findTransactions(
+                userId, cardId, effectiveFrom, effectiveTo, usageType);
+
+        List<Map<String, Object>> transactions = new ArrayList<>();
+        for (int i = 0; i < rows.size(); i++) {
+            transactions.add(mapUsageTransaction(rows.get(i), i));
+        }
+
+        // 결제예정일 대표값 추출 (가장 먼저 오는 날짜)
+        String upcomingDate = rows.stream()
+                .map(r -> String.valueOf(r.getOrDefault("결제예정일", "")))
+                .filter(d -> !d.isEmpty() && !"null".equals(d))
+                .sorted()
+                .findFirst()
+                .orElse("");
+
+        long totalAmount = transactions.stream()
+                .filter(t -> "승인".equals(t.get("status")))
+                .mapToLong(t -> (Long) t.get("amount"))
+                .sum();
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("transactions", transactions);
+        result.put("totalCount", transactions.size());
+        result.put("paymentSummary", Map.of(
+                "date", formatDateKo(upcomingDate),
+                "totalAmount", totalAmount));
+        return result;
+    }
+
+    /**
+     * 결제예정금액/이용대금명세서 데이터를 조회한다.
+     *
+     * @param userId       사용자 ID
+     * @param yearMonth    특정 월 조회 "YYYY-MM" (null → 공여기간 기반)
+     * @param paymentDay   카드 결제일 (1~31, yearMonth=null 시 사용)
+     * @return { dueDate, totalAmount, items, cardInfo, billingPeriod }
+     */
+    public Map<String, Object> getPaymentStatement(String userId, String yearMonth, String paymentDay) {
+        List<Map<String, Object>> cardRows = transactionRepository.findCardPaymentSettings(userId);
+
+        // { 카드번호: 결제일(int) } — 카드별 결제일을 보관해 공여기간 계산에 사용
+        Map<String, Integer> cardSettings = new HashMap<>();
+        cardRows.forEach(row -> {
+            String no = String.valueOf(row.getOrDefault("카드번호", "")).trim();
+            if (!no.isEmpty()) {
+                cardSettings.put(no, toInt(row.get("결제일")));
+            }
+        });
+
+        Map<String, Object> cardInfo = null;
+        if (!cardRows.isEmpty()) {
+            Map<String, Object> first = cardRows.get(0);
+            cardInfo = Map.of(
+                    "paymentBank",    String.valueOf(first.getOrDefault("결제은행명", "")),
+                    "paymentAccount", String.valueOf(first.getOrDefault("결제계좌", "")),
+                    "paymentDay",     String.valueOf(first.getOrDefault("결제일", ""))
+            );
+        }
+
+        // 날짜 범위 결정
+        String fromDate = null, toDate = null;
+        Map<String, String> billingPeriodFormatted = null;
+
+        // yearMonth 지정 시 카드별 공여기간 캐시 — DB 조회 후 in-memory 필터링에 사용
+        Map<Integer, BillingPeriod> periodByDay = new HashMap<>();
+
+        if (yearMonth != null) {
+            // getBillingPeriodForMonth 역산: 카드별 결제일로 공여기간을 개별 계산한다.
+            // DB 조회는 전체 카드의 공여기간을 포괄하는 최소~최대 범위로 하고,
+            // 조회 후 각 카드의 정확한 공여기간으로 in-memory 필터링한다.
+            Set<Integer> uniqueDays = new HashSet<>(cardSettings.values());
+            if (uniqueDays.isEmpty()) uniqueDays.add(25); // 카드 정보 없을 때 기본값
+
+            String minFrom = null, maxTo = null;
+            for (int day : uniqueDays) {
+                BillingPeriod bp = BillingPeriod.forMonth(yearMonth, day);
+                periodByDay.put(day, bp);
+                if (minFrom == null || bp.fromDate().compareTo(minFrom) < 0) minFrom = bp.fromDate();
+                if (maxTo == null || bp.toDate().compareTo(maxTo) > 0) maxTo = bp.toDate();
+            }
+            fromDate = minFrom;
+            toDate   = maxTo;
+
+            // billingPeriod 응답 필드: 첫 번째 카드의 결제일 기준으로 대표값 설정
+            if (!cardRows.isEmpty()) {
+                int repDay = toInt(cardRows.get(0).get("결제일"));
+                BillingPeriod repBp = periodByDay.getOrDefault(repDay,
+                        periodByDay.values().iterator().next());
+                billingPeriodFormatted = Map.of(
+                        "usageStart", repBp.usageStart(),
+                        "usageEnd",   repBp.usageEnd(),
+                        "dueDate",    repBp.dueDate()
+                );
+            }
+        } else {
+            // yearMonth 없을 때: 오늘 기준 공여기간(forward) 계산
+            String dayStr = paymentDay != null ? paymentDay
+                    : (cardInfo != null ? (String) cardInfo.get("paymentDay") : null);
+            if (dayStr != null && !dayStr.isEmpty() && !"null".equals(dayStr)) {
+                try {
+                    BillingPeriod bp = BillingPeriod.of(LocalDate.now(), Integer.parseInt(dayStr));
+                    fromDate = bp.fromDate();
+                    toDate   = bp.toDate();
+                    billingPeriodFormatted = Map.of(
+                            "usageStart", bp.usageStart(),
+                            "usageEnd",   bp.usageEnd(),
+                            "dueDate",    bp.dueDate()
+                    );
+                } catch (Exception e) {
+                    throw new IllegalStateException("공여기간 계산 실패 (결제일: " + dayStr + "): " + e.getMessage());
+                }
+            }
+        }
+
+        List<Map<String, Object>> txRows = transactionRepository.findForPaymentStatement(userId, fromDate, toDate);
+
+        // yearMonth 지정 시: DB에서 넓은 범위로 가져온 뒤 카드별 공여기간으로 정확히 필터링
+        if (yearMonth != null && !periodByDay.isEmpty()) {
+            final int defaultDay = 25; // cardSettings에 없는 카드의 fallback 결제일
+            txRows = txRows.stream()
+                    .filter(r -> {
+                        String cardNo = String.valueOf(r.getOrDefault("카드번호", "")).trim();
+                        int day = cardSettings.getOrDefault(cardNo, defaultDay);
+                        BillingPeriod bp = periodByDay.get(day);
+                        if (bp == null) return false;
+                        // YYYYMMDD 문자열은 사전식 정렬 = 날짜 순 → 부등호 비교 가능
+                        String useDate = String.valueOf(r.getOrDefault("이용일자", ""));
+                        return useDate.compareTo(bp.fromDate()) >= 0 && useDate.compareTo(bp.toDate()) <= 0;
+                    })
+                    .collect(Collectors.toList());
+        }
+
+        // 카드+결제예정일 기준 집계
+        Map<String, Map<String, Object>> cardMap = new LinkedHashMap<>();
+        for (Map<String, Object> r : txRows) {
+            String cardNo  = String.valueOf(r.getOrDefault("카드번호", ""));
+            String dDate   = String.valueOf(r.getOrDefault("결제예정일", ""));
+            String key     = cardNo + "_" + dDate;
+            cardMap.computeIfAbsent(key, k -> {
+                Map<String, Object> item = new LinkedHashMap<>();
+                item.put("cardNo",   cardNo);
+                item.put("cardName", r.getOrDefault("카드명", ""));
+                item.put("amount",   0L);
+                item.put("dueDate",  dDate);
+                return item;
+            });
+            long prev = (Long) cardMap.get(key).get("amount");
+            cardMap.get(key).put("amount", prev + toLong(r.get("이용금액")));
+        }
+
+        List<Map<String, Object>> items = new ArrayList<>(cardMap.values());
+        long totalAmount = items.stream().mapToLong(i -> (Long) i.get("amount")).sum();
+
+        // 대표 결제예정일 (가장 많이 등장하는 값)
+        String dueDate = txRows.stream()
+                .map(r -> String.valueOf(r.getOrDefault("결제예정일", "")))
+                .filter(d -> !d.isEmpty() && !"null".equals(d))
+                .collect(Collectors.groupingBy(d -> d, Collectors.counting()))
+                .entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse("");
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("dueDate",       dueDate);
+        result.put("totalAmount",   totalAmount);
+        result.put("items",         items);
+        result.put("cardInfo",      cardInfo);
+        result.put("billingPeriod", billingPeriodFormatted);
+        return result;
+    }
+
+    // ── 내부 유틸 ───────────────────────────────────────────────────────────
+
+    /** DB 로우 → 프론트 Transaction 객체 변환 */
+    private Map<String, Object> mapUsageTransaction(Map<String, Object> row, int idx) {
+        boolean approved    = "Y".equals(row.get("승인여부"));
+        int installment     = toInt(row.get("할부개월"));
+        String type = !approved ? "취소"
+                : installment > 1 ? "할부(" + installment + "개월)"
+                : "일시불";
+        long amount = approved
+                ? toLong(row.get("이용금액"))
+                : -toLong(row.get("이용금액")); // 취소는 음수
+
+        Map<String, Object> tx = new LinkedHashMap<>();
+        tx.put("id",             String.format("%s-%s-%s-%d",
+                row.get("카드번호"), row.get("이용일자"), row.get("승인시각"), idx));
+        tx.put("merchant",       row.getOrDefault("이용가맹점", ""));
+        tx.put("amount",         amount);
+        tx.put("date",           formatDateTime(
+                String.valueOf(row.getOrDefault("이용일자", "")),
+                String.valueOf(row.getOrDefault("승인시각", ""))));
+        tx.put("type",           type);
+        tx.put("approvalNumber", String.valueOf(row.getOrDefault("승인번호", "")));
+        tx.put("status",         approved ? "승인" : "취소");
+        tx.put("cardName",       row.getOrDefault("카드명", ""));
+        return tx;
+    }
+
+    /** period → { from, to } YYYYMMDD 변환 */
+    private DateRange getDateRange(String period, String customMonth) {
+        LocalDate now = LocalDate.now();
+        DateTimeFormatter ymd = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+        if ("thisMonth".equals(period)) {
+            String y = String.valueOf(now.getYear());
+            String m = String.format("%02d", now.getMonthValue());
+            return new DateRange(y + m + "01", y + m + "31");
+        }
+        if ("1month".equals(period)) {
+            return new DateRange(now.minusMonths(1).format(ymd), now.format(ymd));
+        }
+        if ("3months".equals(period)) {
+            return new DateRange(now.minusMonths(3).format(ymd), now.format(ymd));
+        }
+        if ("custom".equals(period) && customMonth != null) {
+            String[] parts = customMonth.split("-");
+            return new DateRange(parts[0] + parts[1] + "01", parts[0] + parts[1] + "31");
+        }
+        return new DateRange(null, null);
+    }
+
+    /** 날짜(YYYYMMDD) + 시각(HHmmss) → 'YYYY.MM.DD HH:mm' */
+    private String formatDateTime(String date, String time) {
+        String d = date == null ? "" : date.replaceAll("\\D", "");
+        String t = time == null ? "" : time.replaceAll("\\D", "");
+        String datePart = d.length() == 8
+                ? d.substring(0, 4) + "." + d.substring(4, 6) + "." + d.substring(6, 8)
+                : d.length() == 6
+                ? "20" + d.substring(0, 2) + "." + d.substring(2, 4) + "." + d.substring(4, 6)
+                : d;
+        String timePart = t.length() >= 4 ? t.substring(0, 2) + ":" + t.substring(2, 4) : "";
+        return timePart.isEmpty() ? datePart : datePart + " " + timePart;
+    }
+
+    /** 날짜 문자열 → 'M월 D일' */
+    private String formatDateKo(String raw) {
+        if (raw == null || raw.isEmpty()) return "";
+        String s = raw.replaceAll("\\D", "");
+        if (s.length() == 8) return Integer.parseInt(s.substring(4, 6)) + "월 " + Integer.parseInt(s.substring(6, 8)) + "일";
+        if (s.length() == 6) return Integer.parseInt(s.substring(2, 4)) + "월 " + Integer.parseInt(s.substring(4, 6)) + "일";
+        return raw;
+    }
+
+    private long toLong(Object v) {
+        if (v == null) return 0L;
+        if (v instanceof Number n) return n.longValue();
+        try { return Long.parseLong(v.toString()); } catch (NumberFormatException e) { return 0L; }
+    }
+
+    private int toInt(Object v) { return (int) toLong(v); }
+
+    private record DateRange(String from, String to) {}
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/handler/AuthHandler.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/handler/AuthHandler.java
@@ -1,0 +1,111 @@
+/**
+ * @file AuthHandler.java
+ * @description 인증 관련 TCP 커맨드 처리 핸들러.
+ *              LOGIN, LOGOUT, GET_PROFILE 커맨드를 담당한다.
+ */
+package com.example.tcpbackend.handler;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.example.tcpbackend.domain.auth.AuthService;
+import com.example.tcpbackend.domain.auth.dto.UserRow;
+import com.example.tcpbackend.tcp.TcpRequest;
+import com.example.tcpbackend.tcp.TcpResponse;
+import com.example.tcpbackend.tcp.session.SessionInfo;
+import com.example.tcpbackend.tcp.session.TcpSessionManager;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.netty.channel.Channel;
+
+/**
+ * 인증 핸들러.
+ *
+ * <p>각 메서드는 {@link com.example.tcpbackend.tcp.TcpMessageHandler}에서 커맨드 타입에 따라 호출된다.
+ */
+@Component
+public class AuthHandler {
+
+    private final AuthService authService;
+    private final TcpSessionManager sessionManager;
+
+    public AuthHandler(AuthService authService, TcpSessionManager sessionManager) {
+        this.authService = authService;
+        this.sessionManager = sessionManager;
+    }
+
+    /**
+     * LOGIN 커맨드 처리.
+     * payload: { "userId": "...", "password": "..." }
+     *
+     * @param request 요청 메시지
+     * @param channel 요청을 보낸 Netty 채널 (세션 생성에 사용)
+     * @return 로그인 결과 응답 (sessionId 포함)
+     */
+    public TcpResponse handleLogin(TcpRequest request, Channel channel) {
+        JsonNode payload = request.getPayload();
+        if (payload == null) {
+            return TcpResponse.error("LOGIN", "요청 데이터가 없습니다.");
+        }
+
+        String userId   = payload.path("userId").asText(null);
+        String password = payload.path("password").asText(null);
+
+        if (userId == null || userId.isBlank() || password == null || password.isBlank()) {
+            return TcpResponse.error("LOGIN", "아이디와 비밀번호를 입력하세요.");
+        }
+
+        try {
+            UserRow user = authService.login(userId, password);
+
+            // 세션 생성 — HTTP JWT 역할을 TCP 세션이 대체
+            String sessionId = sessionManager.createSession(
+                    user.userId(), user.userName(), user.userGrade(), channel);
+
+            Map<String, Object> data = new LinkedHashMap<>();
+            data.put("userId",    user.userId());
+            data.put("userName",  user.userName());
+            data.put("userGrade", user.userGrade());
+            data.put("lastLogin", AuthService.formatLoginDtime(user.lastLoginDtime()));
+
+            return TcpResponse.okWithSession("LOGIN", sessionId, data);
+
+        } catch (IllegalArgumentException e) {
+            return TcpResponse.error("LOGIN", e.getMessage());
+        } catch (IllegalStateException e) {
+            // 비활성 계정
+            return TcpResponse.error("LOGIN", e.getMessage());
+        }
+    }
+
+    /**
+     * LOGOUT 커맨드 처리.
+     * sessionId만 있으면 처리 가능 (payload 불필요).
+     *
+     * @param request 요청 메시지 (sessionId 필드 사용)
+     * @return 로그아웃 결과 응답
+     */
+    public TcpResponse handleLogout(TcpRequest request) {
+        sessionManager.invalidate(request.getSessionId());
+        return TcpResponse.ok("LOGOUT");
+    }
+
+    /**
+     * GET_PROFILE 커맨드 처리.
+     * 세션에서 userId를 가져와 DB에서 최신 프로필을 조회한다.
+     *
+     * @param request 요청 메시지
+     * @param session 검증된 세션 정보
+     * @return 사용자 프로필 응답
+     */
+    public TcpResponse handleGetProfile(TcpRequest request, SessionInfo session) {
+        try {
+            Map<String, Object> data = authService.getProfile(session.getUserId());
+            return TcpResponse.ok("GET_PROFILE", data);
+        } catch (IllegalArgumentException e) {
+            return TcpResponse.error("GET_PROFILE", e.getMessage());
+        }
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/handler/CardHandler.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/handler/CardHandler.java
@@ -1,0 +1,144 @@
+/**
+ * @file CardHandler.java
+ * @description 카드 관련 TCP 커맨드 처리 핸들러.
+ *              GET_CARDS, GET_PAYABLE_AMOUNT, IMMEDIATE_PAY, RESET_PIN_ATTEMPTS 커맨드를 담당한다.
+ */
+package com.example.tcpbackend.handler;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.example.tcpbackend.domain.card.CardService;
+import com.example.tcpbackend.domain.card.CardService.BusinessException;
+import com.example.tcpbackend.domain.card.CardService.PinException;
+import com.example.tcpbackend.tcp.TcpRequest;
+import com.example.tcpbackend.tcp.TcpResponse;
+import com.example.tcpbackend.tcp.session.SessionInfo;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * 카드 핸들러.
+ */
+@Component
+public class CardHandler {
+
+    private final CardService cardService;
+
+    public CardHandler(CardService cardService) {
+        this.cardService = cardService;
+    }
+
+    /**
+     * GET_CARDS 커맨드 처리.
+     * payload: {} (빈 페이로드 가능, userId는 세션에서 추출)
+     *
+     * @param session 검증된 세션 정보
+     * @return 카드 목록 응답
+     */
+    public TcpResponse handleGetCards(SessionInfo session) {
+        try {
+            List<Map<String, Object>> cards = cardService.getCards(session.getUserId());
+            return TcpResponse.ok("GET_CARDS", Map.of("cards", cards));
+        } catch (Exception e) {
+            return TcpResponse.error("GET_CARDS", "카드 목록 조회 중 오류가 발생했습니다.");
+        }
+    }
+
+    /**
+     * GET_PAYABLE_AMOUNT 커맨드 처리.
+     * payload: { "cardId": "..." }
+     *
+     * @param request 요청 메시지
+     * @param session 검증된 세션 정보
+     * @return { payableAmount, creditLimit } 응답
+     */
+    public TcpResponse handleGetPayableAmount(TcpRequest request, SessionInfo session) {
+        JsonNode payload = request.getPayload();
+        String cardId = payload != null ? payload.path("cardId").asText(null) : null;
+
+        if (cardId == null || cardId.isBlank()) {
+            return TcpResponse.error("GET_PAYABLE_AMOUNT", "cardId가 필요합니다.");
+        }
+
+        try {
+            Map<String, Object> data = cardService.getPayableAmount(session.getUserId(), cardId);
+            return TcpResponse.ok("GET_PAYABLE_AMOUNT", data);
+        } catch (Exception e) {
+            return TcpResponse.error("GET_PAYABLE_AMOUNT", "가능금액 조회 중 오류가 발생했습니다.");
+        }
+    }
+
+    /**
+     * IMMEDIATE_PAY 커맨드 처리.
+     * payload: { "cardId": "...", "pin": "MMDD", "amount": 100000, "accountNumber": "..." }
+     *
+     * <p>PIN 오류(PinException)는 일반 오류와 구분해 attemptsLeft를 함께 반환한다.
+     *
+     * @param request 요청 메시지
+     * @param session 검증된 세션 정보
+     * @return { paidAmount, processedCount, completedAt } 또는 오류 응답
+     */
+    public TcpResponse handleImmediatePay(TcpRequest request, SessionInfo session) {
+        JsonNode payload = request.getPayload();
+        if (payload == null) {
+            return TcpResponse.error("IMMEDIATE_PAY", "요청 데이터가 없습니다.");
+        }
+
+        String cardId       = payload.path("cardId").asText(null);
+        String pin          = payload.path("pin").asText(null);
+        long   amount       = payload.path("amount").asLong(0);
+        String accountNumber = payload.path("accountNumber").asText(null);
+
+        if (cardId == null || pin == null || amount <= 0 || accountNumber == null) {
+            return TcpResponse.error("IMMEDIATE_PAY", "cardId, pin, amount, accountNumber가 모두 필요합니다.");
+        }
+
+        try {
+            Map<String, Object> result = cardService.immediatePay(
+                    session.getUserId(), cardId, pin, amount, accountNumber);
+            return TcpResponse.ok("IMMEDIATE_PAY", result);
+
+        } catch (PinException e) {
+            return buildPinErrorResponse(e);
+
+        } catch (BusinessException e) {
+            return TcpResponse.error("IMMEDIATE_PAY", e.getMessage());
+
+        } catch (Exception e) {
+            return TcpResponse.error("IMMEDIATE_PAY", "즉시결제 처리 중 오류가 발생했습니다.");
+        }
+    }
+
+    /**
+     * RESET_PIN_ATTEMPTS 커맨드 처리.
+     * payload: { "cardId": "..." }
+     *
+     * @param request 요청 메시지
+     * @param session 검증된 세션 정보
+     * @return 초기화 완료 응답
+     */
+    public TcpResponse handleResetPinAttempts(TcpRequest request, SessionInfo session) {
+        JsonNode payload = request.getPayload();
+        String cardId = payload != null ? payload.path("cardId").asText(null) : null;
+
+        if (cardId == null || cardId.isBlank()) {
+            return TcpResponse.error("RESET_PIN_ATTEMPTS", "cardId가 필요합니다.");
+        }
+
+        cardService.resetPinAttempts(session.getUserId(), cardId);
+        return TcpResponse.ok("RESET_PIN_ATTEMPTS", Map.of("ok", true));
+    }
+
+    /**
+     * PIN 오류 응답 — 남은 시도 횟수를 error 메시지에 포함해 클라이언트에 전달한다.
+     *
+     * <p>attemptsLeft를 별도 필드로 전달하려면 TcpResponse에 data 필드를 추가하면 되나,
+     * POC에서는 메시지에 포함하는 방식으로 단순화한다.
+     */
+    private TcpResponse buildPinErrorResponse(PinException e) {
+        return TcpResponse.error("IMMEDIATE_PAY",
+                e.getMessage() + " (남은 시도: " + e.getAttemptsLeft() + "회)");
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/handler/NoticeHandler.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/handler/NoticeHandler.java
@@ -1,0 +1,154 @@
+/**
+ * @file NoticeHandler.java
+ * @description 긴급공지 TCP 커맨드 처리 핸들러.
+ *              NOTICE_SUBSCRIBE (Frontend), NOTICE_SYNC / NOTICE_END / NOTICE_PREVIEW (Admin) 커맨드를 담당한다.
+ */
+package com.example.tcpbackend.handler;
+
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.example.tcpbackend.config.AppProperties;
+import com.example.tcpbackend.domain.notice.NoticeService;
+import com.example.tcpbackend.domain.notice.dto.NoticeState;
+import com.example.tcpbackend.tcp.TcpRequest;
+import com.example.tcpbackend.tcp.TcpResponse;
+import com.example.tcpbackend.tcp.session.TcpSessionManager;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.netty.channel.Channel;
+
+/**
+ * 긴급공지 핸들러.
+ *
+ * <p>NOTICE_SUBSCRIBE는 일반 사용자(세션 필요), 나머지는 Admin 전용(adminSecret 필요)이다.
+ */
+@Component
+public class NoticeHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(NoticeHandler.class);
+
+    private final NoticeService noticeService;
+    private final TcpSessionManager sessionManager;
+    private final AppProperties appProperties;
+    private final ObjectMapper objectMapper;
+
+    public NoticeHandler(NoticeService noticeService,
+                         TcpSessionManager sessionManager,
+                         AppProperties appProperties,
+                         ObjectMapper objectMapper) {
+        this.noticeService = noticeService;
+        this.sessionManager = sessionManager;
+        this.appProperties = appProperties;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * NOTICE_SUBSCRIBE 커맨드 처리 — Frontend 연결 시 공지 구독 등록.
+     * Node.js의 GET /api/notices/sse와 동일한 역할.
+     *
+     * <p>구독 등록 후 현재 공지 상태를 즉시 전송한다 (재접속 시 최신 상태 즉시 반영).
+     *
+     * @param channel 구독을 요청한 채널
+     * @return 현재 공지 상태 응답
+     */
+    public TcpResponse handleSubscribe(Channel channel) {
+        sessionManager.addNoticeSubscriber(channel);
+        NoticeState current = noticeService.getCurrentNotice();
+        log.info("[Notice] 공지 구독 등록 (channel={}, 총 구독자={})",
+                channel.id(), sessionManager.getSubscriberCount());
+        // 현재 상태를 즉시 응답으로 반환 (null이면 "공지 없음" 상태)
+        return TcpResponse.ok("NOTICE_SUBSCRIBE", current);
+    }
+
+    /**
+     * NOTICE_SYNC 커맨드 처리 — Admin 긴급공지 배포 동기화.
+     * Node.js의 POST /api/notices/sync에 해당.
+     *
+     * payload:
+     * <pre>
+     * {
+     *   "notices":     [{ "lang": "EMERGENCY_KO", "title": "...", "content": "..." }],
+     *   "displayType": "A",
+     *   "closeableYn": "Y",
+     *   "hideTodayYn": "Y"
+     * }
+     * </pre>
+     *
+     * @param request 요청 메시지 (adminSecret 검증 필요)
+     * @return 동기화 완료 응답 또는 인증 오류
+     */
+    public TcpResponse handleSync(TcpRequest request) {
+        if (!verifyAdmin(request)) {
+            return TcpResponse.error("NOTICE_SYNC", "관리자 인증이 필요합니다.");
+        }
+
+        JsonNode payload = request.getPayload();
+        if (payload == null) {
+            return TcpResponse.error("NOTICE_SYNC", "요청 데이터가 없습니다.");
+        }
+
+        JsonNode noticesNode = payload.path("notices");
+        String displayType   = payload.path("displayType").asText(null);
+
+        if (!noticesNode.isArray() || displayType == null) {
+            return TcpResponse.error("NOTICE_SYNC", "notices 배열과 displayType이 필요합니다.");
+        }
+
+        // JsonNode 배열을 List<Map> 으로 변환
+        List<Map<String, Object>> notices = objectMapper.convertValue(
+                noticesNode,
+                objectMapper.getTypeFactory().constructCollectionType(List.class, Map.class));
+
+        String closeableYn = payload.path("closeableYn").asText("Y");
+        String hideTodayYn = payload.path("hideTodayYn").asText("Y");
+
+        noticeService.sync(notices, displayType, closeableYn, hideTodayYn);
+        return TcpResponse.ok("NOTICE_SYNC", Map.of("success", true));
+    }
+
+    /**
+     * NOTICE_END 커맨드 처리 — Admin 긴급공지 배포 종료.
+     * Node.js의 POST /api/notices/end에 해당.
+     *
+     * @param request 요청 메시지 (adminSecret 검증 필요)
+     * @return 종료 완료 응답 또는 인증 오류
+     */
+    public TcpResponse handleEnd(TcpRequest request) {
+        if (!verifyAdmin(request)) {
+            return TcpResponse.error("NOTICE_END", "관리자 인증이 필요합니다.");
+        }
+        noticeService.end();
+        return TcpResponse.ok("NOTICE_END", Map.of("success", true));
+    }
+
+    /**
+     * NOTICE_PREVIEW 커맨드 처리 — Admin 미리보기.
+     * DEPLOY_STATUS 무관하게 DB의 최신 저장값을 반환한다.
+     *
+     * @param request 요청 메시지 (adminSecret 검증 필요)
+     * @return { notices, displayType } 응답
+     */
+    public TcpResponse handlePreview(TcpRequest request) {
+        if (!verifyAdmin(request)) {
+            return TcpResponse.error("NOTICE_PREVIEW", "관리자 인증이 필요합니다.");
+        }
+        try {
+            Map<String, Object> data = noticeService.preview();
+            return TcpResponse.ok("NOTICE_PREVIEW", data);
+        } catch (Exception e) {
+            return TcpResponse.error("NOTICE_PREVIEW", "공지 데이터를 불러오지 못했습니다.");
+        }
+    }
+
+    /** adminSecret 헤더(필드)를 검증한다. */
+    private boolean verifyAdmin(TcpRequest request) {
+        String secret = request.getAdminSecret();
+        return secret != null && secret.equals(appProperties.getAuth().getAdminSecret());
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/handler/TransactionHandler.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/handler/TransactionHandler.java
@@ -1,0 +1,100 @@
+/**
+ * @file TransactionHandler.java
+ * @description 이용내역/결제명세서 TCP 커맨드 처리 핸들러.
+ *              GET_TRANSACTIONS, GET_PAYMENT_STATEMENT 커맨드를 담당한다.
+ */
+package com.example.tcpbackend.handler;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.example.tcpbackend.domain.transaction.TransactionService;
+import com.example.tcpbackend.tcp.TcpRequest;
+import com.example.tcpbackend.tcp.TcpResponse;
+import com.example.tcpbackend.tcp.session.SessionInfo;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * 이용내역 핸들러.
+ */
+@Component
+public class TransactionHandler {
+
+    private final TransactionService transactionService;
+
+    public TransactionHandler(TransactionService transactionService) {
+        this.transactionService = transactionService;
+    }
+
+    /**
+     * GET_TRANSACTIONS 커맨드 처리.
+     *
+     * payload:
+     * <pre>
+     * {
+     *   "cardId":      "all" | "카드번호",  // 선택
+     *   "period":      "thisMonth" | "1month" | "3months" | "custom",  // 선택
+     *   "customMonth": "YYYY-MM",            // period="custom" 시 필요
+     *   "fromDate":    "YYYYMMDD",           // 직접 지정 (period 무시)
+     *   "toDate":      "YYYYMMDD",
+     *   "usageType":   "lump" | "installment" | "cancel"  // 선택, 없으면 전체
+     * }
+     * </pre>
+     *
+     * @param request 요청 메시지
+     * @param session 검증된 세션 정보
+     * @return { transactions, totalCount, paymentSummary } 응답
+     */
+    public TcpResponse handleGetTransactions(TcpRequest request, SessionInfo session) {
+        JsonNode p = request.getPayload();
+
+        String cardId      = p != null ? p.path("cardId").asText(null)      : null;
+        String period      = p != null ? p.path("period").asText(null)      : null;
+        String customMonth = p != null ? p.path("customMonth").asText(null) : null;
+        String fromDate    = p != null ? p.path("fromDate").asText(null)    : null;
+        String toDate      = p != null ? p.path("toDate").asText(null)      : null;
+        String usageType   = p != null ? p.path("usageType").asText(null)   : null;
+
+        try {
+            Map<String, Object> data = transactionService.getTransactions(
+                    session.getUserId(), cardId, period, customMonth, fromDate, toDate, usageType);
+            return TcpResponse.ok("GET_TRANSACTIONS", data);
+        } catch (Exception e) {
+            return TcpResponse.error("GET_TRANSACTIONS", "이용내역 조회 중 오류가 발생했습니다.");
+        }
+    }
+
+    /**
+     * GET_PAYMENT_STATEMENT 커맨드 처리.
+     *
+     * payload:
+     * <pre>
+     * {
+     *   "yearMonth":  "YYYY-MM",  // 선택 — 특정 월 명세서 조회
+     *   "paymentDay": "25"        // 선택 — 공여기간 기준 결제일
+     * }
+     * </pre>
+     *
+     * @param request 요청 메시지
+     * @param session 검증된 세션 정보
+     * @return { dueDate, totalAmount, items, cardInfo, billingPeriod } 응답
+     */
+    public TcpResponse handleGetPaymentStatement(TcpRequest request, SessionInfo session) {
+        JsonNode p = request.getPayload();
+
+        String yearMonth  = p != null ? p.path("yearMonth").asText(null)  : null;
+        String paymentDay = p != null ? p.path("paymentDay").asText(null) : null;
+
+        try {
+            Map<String, Object> data = transactionService.getPaymentStatement(
+                    session.getUserId(), yearMonth, paymentDay);
+            return TcpResponse.ok("GET_PAYMENT_STATEMENT", data);
+        } catch (IllegalStateException e) {
+            // 공여기간 계산 실패 등 비즈니스 예외
+            return TcpResponse.error("GET_PAYMENT_STATEMENT", e.getMessage());
+        } catch (Exception e) {
+            return TcpResponse.error("GET_PAYMENT_STATEMENT", "결제예정금액 조회 중 오류가 발생했습니다.");
+        }
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/TcpMessageHandler.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/TcpMessageHandler.java
@@ -1,0 +1,166 @@
+/**
+ * @file TcpMessageHandler.java
+ * @description Netty 메인 인바운드 핸들러 — TCP 커맨드 라우팅 및 세션 인증.
+ *              LengthPrefixDecoder가 역직렬화한 TcpRequest를 받아
+ *              커맨드 타입에 따라 적절한 도메인 Handler로 위임한다.
+ *
+ * @description 커맨드 목록:
+ *   인증 불필요: LOGIN
+ *   세션 필요:   LOGOUT, GET_PROFILE, GET_CARDS, GET_TRANSACTIONS,
+ *                GET_PAYMENT_STATEMENT, GET_PAYABLE_AMOUNT, IMMEDIATE_PAY,
+ *                RESET_PIN_ATTEMPTS, NOTICE_SUBSCRIBE
+ *   Admin 전용:  NOTICE_SYNC, NOTICE_END, NOTICE_PREVIEW (adminSecret 검증은 NoticeHandler에서)
+ */
+package com.example.tcpbackend.tcp;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.example.tcpbackend.handler.AuthHandler;
+import com.example.tcpbackend.handler.CardHandler;
+import com.example.tcpbackend.handler.NoticeHandler;
+import com.example.tcpbackend.handler.TransactionHandler;
+import com.example.tcpbackend.tcp.session.SessionInfo;
+import com.example.tcpbackend.tcp.session.TcpSessionManager;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+
+/**
+ * TCP 메시지 라우터.
+ *
+ * <p>{@code @ChannelHandler.Sharable}: 상태를 가지지 않으므로 모든 채널이 단일 인스턴스를 공유한다.
+ * 채널별 상태(세션 등)는 {@link TcpSessionManager}에서 관리한다.
+ */
+@Component
+@ChannelHandler.Sharable
+public class TcpMessageHandler extends SimpleChannelInboundHandler<TcpRequest> {
+
+    private static final Logger log = LoggerFactory.getLogger(TcpMessageHandler.class);
+
+    private final TcpSessionManager sessionManager;
+    private final AuthHandler authHandler;
+    private final CardHandler cardHandler;
+    private final TransactionHandler transactionHandler;
+    private final NoticeHandler noticeHandler;
+
+    public TcpMessageHandler(TcpSessionManager sessionManager,
+                              AuthHandler authHandler,
+                              CardHandler cardHandler,
+                              TransactionHandler transactionHandler,
+                              NoticeHandler noticeHandler) {
+        this.sessionManager     = sessionManager;
+        this.authHandler        = authHandler;
+        this.cardHandler        = cardHandler;
+        this.transactionHandler = transactionHandler;
+        this.noticeHandler      = noticeHandler;
+    }
+
+    // ── Netty 생명주기 이벤트 ─────────────────────────────────────────────────
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) {
+        log.info("[TCP] 클라이언트 연결 (channel={})", ctx.channel().id());
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) {
+        // 채널 종료 시 연결된 세션을 자동으로 정리
+        sessionManager.onChannelInactive(ctx.channel());
+        log.info("[TCP] 클라이언트 연결 종료 (channel={})", ctx.channel().id());
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        log.error("[TCP] 채널 예외 발생 (channel={}): {}", ctx.channel().id(), cause.getMessage());
+        ctx.close();
+    }
+
+    // ── 메시지 처리 ────────────────────────────────────────────────────────────
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, TcpRequest request) {
+        String cmd = request.getCmd();
+        if (cmd == null || cmd.isBlank()) {
+            ctx.writeAndFlush(TcpResponse.error("UNKNOWN", "cmd 필드가 필요합니다."));
+            return;
+        }
+
+        log.debug("[TCP] 수신 (channel={}, cmd={})", ctx.channel().id(), cmd);
+
+        TcpResponse response = route(ctx, request, cmd);
+        ctx.writeAndFlush(response);
+    }
+
+    /**
+     * 커맨드 타입에 따라 적절한 핸들러로 요청을 위임한다.
+     *
+     * <p>LOGIN은 인증 없이 처리한다.
+     * Admin 전용 커맨드(NOTICE_*)는 세션 대신 adminSecret을 사용한다.
+     * 나머지 커맨드는 세션 검증 후 처리한다.
+     *
+     * @param ctx     Netty 채널 컨텍스트
+     * @param request 역직렬화된 요청
+     * @param cmd     커맨드 문자열
+     * @return 응답 메시지
+     */
+    private TcpResponse route(ChannelHandlerContext ctx, TcpRequest request, String cmd) {
+        return switch (cmd) {
+
+            // ── 인증 불필요 ─────────────────────────────────────────────
+            case "LOGIN" -> authHandler.handleLogin(request, ctx.channel());
+
+            // ── Admin 전용 (adminSecret 검증은 NoticeHandler 내부에서) ──
+            case "NOTICE_SYNC"    -> noticeHandler.handleSync(request);
+            case "NOTICE_END"     -> noticeHandler.handleEnd(request);
+            case "NOTICE_PREVIEW" -> noticeHandler.handlePreview(request);
+
+            // ── 세션 인증 필요 커맨드 ───────────────────────────────────
+            default -> {
+                SessionInfo session = sessionManager.getSession(request.getSessionId());
+                if (session == null) {
+                    // 유효하지 않은 세션 — 클라이언트에게 재로그인 요구
+                    yield TcpResponse.error(cmd, "인증이 필요합니다. 다시 로그인하세요.");
+                }
+                yield routeAuthenticated(ctx, request, cmd, session);
+            }
+        };
+    }
+
+    /**
+     * 세션 인증이 완료된 커맨드를 처리한다.
+     *
+     * @param ctx     Netty 채널 컨텍스트
+     * @param request 요청
+     * @param cmd     커맨드
+     * @param session 검증된 세션 정보
+     * @return 응답
+     */
+    private TcpResponse routeAuthenticated(ChannelHandlerContext ctx, TcpRequest request,
+                                            String cmd, SessionInfo session) {
+        return switch (cmd) {
+
+            // 인증
+            case "LOGOUT"      -> authHandler.handleLogout(request);
+            case "GET_PROFILE" -> authHandler.handleGetProfile(request, session);
+
+            // 카드
+            case "GET_CARDS"          -> cardHandler.handleGetCards(session);
+            case "GET_PAYABLE_AMOUNT" -> cardHandler.handleGetPayableAmount(request, session);
+            case "IMMEDIATE_PAY"      -> cardHandler.handleImmediatePay(request, session);
+            case "RESET_PIN_ATTEMPTS" -> cardHandler.handleResetPinAttempts(request, session);
+
+            // 이용내역
+            case "GET_TRANSACTIONS"      -> transactionHandler.handleGetTransactions(request, session);
+            case "GET_PAYMENT_STATEMENT" -> transactionHandler.handleGetPaymentStatement(request, session);
+
+            // 공지 구독 (Frontend가 연결 유지 상태에서 구독)
+            case "NOTICE_SUBSCRIBE" -> noticeHandler.handleSubscribe(ctx.channel());
+
+            // 알 수 없는 커맨드
+            default -> TcpResponse.error(cmd, "알 수 없는 커맨드입니다: " + cmd);
+        };
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/TcpRequest.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/TcpRequest.java
@@ -1,0 +1,61 @@
+/**
+ * @file TcpRequest.java
+ * @description 클라이언트 → 서버 TCP 요청 메시지 구조체.
+ *              4바이트 길이 헤더 뒤에 오는 JSON body를 역직렬화한 객체다.
+ *
+ * @example
+ * // 카드 목록 조회 요청
+ * {
+ *   "cmd": "GET_CARDS",
+ *   "sessionId": "a1b2c3d4",
+ *   "adminSecret": null,
+ *   "payload": {}
+ * }
+ */
+package com.example.tcpbackend.tcp;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * TCP 요청 메시지.
+ *
+ * <p>모든 필드는 JSON 역직렬화 시 자동으로 채워진다.
+ * 알 수 없는 필드는 무시한다({@link JsonIgnoreProperties}).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TcpRequest {
+
+    /** 처리할 커맨드 타입 (예: "LOGIN", "GET_CARDS") */
+    private String cmd;
+
+    /**
+     * 세션 ID — 로그인 이후 모든 요청에 포함해야 한다.
+     * 서버는 이 값으로 인증 상태를 검증한다.
+     */
+    private String sessionId;
+
+    /**
+     * Admin 전용 커맨드(NOTICE_SYNC, NOTICE_END) 인증 비밀 키.
+     * 일반 사용자 요청에는 null이어야 한다.
+     */
+    private String adminSecret;
+
+    /**
+     * 커맨드별 요청 데이터.
+     * 각 Handler가 타입에 맞게 역직렬화해 사용한다.
+     */
+    private JsonNode payload;
+
+    public String getCmd() { return cmd; }
+    public void setCmd(String cmd) { this.cmd = cmd; }
+
+    public String getSessionId() { return sessionId; }
+    public void setSessionId(String sessionId) { this.sessionId = sessionId; }
+
+    public String getAdminSecret() { return adminSecret; }
+    public void setAdminSecret(String adminSecret) { this.adminSecret = adminSecret; }
+
+    public JsonNode getPayload() { return payload; }
+    public void setPayload(JsonNode payload) { this.payload = payload; }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/TcpResponse.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/TcpResponse.java
@@ -1,0 +1,102 @@
+/**
+ * @file TcpResponse.java
+ * @description 서버 → 클라이언트 TCP 응답 메시지 구조체.
+ *              정적 팩토리 메서드로 성공/실패 응답을 간결하게 생성한다.
+ *
+ * @example
+ * // 성공 응답
+ * { "cmd": "LOGIN", "success": true, "sessionId": "a1b2c3d4", "data": { ... }, "error": null }
+ *
+ * // 실패 응답
+ * { "cmd": "LOGIN", "success": false, "sessionId": null, "data": null, "error": "아이디 또는 비밀번호가 틀렸습니다." }
+ */
+package com.example.tcpbackend.tcp;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * TCP 응답 메시지.
+ *
+ * <p>null 필드는 JSON 직렬화 시 생략한다({@link JsonInclude.Include#NON_NULL}).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TcpResponse {
+
+    /** 요청한 커맨드 타입 (에코) */
+    private String cmd;
+
+    /** 처리 성공 여부 */
+    private boolean success;
+
+    /**
+     * 로그인 성공 시 발급된 세션 ID.
+     * 이후 모든 요청의 sessionId 필드에 사용해야 한다.
+     */
+    private String sessionId;
+
+    /** 성공 시 반환 데이터 */
+    private Object data;
+
+    /** 실패 시 오류 메시지 */
+    private String error;
+
+    /**
+     * 성공 응답 생성 — 데이터 없이 성공만 알릴 때 사용.
+     *
+     * @param cmd 요청 커맨드
+     * @return 성공 응답
+     */
+    public static TcpResponse ok(String cmd) {
+        return ok(cmd, null);
+    }
+
+    /**
+     * 성공 응답 생성 — 데이터를 포함한 성공 응답.
+     *
+     * @param cmd  요청 커맨드
+     * @param data 응답 데이터 (null 허용)
+     * @return 성공 응답
+     */
+    public static TcpResponse ok(String cmd, Object data) {
+        TcpResponse r = new TcpResponse();
+        r.cmd = cmd;
+        r.success = true;
+        r.data = data;
+        return r;
+    }
+
+    /**
+     * 로그인 성공 응답 생성 — sessionId를 포함한다.
+     *
+     * @param cmd       요청 커맨드
+     * @param sessionId 발급된 세션 ID
+     * @param data      사용자 정보 등 응답 데이터
+     * @return 세션 ID 포함 성공 응답
+     */
+    public static TcpResponse okWithSession(String cmd, String sessionId, Object data) {
+        TcpResponse r = ok(cmd, data);
+        r.sessionId = sessionId;
+        return r;
+    }
+
+    /**
+     * 실패 응답 생성.
+     *
+     * @param cmd   요청 커맨드
+     * @param error 사용자에게 전달할 오류 메시지
+     * @return 실패 응답
+     */
+    public static TcpResponse error(String cmd, String error) {
+        TcpResponse r = new TcpResponse();
+        r.cmd = cmd;
+        r.success = false;
+        r.error = error;
+        return r;
+    }
+
+    public String getCmd() { return cmd; }
+    public boolean isSuccess() { return success; }
+    public String getSessionId() { return sessionId; }
+    public Object getData() { return data; }
+    public String getError() { return error; }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/TcpServerInitializer.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/TcpServerInitializer.java
@@ -1,0 +1,65 @@
+/**
+ * @file TcpServerInitializer.java
+ * @description Netty 채널 파이프라인 초기화기.
+ *              신규 TCP 연결이 수락될 때마다 호출되어 코덱과 핸들러를 파이프라인에 등록한다.
+ *
+ * @description 파이프라인 구성 (인바운드 순서):
+ *   1. LengthPrefixDecoder  — 4바이트 길이 헤더를 읽어 TcpRequest로 역직렬화
+ *   2. TcpMessageHandler    — 커맨드 라우팅 및 비즈니스 처리
+ *
+ * @description 파이프라인 구성 (아웃바운드 순서):
+ *   1. LengthPrefixEncoder  — TcpResponse를 4바이트 길이 헤더 + JSON으로 직렬화
+ */
+package com.example.tcpbackend.tcp;
+
+import org.springframework.stereotype.Component;
+
+import com.example.tcpbackend.config.AppProperties;
+import com.example.tcpbackend.tcp.codec.LengthPrefixDecoder;
+import com.example.tcpbackend.tcp.codec.LengthPrefixEncoder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+
+/**
+ * Netty 채널 파이프라인 초기화기.
+ *
+ * <p>LengthPrefixEncoder는 Sharable이므로 공유 인스턴스를 재사용한다.
+ * LengthPrefixDecoder는 채널별 내부 누적 버퍼를 가지므로 매 연결마다 new 인스턴스를 생성한다.
+ */
+@Component
+public class TcpServerInitializer extends ChannelInitializer<SocketChannel> {
+
+    private final ObjectMapper objectMapper;
+    private final AppProperties appProperties;
+    private final TcpMessageHandler messageHandler;
+
+    /** 모든 채널이 공유하는 Encoder 단일 인스턴스 (Sharable) */
+    private final LengthPrefixEncoder encoder;
+
+    public TcpServerInitializer(ObjectMapper objectMapper,
+                                AppProperties appProperties,
+                                TcpMessageHandler messageHandler) {
+        this.objectMapper   = objectMapper;
+        this.appProperties  = appProperties;
+        this.messageHandler = messageHandler;
+        this.encoder        = new LengthPrefixEncoder(objectMapper);
+    }
+
+    @Override
+    protected void initChannel(SocketChannel ch) {
+        ChannelPipeline pipeline = ch.pipeline();
+
+        // 아웃바운드: TcpResponse → 4바이트 헤더 + JSON (Sharable, 단일 인스턴스 재사용)
+        pipeline.addLast("encoder", encoder);
+
+        // 인바운드: 바이트 스트림 → TcpRequest (채널별 별도 인스턴스 필요)
+        pipeline.addLast("decoder", new LengthPrefixDecoder(
+                objectMapper, appProperties.getTcp().getMaxFrameLength()));
+
+        // 비즈니스 로직 라우터 (Sharable, 단일 인스턴스 재사용)
+        pipeline.addLast("handler", messageHandler);
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/codec/LengthPrefixDecoder.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/codec/LengthPrefixDecoder.java
@@ -18,6 +18,7 @@ import com.example.tcpbackend.tcp.TcpRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 
@@ -81,12 +82,9 @@ public class LengthPrefixDecoder extends ByteToMessageDecoder {
             return;
         }
 
-        // body를 바이트 배열로 읽어 JSON 역직렬화
-        byte[] bodyBytes = new byte[bodyLength];
-        in.readBytes(bodyBytes);
-
-        try {
-            TcpRequest request = objectMapper.readValue(bodyBytes, TcpRequest.class);
+        // ByteBufInputStream으로 ByteBuf에서 직접 역직렬화 — byte[] 중간 복사 생략
+        try (ByteBufInputStream bbis = new ByteBufInputStream(in, bodyLength)) {
+            TcpRequest request = objectMapper.readValue((java.io.InputStream) bbis, TcpRequest.class);
             out.add(request);
         } catch (Exception e) {
             log.error("[Decoder] JSON 역직렬화 실패 (channel={}): {}", ctx.channel().id(), e.getMessage());

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/codec/LengthPrefixDecoder.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/codec/LengthPrefixDecoder.java
@@ -1,0 +1,96 @@
+/**
+ * @file LengthPrefixDecoder.java
+ * @description Netty 인바운드 핸들러 — 4바이트 길이 헤더 + JSON body 디코더.
+ *              TCP 스트림에서 메시지 경계를 식별하고 TcpRequest로 역직렬화한다.
+ *
+ * @description 프레임 구조:
+ *   [4 bytes: 전체 길이 (big-endian int)] [N bytes: UTF-8 JSON]
+ *   - 전체 길이 = JSON body 바이트 수 (길이 헤더 자체 4바이트 미포함)
+ */
+package com.example.tcpbackend.tcp.codec;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.example.tcpbackend.tcp.TcpRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageDecoder;
+
+/**
+ * TCP 메시지 디코더.
+ *
+ * <p>Netty의 {@link ByteToMessageDecoder}를 상속해 다음 순서로 동작한다:
+ * <ol>
+ *   <li>수신 버퍼에서 첫 4바이트(길이 헤더)를 읽는다.</li>
+ *   <li>길이 헤더만큼 body 바이트가 누적될 때까지 대기한다.</li>
+ *   <li>body를 UTF-8로 읽어 {@link TcpRequest}로 역직렬화한다.</li>
+ * </ol>
+ *
+ * <p>{@code @ChannelHandler.Sharable}을 붙이지 않은 이유:
+ * ByteToMessageDecoder는 내부에 누적 버퍼(cumulation)를 가지므로
+ * 채널마다 별도 인스턴스가 필요하다. {@link TcpServerInitializer}에서
+ * 매 채널 연결 시 new 인스턴스를 주입한다.
+ */
+public class LengthPrefixDecoder extends ByteToMessageDecoder {
+
+    private static final Logger log = LoggerFactory.getLogger(LengthPrefixDecoder.class);
+
+    /** 길이 헤더 바이트 크기 (4바이트 고정) */
+    private static final int HEADER_SIZE = 4;
+
+    private final ObjectMapper objectMapper;
+    private final int maxFrameLength;
+
+    /**
+     * @param objectMapper  JSON 역직렬화에 사용할 Jackson ObjectMapper
+     * @param maxFrameLength 허용할 최대 메시지 바이트 수 (초과 시 연결 종료)
+     */
+    public LengthPrefixDecoder(ObjectMapper objectMapper, int maxFrameLength) {
+        this.objectMapper = objectMapper;
+        this.maxFrameLength = maxFrameLength;
+    }
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+        // 길이 헤더(4바이트)를 읽을 수 있는지 확인 — 부족하면 다음 패킷 도착까지 대기
+        if (in.readableBytes() < HEADER_SIZE) {
+            return;
+        }
+
+        // 현재 읽기 위치를 마킹해 두어, body가 부족하면 복원할 수 있게 한다
+        in.markReaderIndex();
+
+        int bodyLength = in.readInt(); // big-endian 4바이트 길이
+
+        // 비정상적으로 큰 메시지는 악의적 요청 또는 프로토콜 오류로 판단해 연결을 끊는다
+        if (bodyLength > maxFrameLength || bodyLength < 0) {
+            log.warn("[Decoder] 비정상 메시지 길이 감지: {} bytes — 연결 종료 (channel={})",
+                    bodyLength, ctx.channel().id());
+            ctx.close();
+            return;
+        }
+
+        // body 바이트가 아직 다 도착하지 않았으면 읽기 위치를 헤더 이전으로 복원하고 대기
+        if (in.readableBytes() < bodyLength) {
+            in.resetReaderIndex();
+            return;
+        }
+
+        // body를 바이트 배열로 읽어 JSON 역직렬화
+        byte[] bodyBytes = new byte[bodyLength];
+        in.readBytes(bodyBytes);
+
+        try {
+            TcpRequest request = objectMapper.readValue(bodyBytes, TcpRequest.class);
+            out.add(request);
+        } catch (Exception e) {
+            log.error("[Decoder] JSON 역직렬화 실패 (channel={}): {}", ctx.channel().id(), e.getMessage());
+            // 잘못된 JSON은 해당 메시지만 버리고 연결은 유지한다
+        }
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/codec/LengthPrefixEncoder.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/codec/LengthPrefixEncoder.java
@@ -1,0 +1,56 @@
+/**
+ * @file LengthPrefixEncoder.java
+ * @description Netty 아웃바운드 핸들러 — TcpResponse를 4바이트 길이 헤더 + JSON body로 인코딩.
+ *
+ * @description 인코딩 순서:
+ *   1. TcpResponse를 UTF-8 JSON 바이트 배열로 직렬화한다.
+ *   2. 4바이트 big-endian 정수로 JSON 길이를 쓴다.
+ *   3. JSON 바이트를 이어서 쓴다.
+ */
+package com.example.tcpbackend.tcp.codec;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.example.tcpbackend.tcp.TcpResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToByteEncoder;
+
+/**
+ * TCP 메시지 인코더.
+ *
+ * <p>{@code @ChannelHandler.Sharable}: ObjectMapper는 스레드 안전하므로
+ * 모든 채널이 단일 인스턴스를 공유할 수 있다.
+ * {@link TcpServerInitializer}에서 동일 인스턴스를 모든 채널에 등록한다.
+ */
+@io.netty.channel.ChannelHandler.Sharable
+public class LengthPrefixEncoder extends MessageToByteEncoder<TcpResponse> {
+
+    private static final Logger log = LoggerFactory.getLogger(LengthPrefixEncoder.class);
+
+    private final ObjectMapper objectMapper;
+
+    /**
+     * @param objectMapper JSON 직렬화에 사용할 Jackson ObjectMapper
+     */
+    public LengthPrefixEncoder(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    protected void encode(ChannelHandlerContext ctx, TcpResponse msg, ByteBuf out) throws Exception {
+        try {
+            byte[] jsonBytes = objectMapper.writeValueAsBytes(msg);
+            // 4바이트 길이 헤더 (big-endian) 먼저 기록
+            out.writeInt(jsonBytes.length);
+            // JSON body 기록
+            out.writeBytes(jsonBytes);
+        } catch (Exception e) {
+            log.error("[Encoder] JSON 직렬화 실패 (channel={}): {}", ctx.channel().id(), e.getMessage());
+            // 직렬화 실패 시 해당 응답은 전송하지 않는다 — 클라이언트 타임아웃으로 처리
+        }
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/codec/LengthPrefixEncoder.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/codec/LengthPrefixEncoder.java
@@ -16,6 +16,7 @@ import com.example.tcpbackend.tcp.TcpResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufOutputStream;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToByteEncoder;
 
@@ -43,11 +44,16 @@ public class LengthPrefixEncoder extends MessageToByteEncoder<TcpResponse> {
     @Override
     protected void encode(ChannelHandlerContext ctx, TcpResponse msg, ByteBuf out) throws Exception {
         try {
-            byte[] jsonBytes = objectMapper.writeValueAsBytes(msg);
-            // 4바이트 길이 헤더 (big-endian) 먼저 기록
-            out.writeInt(jsonBytes.length);
-            // JSON body 기록
-            out.writeBytes(jsonBytes);
+            // 길이 헤더 자리를 먼저 확보하고, ByteBufOutputStream으로 ByteBuf에 직접 직렬화
+            // — byte[] 중간 복사 없이 메모리 할당 비용을 줄인다
+            int lenIdx = out.writerIndex();
+            out.writeInt(0); // 길이 헤더 placeholder
+            try (ByteBufOutputStream bbos = new ByteBufOutputStream(out)) {
+                objectMapper.writeValue((java.io.OutputStream) bbos, msg);
+            }
+            // 실제 기록된 JSON 바이트 수로 길이 헤더를 덮어씀
+            int bodyLen = out.writerIndex() - lenIdx - Integer.BYTES;
+            out.setInt(lenIdx, bodyLen);
         } catch (Exception e) {
             log.error("[Encoder] JSON 직렬화 실패 (channel={}): {}", ctx.channel().id(), e.getMessage());
             // 직렬화 실패 시 해당 응답은 전송하지 않는다 — 클라이언트 타임아웃으로 처리

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/session/SessionInfo.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/session/SessionInfo.java
@@ -1,0 +1,51 @@
+/**
+ * @file SessionInfo.java
+ * @description TCP 세션에 저장되는 인증 사용자 정보.
+ *              HTTP의 JWT 페이로드와 동일한 역할을 한다.
+ */
+package com.example.tcpbackend.tcp.session;
+
+import java.time.Instant;
+
+/**
+ * 인증된 사용자의 TCP 세션 정보.
+ *
+ * <p>로그인 성공 시 생성되어 {@link TcpSessionManager}에 저장된다.
+ * 이후 요청은 sessionId로 이 객체를 조회해 인증 상태를 확인한다.
+ */
+public class SessionInfo {
+
+    /** 사용자 ID */
+    private final String userId;
+
+    /** 사용자 이름 */
+    private final String userName;
+
+    /** 사용자 등급 */
+    private final String userGrade;
+
+    /** 세션 생성 시각 (만료 계산에 사용 가능) */
+    private final Instant createdAt;
+
+    /** 마지막 활동 시각 (연결 유지 중 주기적으로 갱신) */
+    private volatile Instant lastActiveAt;
+
+    public SessionInfo(String userId, String userName, String userGrade) {
+        this.userId = userId;
+        this.userName = userName;
+        this.userGrade = userGrade;
+        this.createdAt = Instant.now();
+        this.lastActiveAt = this.createdAt;
+    }
+
+    /** 활동 감지 시 호출 — lastActiveAt을 현재 시각으로 갱신 */
+    public void touch() {
+        this.lastActiveAt = Instant.now();
+    }
+
+    public String getUserId() { return userId; }
+    public String getUserName() { return userName; }
+    public String getUserGrade() { return userGrade; }
+    public Instant getCreatedAt() { return createdAt; }
+    public Instant getLastActiveAt() { return lastActiveAt; }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/session/TcpSessionManager.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/session/TcpSessionManager.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 import io.netty.channel.Channel;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.GlobalEventExecutor;
 
 /**
@@ -36,7 +37,13 @@ public class TcpSessionManager {
     private final ConcurrentHashMap<String, SessionInfo> sessions = new ConcurrentHashMap<>();
 
     /**
-     * sessionId → Netty Channel 역매핑 (채널 종료 시 세션 자동 정리에 사용).
+     * 채널에 sessionId를 직접 저장하기 위한 AttributeKey.
+     * onChannelInactive 시 Map 순회 없이 O(1)으로 세션을 탐색·정리할 수 있다.
+     */
+    static final AttributeKey<String> SESSION_ID_KEY = AttributeKey.valueOf("tcp.sessionId");
+
+    /**
+     * sessionId → Netty Channel 역매핑 (invalidate 시 채널 참조 정리에 사용).
      */
     private final ConcurrentHashMap<String, Channel> sessionChannels = new ConcurrentHashMap<>();
 
@@ -94,6 +101,8 @@ public class TcpSessionManager {
         // channel이 null이면 HTTP 세션 — 채널 종료 이벤트가 없으므로 채널 매핑 생략
         if (channel != null) {
             sessionChannels.put(sessionId, channel);
+            // AttributeKey로 채널에 sessionId를 직접 저장 → onChannelInactive O(1) 탐색
+            channel.attr(SESSION_ID_KEY).set(sessionId);
         }
         userSessions.put(userId, sessionId);
 
@@ -138,14 +147,12 @@ public class TcpSessionManager {
      * @param channel 끊긴 Netty 채널
      */
     public void onChannelInactive(Channel channel) {
-        // 채널 ID로 sessionId를 역탐색해 제거
-        sessionChannels.entrySet().removeIf(entry -> {
-            if (entry.getValue().equals(channel)) {
-                invalidate(entry.getKey());
-                return true;
-            }
-            return false;
-        });
+        // AttributeKey로 채널에 저장된 sessionId를 O(1)으로 꺼내 세션 정리
+        // — 기존 Map 전체 순회(O(N)) 방식 대비 성능 개선
+        String sessionId = channel.attr(SESSION_ID_KEY).getAndSet(null);
+        if (sessionId != null) {
+            invalidate(sessionId);
+        }
     }
 
     // ── 공지 구독 채널 관리 ────────────────────────────────────────────────────

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/session/TcpSessionManager.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/session/TcpSessionManager.java
@@ -1,0 +1,180 @@
+/**
+ * @file TcpSessionManager.java
+ * @description TCP 세션 저장소 및 공지 구독자 채널 관리.
+ *              HTTP의 JWT + 인메모리 Refresh Token Store 역할을 통합한다.
+ *              공지 브로드캐스트 대상 채널(ChannelGroup)도 함께 관리한다.
+ */
+package com.example.tcpbackend.tcp.session;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import io.netty.channel.Channel;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.util.concurrent.GlobalEventExecutor;
+
+/**
+ * TCP 세션 및 공지 구독 채널 관리자.
+ *
+ * <p>스레드 안전성: ConcurrentHashMap과 Netty의 ChannelGroup을 사용해
+ * 다중 I/O 스레드에서 동시 접근해도 안전하다.
+ */
+@Component
+public class TcpSessionManager {
+
+    private static final Logger log = LoggerFactory.getLogger(TcpSessionManager.class);
+
+    /**
+     * sessionId → SessionInfo 매핑.
+     * 로그인 성공 시 생성, 로그아웃 또는 채널 종료 시 제거된다.
+     */
+    private final ConcurrentHashMap<String, SessionInfo> sessions = new ConcurrentHashMap<>();
+
+    /**
+     * sessionId → Netty Channel 역매핑 (채널 종료 시 세션 자동 정리에 사용).
+     */
+    private final ConcurrentHashMap<String, Channel> sessionChannels = new ConcurrentHashMap<>();
+
+    /**
+     * userId → sessionId 역매핑 (중복 로그인 제어에 사용).
+     * 동일 userId로 재로그인하면 기존 세션을 무효화한다.
+     */
+    private final ConcurrentHashMap<String, String> userSessions = new ConcurrentHashMap<>();
+
+    /**
+     * 공지 브로드캐스트 대상 채널 그룹.
+     * NOTICE_SUBSCRIBE 커맨드를 받은 채널이 여기에 등록된다.
+     * 채널이 끊기면 Netty가 자동으로 그룹에서 제거한다.
+     */
+    private final ChannelGroup noticeSubscribers =
+            new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
+
+    // ── 세션 생성 / 조회 / 삭제 ──────────────────────────────────────────────
+
+    /**
+     * HTTP 요청용 세션 생성 — Netty 채널 없이 세션만 등록한다.
+     * 채널 종료 이벤트가 없으므로 세션은 로그아웃 호출 또는 서버 재기동 시 제거된다.
+     *
+     * @param userId    인증된 사용자 ID
+     * @param userName  사용자 이름
+     * @param userGrade 사용자 등급
+     * @return 새로 발급된 세션 ID (UUID)
+     */
+    public String createSession(String userId, String userName, String userGrade) {
+        return createSession(userId, userName, userGrade, null);
+    }
+
+    /**
+     * 로그인 성공 시 새 세션을 생성한다.
+     * 동일 userId로 기존 세션이 있으면 먼저 무효화한다(중복 로그인 방지).
+     *
+     * @param userId    인증된 사용자 ID
+     * @param userName  사용자 이름
+     * @param userGrade 사용자 등급
+     * @param channel   로그인 요청을 보낸 Netty 채널 (HTTP 요청 시 null 허용)
+     * @return 새로 발급된 세션 ID (UUID)
+     */
+    public String createSession(String userId, String userName, String userGrade, Channel channel) {
+        // 기존 세션이 있으면 제거 (중복 로그인 → 기존 세션 무효화)
+        String existingSessionId = userSessions.get(userId);
+        if (existingSessionId != null) {
+            invalidate(existingSessionId);
+            log.debug("[Session] 기존 세션 무효화 (userId={})", userId);
+        }
+
+        String sessionId = UUID.randomUUID().toString().replace("-", "");
+        SessionInfo info = new SessionInfo(userId, userName, userGrade);
+
+        sessions.put(sessionId, info);
+        // channel이 null이면 HTTP 세션 — 채널 종료 이벤트가 없으므로 채널 매핑 생략
+        if (channel != null) {
+            sessionChannels.put(sessionId, channel);
+        }
+        userSessions.put(userId, sessionId);
+
+        log.info("[Session] 세션 생성 (userId={}, sessionId={})", userId, sessionId);
+        return sessionId;
+    }
+
+    /**
+     * sessionId로 세션 정보를 조회한다.
+     * 세션이 존재하면 lastActiveAt을 갱신한다(Touch 방식).
+     *
+     * @param sessionId 조회할 세션 ID
+     * @return 세션 정보, 없으면 null
+     */
+    public SessionInfo getSession(String sessionId) {
+        if (sessionId == null) return null;
+        SessionInfo info = sessions.get(sessionId);
+        if (info != null) {
+            info.touch(); // 마지막 활동 시각 갱신
+        }
+        return info;
+    }
+
+    /**
+     * 세션을 무효화(로그아웃)한다.
+     *
+     * @param sessionId 무효화할 세션 ID
+     */
+    public void invalidate(String sessionId) {
+        if (sessionId == null) return;
+        SessionInfo info = sessions.remove(sessionId);
+        sessionChannels.remove(sessionId);
+        if (info != null) {
+            userSessions.remove(info.getUserId());
+            log.info("[Session] 세션 만료 (userId={}, sessionId={})", info.getUserId(), sessionId);
+        }
+    }
+
+    /**
+     * 채널이 끊길 때 호출 — 해당 채널의 세션을 정리한다.
+     *
+     * @param channel 끊긴 Netty 채널
+     */
+    public void onChannelInactive(Channel channel) {
+        // 채널 ID로 sessionId를 역탐색해 제거
+        sessionChannels.entrySet().removeIf(entry -> {
+            if (entry.getValue().equals(channel)) {
+                invalidate(entry.getKey());
+                return true;
+            }
+            return false;
+        });
+    }
+
+    // ── 공지 구독 채널 관리 ────────────────────────────────────────────────────
+
+    /**
+     * 공지 구독 채널로 등록한다.
+     *
+     * @param channel 등록할 채널 (NOTICE_SUBSCRIBE 요청을 보낸 채널)
+     */
+    public void addNoticeSubscriber(Channel channel) {
+        noticeSubscribers.add(channel);
+        log.debug("[Notice] 구독 채널 등록 (channel={}, 총 구독자={})",
+                channel.id(), noticeSubscribers.size());
+    }
+
+    /**
+     * @return 현재 공지 구독 채널 그룹 (브로드캐스트에 직접 사용 가능)
+     */
+    public ChannelGroup getNoticeSubscribers() {
+        return noticeSubscribers;
+    }
+
+    /** @return 현재 활성 세션 수 */
+    public int getSessionCount() {
+        return sessions.size();
+    }
+
+    /** @return 현재 공지 구독자 수 */
+    public int getSubscriberCount() {
+        return noticeSubscribers.size();
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/web/controller/AuthController.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/web/controller/AuthController.java
@@ -1,0 +1,184 @@
+/**
+ * @file AuthController.java
+ * @description 인증 REST 컨트롤러.
+ *              프론트엔드 Axios 클라이언트와 HTTP로 통신하는 인증 엔드포인트를 제공한다.
+ *
+ * @description 엔드포인트:
+ *   POST /api/auth/login    — 로그인 (세션 발급 + httpOnly 쿠키 설정)
+ *   POST /api/auth/refresh  — Access Token 갱신 (httpOnly 쿠키 기반)
+ *   POST /api/auth/logout   — 로그아웃 (세션 무효화 + 쿠키 삭제)
+ *   GET  /api/auth/me       — 현재 사용자 프로필 조회
+ */
+package com.example.tcpbackend.web.controller;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.tcpbackend.domain.auth.AuthService;
+import com.example.tcpbackend.domain.auth.dto.UserRow;
+import com.example.tcpbackend.tcp.session.SessionInfo;
+import com.example.tcpbackend.tcp.session.TcpSessionManager;
+
+/**
+ * 인증 컨트롤러.
+ *
+ * <p>세션 ID를 Access Token으로 사용한다 (POC 방식 — 실제 JWT 미사용).
+ * Refresh Token은 동일한 세션 ID를 httpOnly 쿠키에 저장해 갱신 요청 시 재사용한다.
+ *
+ * <pre>{@code
+ * 로그인 응답:
+ *   Body  : { success, userId, userName, userGrade, token, lastLogin }
+ *   Cookie: hnc_refresh={sessionId}; HttpOnly; Path=/api/auth; Max-Age=604800
+ * }</pre>
+ */
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    /** Refresh Token 쿠키 이름 */
+    private static final String REFRESH_COOKIE = "hnc_refresh";
+
+    private final AuthService authService;
+    private final TcpSessionManager sessionManager;
+
+    public AuthController(AuthService authService, TcpSessionManager sessionManager) {
+        this.authService = authService;
+        this.sessionManager = sessionManager;
+    }
+
+    // ── 엔드포인트 ────────────────────────────────────────────────────────────
+
+    /**
+     * 로그인 처리.
+     * 성공 시 sessionId를 Access Token으로 반환하고, httpOnly 쿠키에 Refresh Token을 설정한다.
+     *
+     * @param body     { userId, password }
+     * @param response Refresh Token 쿠키 설정용
+     */
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody LoginRequest body, HttpServletResponse response) {
+        try {
+            UserRow user = authService.login(body.userId(), body.password());
+            String sessionId = sessionManager.createSession(
+                    user.userId(), user.userName(), user.userGrade());
+
+            // httpOnly 쿠키에 Refresh Token 설정 (브라우저가 /api/auth/* 요청 시 자동 전송)
+            response.addCookie(buildRefreshCookie(sessionId, 7 * 24 * 3600));
+
+            Map<String, Object> data = new LinkedHashMap<>();
+            data.put("success", true);
+            data.put("userId", user.userId());
+            data.put("userName", user.userName());
+            data.put("userGrade", user.userGrade());
+            data.put("token", sessionId);  // 프론트엔드가 localStorage에 저장하는 Access Token
+            data.put("lastLogin", AuthService.formatLoginDtime(user.lastLoginDtime()));
+
+            return ResponseEntity.ok(data);
+
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            // 아이디/비밀번호 오류 or 비활성 계정 → 401
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("success", false, "error", e.getMessage()));
+        }
+    }
+
+    /**
+     * Access Token 갱신.
+     * httpOnly 쿠키의 Refresh Token(= sessionId)을 검증하고 새 Access Token을 반환한다.
+     * POC에서는 세션이 유효하면 동일한 sessionId를 재발급한다.
+     *
+     * @param request Refresh Token 쿠키 추출용
+     */
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refresh(HttpServletRequest request) {
+        String refreshToken = extractRefreshCookie(request);
+        if (refreshToken == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("error", "리프레시 토큰이 없습니다."));
+        }
+
+        SessionInfo session = sessionManager.getSession(refreshToken);
+        if (session == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("error", "만료된 세션입니다. 다시 로그인해 주세요."));
+        }
+
+        // 프로필에서 최신 lastLogin을 가져와 함께 반환
+        Map<String, Object> profile = authService.getProfile(session.getUserId());
+        return ResponseEntity.ok(Map.of(
+                "accessToken", refreshToken,
+                "lastLogin", profile.getOrDefault("lastLogin", "")
+        ));
+    }
+
+    /**
+     * 로그아웃 처리.
+     * 세션을 무효화하고 Refresh Token 쿠키를 삭제한다.
+     */
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
+        String sessionId = (String) request.getAttribute("sessionId");
+        if (sessionId != null) {
+            sessionManager.invalidate(sessionId);
+        }
+        // Max-Age=0 으로 쿠키 즉시 만료
+        response.addCookie(buildRefreshCookie("", 0));
+        return ResponseEntity.ok(Map.of("success", true));
+    }
+
+    /**
+     * 현재 사용자 프로필 조회.
+     * 대시보드 진입 시 lastLogin이 없는 경우를 보완하는 용도로 사용된다.
+     */
+    @GetMapping("/me")
+    public ResponseEntity<?> me(HttpServletRequest request) {
+        SessionInfo session = (SessionInfo) request.getAttribute("session");
+        try {
+            Map<String, Object> profile = authService.getProfile(session.getUserId());
+            return ResponseEntity.ok(profile);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    // ── 내부 유틸 ────────────────────────────────────────────────────────────
+
+    /** httpOnly Refresh Token 쿠키를 생성한다. */
+    private Cookie buildRefreshCookie(String value, int maxAge) {
+        Cookie cookie = new Cookie(REFRESH_COOKIE, value);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/api/auth");  // /api/auth/* 요청에만 자동 첨부
+        cookie.setMaxAge(maxAge);
+        return cookie;
+    }
+
+    /** 요청에서 Refresh Token 쿠키 값을 추출한다. */
+    private String extractRefreshCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return null;
+        return Arrays.stream(cookies)
+                .filter(c -> REFRESH_COOKIE.equals(c.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    // ── 요청 DTO ─────────────────────────────────────────────────────────────
+
+    /** POST /api/auth/login 요청 본문 */
+    record LoginRequest(String userId, String password) {}
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/web/controller/CardController.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/web/controller/CardController.java
@@ -1,0 +1,150 @@
+/**
+ * @file CardController.java
+ * @description 카드 도메인 REST 컨트롤러.
+ *              프론트엔드에서 호출하는 카드 관련 엔드포인트를 제공한다.
+ *
+ * @description 엔드포인트:
+ *   GET    /api/cards                          — 카드 목록 조회
+ *   GET    /api/cards/{cardId}/payable-amount  — 즉시결제 가능금액 조회
+ *   POST   /api/cards/{cardId}/immediate-pay   — 즉시결제 처리
+ *   DELETE /api/cards/{cardId}/pin-attempts    — PIN 시도 횟수 초기화
+ */
+package com.example.tcpbackend.web.controller;
+
+import java.util.List;
+import java.util.Map;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.example.tcpbackend.domain.card.CardService;
+import com.example.tcpbackend.domain.card.CardService.BusinessException;
+import com.example.tcpbackend.domain.card.CardService.PinException;
+import com.example.tcpbackend.tcp.session.SessionInfo;
+
+/**
+ * 카드 컨트롤러.
+ *
+ * <p>모든 엔드포인트는 SessionAuthInterceptor가 검증한 세션을 request attribute에서 꺼내 사용한다.
+ *
+ * <p>즉시결제 PIN 오류 응답 형식:
+ * <pre>{@code
+ * { "error": "PIN 번호가 올바르지 않습니다.", "attemptsLeft": 2 }  // HTTP 403
+ * }</pre>
+ */
+@RestController
+@RequestMapping("/api/cards")
+public class CardController {
+
+    private static final Logger log = LoggerFactory.getLogger(CardController.class);
+
+    private final CardService cardService;
+
+    public CardController(CardService cardService) {
+        this.cardService = cardService;
+    }
+
+    /**
+     * 카드 목록 조회.
+     *
+     * @return { cards: [ { id, name, maskedNumber, balance, paymentBank, paymentAccount, ... } ] }
+     */
+    @GetMapping
+    public ResponseEntity<?> getCards(HttpServletRequest request) {
+        SessionInfo session = (SessionInfo) request.getAttribute("session");
+        try {
+            List<Map<String, Object>> cards = cardService.getCards(session.getUserId());
+            return ResponseEntity.ok(Map.of("cards", cards));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "카드 목록 조회 중 오류가 발생했습니다."));
+        }
+    }
+
+    /**
+     * 즉시결제 가능금액 조회.
+     *
+     * @param cardId 카드번호 (URL 경로 변수)
+     * @return { payableAmount, creditLimit }
+     */
+    @GetMapping("/{cardId}/payable-amount")
+    public ResponseEntity<?> getPayableAmount(@PathVariable String cardId,
+                                               HttpServletRequest request) {
+        SessionInfo session = (SessionInfo) request.getAttribute("session");
+        try {
+            Map<String, Object> data = cardService.getPayableAmount(session.getUserId(), cardId);
+            return ResponseEntity.ok(data);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "가능금액 조회 중 오류가 발생했습니다."));
+        }
+    }
+
+    /**
+     * 즉시결제 처리.
+     *
+     * <p>PIN 오류 시 HTTP 403과 함께 attemptsLeft를 반환한다.
+     * 프론트엔드 인터셉터가 401만 재시도하므로 PIN 오류는 반드시 403을 사용해야 한다.
+     *
+     * @param cardId 카드번호 (URL 경로 변수)
+     * @param body   { pin, amount, accountNumber }
+     * @return { paidAmount, processedCount, completedAt }
+     */
+    @PostMapping("/{cardId}/immediate-pay")
+    public ResponseEntity<?> immediatePay(@PathVariable String cardId,
+                                           @RequestBody ImmediatePayRequest body,
+                                           HttpServletRequest request) {
+        SessionInfo session = (SessionInfo) request.getAttribute("session");
+        try {
+            Map<String, Object> result = cardService.immediatePay(
+                    session.getUserId(), cardId, body.pin(), body.amount(), body.accountNumber());
+            return ResponseEntity.ok(result);
+
+        } catch (PinException e) {
+            // PIN 오류: 403 + attemptsLeft 반환 (인터셉터 재시도 방지)
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Map.of("error", e.getMessage(), "attemptsLeft", e.getAttemptsLeft()));
+
+        } catch (BusinessException e) {
+            // 잔액 부족, 계좌 미존재 등 비즈니스 오류: 400
+            return ResponseEntity.badRequest()
+                    .body(Map.of("error", e.getMessage()));
+
+        } catch (Exception e) {
+            log.error("즉시결제 처리 중 예외 발생 — cardId={}, userId={}", cardId, session.getUserId(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "즉시결제 처리 중 오류가 발생했습니다."));
+        }
+    }
+
+    /**
+     * PIN 시도 횟수 초기화.
+     * 프론트엔드에서 횟수 초과 후 초기화 버튼 클릭 시 호출된다.
+     *
+     * @param cardId 카드번호 (URL 경로 변수)
+     */
+    @DeleteMapping("/{cardId}/pin-attempts")
+    public ResponseEntity<?> resetPinAttempts(@PathVariable String cardId,
+                                               HttpServletRequest request) {
+        SessionInfo session = (SessionInfo) request.getAttribute("session");
+        cardService.resetPinAttempts(session.getUserId(), cardId);
+        return ResponseEntity.ok(Map.of("ok", true));
+    }
+
+    // ── 요청 DTO ─────────────────────────────────────────────────────────────
+
+    /** POST /api/cards/{cardId}/immediate-pay 요청 본문 */
+    record ImmediatePayRequest(String pin, long amount, String accountNumber) {}
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/web/controller/NoticeController.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/web/controller/NoticeController.java
@@ -1,0 +1,52 @@
+/**
+ * @file NoticeController.java
+ * @description 긴급공지 SSE REST 컨트롤러.
+ *              프론트엔드 EventSource가 연결하는 SSE 엔드포인트를 제공한다.
+ *
+ * @description 엔드포인트:
+ *   GET /api/notices/sse — SSE 구독 (인증 불필요, Vite 프록시 경유)
+ *
+ * @description SSE 이벤트 형식:
+ *   event: notice
+ *   data: {"notices":[...],"displayType":"A","closeableYn":"Y","hideTodayYn":"Y"}
+ *
+ *   공지 없음:
+ *   event: notice
+ *   data: null
+ */
+package com.example.tcpbackend.web.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.example.tcpbackend.domain.notice.NoticeService;
+
+/**
+ * 긴급공지 SSE 컨트롤러.
+ *
+ * <p>프론트엔드 {@code useEmergencyNotice} 훅의 EventSource가 이 엔드포인트에 연결한다.
+ * Vite 프록시(5173 → 9998)를 통해 접근하므로 CORS 설정이 불필요하다.
+ */
+@RestController
+@RequestMapping("/api/notices")
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    public NoticeController(NoticeService noticeService) {
+        this.noticeService = noticeService;
+    }
+
+    /**
+     * SSE 구독 엔드포인트.
+     * 연결 즉시 현재 공지 상태를 전송하고, 이후 변경 시 이벤트를 푸시한다.
+     *
+     * @return SseEmitter (Spring이 연결을 유지하며 이벤트를 스트리밍)
+     */
+    @GetMapping("/sse")
+    public SseEmitter subscribe() {
+        return noticeService.subscribe();
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/web/controller/TransactionController.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/web/controller/TransactionController.java
@@ -1,0 +1,98 @@
+/**
+ * @file TransactionController.java
+ * @description 이용내역/결제명세서 REST 컨트롤러.
+ *              프론트엔드에서 호출하는 이용내역 관련 엔드포인트를 제공한다.
+ *
+ * @description 엔드포인트:
+ *   GET /api/transactions      — 이용내역 조회 (다양한 필터 쿼리 파라미터 지원)
+ *   GET /api/payment-statement — 결제예정금액/명세서 조회
+ */
+package com.example.tcpbackend.web.controller;
+
+import java.util.Map;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.tcpbackend.domain.transaction.TransactionService;
+import com.example.tcpbackend.tcp.session.SessionInfo;
+
+/**
+ * 이용내역·결제명세서 컨트롤러.
+ */
+@RestController
+@RequestMapping("/api")
+public class TransactionController {
+
+    private final TransactionService transactionService;
+
+    public TransactionController(TransactionService transactionService) {
+        this.transactionService = transactionService;
+    }
+
+    /**
+     * 이용내역 조회.
+     *
+     * @param cardId      카드번호 (선택 — 없으면 전체 카드)
+     * @param period      기간 유형: thisMonth | 1month | 3months | custom (선택)
+     * @param customMonth period=custom 시 조회 월 (YYYY-MM 형식)
+     * @param fromDate    직접 지정 시작일 (YYYYMMDD)
+     * @param toDate      직접 지정 종료일 (YYYYMMDD)
+     * @param usageType   이용 유형: lump | installment | cancel (선택 — 없으면 전체)
+     * @return { transactions, totalCount, paymentSummary }
+     */
+    @GetMapping("/transactions")
+    public ResponseEntity<?> getTransactions(
+            @RequestParam(required = false) String cardId,
+            @RequestParam(required = false) String period,
+            @RequestParam(required = false) String customMonth,
+            @RequestParam(required = false) String fromDate,
+            @RequestParam(required = false) String toDate,
+            @RequestParam(required = false) String usageType,
+            HttpServletRequest request) {
+
+        SessionInfo session = (SessionInfo) request.getAttribute("session");
+        try {
+            Map<String, Object> data = transactionService.getTransactions(
+                    session.getUserId(), cardId, period, customMonth, fromDate, toDate, usageType);
+            return ResponseEntity.ok(data);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "이용내역 조회 중 오류가 발생했습니다."));
+        }
+    }
+
+    /**
+     * 결제예정금액/명세서 조회.
+     *
+     * @param yearMonth  조회 청구월 (YYYY-MM 형식, 선택)
+     * @param paymentDay 결제일 (선택 — 공여기간 기준 계산에 사용)
+     * @return { dueDate, totalAmount, items, cardInfo, billingPeriod }
+     */
+    @GetMapping("/payment-statement")
+    public ResponseEntity<?> getPaymentStatement(
+            @RequestParam(required = false) String yearMonth,
+            @RequestParam(required = false) String paymentDay,
+            HttpServletRequest request) {
+
+        SessionInfo session = (SessionInfo) request.getAttribute("session");
+        try {
+            Map<String, Object> data = transactionService.getPaymentStatement(
+                    session.getUserId(), yearMonth, paymentDay);
+            return ResponseEntity.ok(data);
+        } catch (IllegalStateException e) {
+            // 공여기간 계산 실패 등 비즈니스 오류
+            return ResponseEntity.badRequest()
+                    .body(Map.of("error", e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "결제예정금액 조회 중 오류가 발생했습니다."));
+        }
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/web/filter/RequestLoggingFilter.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/web/filter/RequestLoggingFilter.java
@@ -27,6 +27,7 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
 
 /**
  * API 요청/응답 로깅 필터.
@@ -38,6 +39,14 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
 
     /** 로그에 출력할 바디 최대 길이 (너무 크면 로그가 지저분해지므로 제한) */
     private static final int MAX_BODY_LENGTH = 2000;
+
+    /**
+     * JSON 바디에서 민감 필드 값을 마스킹하기 위한 정규식.
+     * password, pin, secret, adminSecret, token 등의 필드 값을 "***"로 대체한다.
+     */
+    private static final Pattern SENSITIVE_FIELD_PATTERN = Pattern.compile(
+            "(?i)(\"(?:password|pin|secret|adminSecret|token)\"\\s*:\\s*)\"[^\"]*\""
+    );
 
     @Override
     protected void doFilterInternal(
@@ -75,7 +84,8 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
             long elapsed = System.currentTimeMillis() - startMs;
             int  status  = wrappedRes.getStatus();
 
-            String reqBody = extractBody(wrappedReq.getContentAsByteArray());
+            // 요청 바디는 비밀번호 등 민감 정보가 포함될 수 있으므로 마스킹 처리한다.
+            String reqBody = maskSensitiveFields(extractBody(wrappedReq.getContentAsByteArray()));
             String resBody = extractBody(wrappedRes.getContentAsByteArray());
 
             if (status >= 500) {
@@ -110,5 +120,16 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
             return body.substring(0, MAX_BODY_LENGTH) + "... (truncated)";
         }
         return body;
+    }
+
+    /**
+     * JSON 문자열에서 민감 필드(password, pin, secret 등)의 값을 "***"로 대체한다.
+     * 로그인 요청 등에서 비밀번호가 평문으로 로그에 남는 것을 방지한다.
+     *
+     * @param body 로그 출력 전 바디 문자열
+     * @return 민감 필드가 마스킹된 문자열
+     */
+    private String maskSensitiveFields(String body) {
+        return SENSITIVE_FIELD_PATTERN.matcher(body).replaceAll("$1\"***\"");
     }
 }

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/web/filter/RequestLoggingFilter.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/web/filter/RequestLoggingFilter.java
@@ -1,0 +1,114 @@
+/**
+ * @file RequestLoggingFilter.java
+ * @description 모든 HTTP API 요청/응답을 콘솔에 출력하는 서블릿 필터.
+ *
+ * <p>요청마다 다음 정보를 로깅한다:
+ * <ul>
+ *   <li>[→ REQ] 메서드, URI, 쿼리스트링, 클라이언트 IP, 요청 바디</li>
+ *   <li>[← RES] HTTP 상태 코드, 소요 시간(ms), 응답 바디</li>
+ *   <li>[✗ ERR] 처리 중 예외 발생 시 예외 메시지 추가 출력</li>
+ * </ul>
+ *
+ * <p>요청/응답 바디는 InputStream이 한 번만 읽힐 수 있으므로
+ * ContentCachingRequestWrapper / ContentCachingResponseWrapper로 래핑해 재사용한다.
+ * SSE 스트리밍 응답은 바디를 버퍼링하지 않는다.
+ */
+package com.example.tcpbackend.web.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * API 요청/응답 로깅 필터.
+ * OncePerRequestFilter 상속으로 요청당 정확히 한 번만 실행된다.
+ */
+@Slf4j
+@Component
+public class RequestLoggingFilter extends OncePerRequestFilter {
+
+    /** 로그에 출력할 바디 최대 길이 (너무 크면 로그가 지저분해지므로 제한) */
+    private static final int MAX_BODY_LENGTH = 2000;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest  request,
+            HttpServletResponse response,
+            FilterChain         filterChain
+    ) throws ServletException, IOException {
+
+        long   startMs = System.currentTimeMillis();
+        String method  = request.getMethod();
+        String uri     = request.getRequestURI();
+        String query   = request.getQueryString();
+        String client  = request.getRemoteAddr();
+
+        // SSE 스트리밍은 응답을 버퍼링하면 클라이언트에 데이터가 전달되지 않으므로 래핑을 건너뛴다.
+        boolean isSse = "text/event-stream".equals(request.getHeader("Accept"));
+        if (isSse) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 요청/응답 바디를 여러 번 읽기 위해 캐싱 래퍼로 교체한다.
+        ContentCachingRequestWrapper  wrappedReq = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper wrappedRes = new ContentCachingResponseWrapper(response);
+
+        String uriWithQuery = query != null ? uri + "?" + query : uri;
+
+        try {
+            filterChain.doFilter(wrappedReq, wrappedRes);
+        } catch (Exception ex) {
+            long elapsed = System.currentTimeMillis() - startMs;
+            log.error("✗ ERR  {} {}  {}ms  exception={}", method, uri, elapsed, ex.getMessage(), ex);
+            throw ex;
+        } finally {
+            long elapsed = System.currentTimeMillis() - startMs;
+            int  status  = wrappedRes.getStatus();
+
+            String reqBody = extractBody(wrappedReq.getContentAsByteArray());
+            String resBody = extractBody(wrappedRes.getContentAsByteArray());
+
+            if (status >= 500) {
+                log.error("→ REQ  {} {}  (from {})  body={}", method, uriWithQuery, client, reqBody);
+                log.error("← RES  {} {}  {} ({}ms)  body={}", method, uri, status, elapsed, resBody);
+            } else if (status >= 400) {
+                log.warn ("→ REQ  {} {}  (from {})  body={}", method, uriWithQuery, client, reqBody);
+                log.warn ("← RES  {} {}  {} ({}ms)  body={}", method, uri, status, elapsed, resBody);
+            } else {
+                log.info ("→ REQ  {} {}  (from {})  body={}", method, uriWithQuery, client, reqBody);
+                log.info ("← RES  {} {}  {} ({}ms)  body={}", method, uri, status, elapsed, resBody);
+            }
+
+            // 래핑된 응답의 바디를 실제 클라이언트에게 복사한다. (필수: 누락 시 응답 바디 유실)
+            wrappedRes.copyBodyToResponse();
+        }
+    }
+
+    /**
+     * 바이트 배열을 UTF-8 문자열로 변환한다.
+     * 바디가 없으면 "(empty)", MAX_BODY_LENGTH 초과분은 잘라낸다.
+     *
+     * @param bytes 캐싱된 바디 바이트 배열
+     * @returns 로그 출력용 문자열
+     */
+    private String extractBody(byte[] bytes) {
+        if (bytes == null || bytes.length == 0) {
+            return "(empty)";
+        }
+        String body = new String(bytes, StandardCharsets.UTF_8);
+        if (body.length() > MAX_BODY_LENGTH) {
+            return body.substring(0, MAX_BODY_LENGTH) + "... (truncated)";
+        }
+        return body;
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/web/interceptor/SessionAuthInterceptor.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/web/interceptor/SessionAuthInterceptor.java
@@ -1,0 +1,70 @@
+/**
+ * @file SessionAuthInterceptor.java
+ * @description HTTP 요청 세션 인증 인터셉터.
+ *              Authorization: Bearer {sessionId} 헤더를 검증하고
+ *              유효한 경우 SessionInfo를 request attribute에 저장한다.
+ *
+ * @description 적용 대상: /api/** (WebConfig에서 login·refresh·sse 경로는 제외)
+ * @description request attribute:
+ *   - "session"   : SessionInfo (컨트롤러에서 사용자 정보 접근용)
+ *   - "sessionId" : String (로그아웃 시 세션 무효화용)
+ */
+package com.example.tcpbackend.web.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.example.tcpbackend.tcp.session.SessionInfo;
+import com.example.tcpbackend.tcp.session.TcpSessionManager;
+
+/**
+ * 세션 인증 인터셉터.
+ *
+ * <p>Authorization 헤더가 없거나 세션이 유효하지 않으면 401을 반환하고 요청을 차단한다.
+ */
+@Component
+public class SessionAuthInterceptor implements HandlerInterceptor {
+
+    private final TcpSessionManager sessionManager;
+
+    public SessionAuthInterceptor(TcpSessionManager sessionManager) {
+        this.sessionManager = sessionManager;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request,
+                             HttpServletResponse response,
+                             Object handler) throws Exception {
+
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            writeUnauthorized(response, "인증이 필요합니다.");
+            return false;
+        }
+
+        String sessionId = authHeader.substring(7).trim();
+        SessionInfo session = sessionManager.getSession(sessionId);
+
+        if (session == null) {
+            writeUnauthorized(response, "유효하지 않은 세션입니다. 다시 로그인해 주세요.");
+            return false;
+        }
+
+        // 컨트롤러에서 사용자 정보와 세션 ID를 꺼낼 수 있도록 attribute에 저장
+        request.setAttribute("session", session);
+        request.setAttribute("sessionId", sessionId);
+        return true;
+    }
+
+    /** 401 응답 본문에 JSON 오류 메시지를 작성한다. */
+    private void writeUnauthorized(HttpServletResponse response, String message) throws Exception {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write("{\"error\":\"" + message + "\"}");
+    }
+}

--- a/demo/tcp-backend/src/main/resources/application.yml
+++ b/demo/tcp-backend/src/main/resources/application.yml
@@ -1,0 +1,32 @@
+server:
+  port: 9998                               # HTTP REST API 포트 (프론트엔드 연결용)
+
+spring:
+  datasource:
+    url: ${DB_URL:jdbc:oracle:thin:@neobns.com:11521/XE}
+    username: ${DB_USERNAME:guest01}
+    password: ${DB_PASSWORD:1q2w3e4r!@}
+    driver-class-name: oracle.jdbc.OracleDriver
+    hikari:
+      # Oracle 환경에 최적화된 커넥션 풀 설정
+      maximum-pool-size: 20
+      minimum-idle: 5
+      connection-timeout: 30000       # 30초: 커넥션 획득 대기 한계
+      idle-timeout: 600000            # 10분: 유휴 커넥션 반환 주기
+      max-lifetime: 1800000           # 30분: 커넥션 최대 수명 (Oracle 세션 타임아웃 고려)
+      connection-test-query: SELECT 1 FROM DUAL
+
+tcp:
+  port: ${TCP_PORT:19998}             # Netty TCP 포트 (HTTP 9998과 충돌 방지)
+  boss-threads: 1                     # Netty acceptor 스레드 수 (단일로 충분)
+  worker-threads: 4                   # I/O 처리 스레드 수 (CPU 코어 수 기준 조정)
+  max-frame-length: 1048576           # 최대 메시지 크기: 1MB
+
+auth:
+  pin-max-attempts: 3                 # PIN 최대 허용 실패 횟수 (3회 초과 시 잠금)
+  admin-secret: ${ADMIN_SECRET:admin-secret}  # Admin 전용 커맨드 인증 비밀 키
+
+logging:
+  level:
+    com.example.tcpbackend: DEBUG
+    io.netty: INFO

--- a/demo/tcp-backend/tcp-server.log
+++ b/demo/tcp-backend/tcp-server.log
@@ -1,0 +1,18 @@
+
+  .   ____          _            __ _ _
+ /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
+( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
+ \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
+  '  |____| .__|_| |_|_| |_\__, | / / / /
+ =========|_|==============|___/=/_/_/_/
+ :: Spring Boot ::                (v3.2.5)
+
+2026-04-21T14:46:41.479+09:00  INFO 22648 --- [           main] c.e.tcpbackend.TcpBackendApplication     : Starting TcpBackendApplication v0.0.1-SNAPSHOT using Java 19.0.1 with PID 22648 (C:\Users\82103\yjpark\workspace\NEOBNS\POC_HNC\demo\tcp-backend\target\tcp-backend-0.0.1-SNAPSHOT.jar started by 82103 in C:\Users\82103\yjpark\workspace\NEOBNS\POC_HNC\demo\tcp-backend)
+2026-04-21T14:46:41.485+09:00 DEBUG 22648 --- [           main] c.e.tcpbackend.TcpBackendApplication     : Running with Spring Boot v3.2.5, Spring v6.1.6
+2026-04-21T14:46:41.487+09:00  INFO 22648 --- [           main] c.e.tcpbackend.TcpBackendApplication     : No active profile set, falling back to 1 default profile: "default"
+2026-04-21T14:46:46.600+09:00  INFO 22648 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Starting...
+2026-04-21T14:46:47.808+09:00  INFO 22648 --- [           main] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection oracle.jdbc.driver.T4CConnection@58437801
+2026-04-21T14:46:47.811+09:00  INFO 22648 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Start completed.
+2026-04-21T14:46:47.847+09:00  INFO 22648 --- [           main] c.e.t.domain.notice.NoticeService        : [Notice] 배포 중인 긴급공지 없음 — 초기 상태로 기동
+2026-04-21T14:46:48.217+09:00  INFO 22648 --- [           main] c.e.t.config.NettyTcpServerConfig        : [TCP Server] Netty TCP 서버 기동 완료 — port: 9998, boss: 1, worker: 4
+2026-04-21T14:46:48.546+09:00  INFO 22648 --- [           main] c.e.tcpbackend.TcpBackendApplication     : Started TcpBackendApplication in 8.824 seconds (process running for 10.001)


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #129
Closes #130

## ✨ 변경 사항 (Changes)

### 1. `demo/tcp-backend` — Netty 기반 TCP 서버 신규 모듈 추가 (#129)
- **Spring Boot 3.2.5 + Netty** 기반 독립 백엔드 서버 신규 추가
- HTTP REST API(**포트 9998**) + TCP 서버(**포트 19998**) 이중 운영
- 4바이트 길이 헤더 + JSON 커스텀 코덱 (`LengthPrefixDecoder` / `LengthPrefixEncoder`)
- 도메인별 핸들러 구현: 인증(Auth), 카드(Card), 거래(Transaction), 공지(Notice)
- Oracle DB + HikariCP 커넥션 풀 연동
- TCP 세션 관리: `TcpSessionManager`, `SessionInfo`
- HTTP 공통 인프라: `SessionAuthInterceptor`, `RequestLoggingFilter`

### 2. `demo/front` — Vite 프록시 확장 및 axios baseURL 상대경로 전환 (#130)
- `axiosInstance.ts`: `API_BASE`를 `'http://localhost:3001/api'` → `'/api'`(상대경로)로 변경하여 CORS 우회 차단
- `vite.config.ts`: 프록시 키를 `/api/notices` → `/api` 전체로 확장, target을 `http://localhost:9998`로 변경

## ⚠️ 고려 및 주의 사항 (선택)
- `demo/tcp-backend`는 Oracle DB(`jdbc:oracle:thin:@neobns.com:11521/XE`) 연결이 필요하므로 로컬 실행 시 DB 접근 환경 확인 필요
- 프론트엔드 개발 서버는 Vite 프록시를 통해 `localhost:9998`로 라우팅되므로 tcp-backend 서버 기동이 선행되어야 함

## 💬 리뷰 포인트 (선택)
- TCP 메시지 라우팅 로직 (`TcpMessageHandler`) 및 도메인 핸들러 분기 처리
- Vite 프록시 범위 확장(`/api` 전체)으로 인한 기존 API 엔드포인트 영향 없는지 확인

## 🔗 참고 사항 (선택)
- HTTP 포트: `9998`, TCP 포트: `19998`
- 기존 demo-backend(포트 3001)는 별도 유지