### PR TITLE
[FEATURE #132]: 승인 관리 화면 공개여부 컬럼 UI 숨김

### DIFF
--- a/admin/src/main/resources/templates/pages/cms-approval/cms-approval-script.html
+++ b/admin/src/main/resources/templates/pages/cms-approval/cms-approval-script.html
@@ -137,7 +137,8 @@
                     <td class="text-center">${HtmlUtils.escape(row.viewMode || '')}</td>
                     <td>${HtmlUtils.escape(row.createUserName || '')}</td>
                     <td class="text-center">${badge}</td>
-                    <td class="text-center">${isPublicBtn}</td>
+                    <!-- 공개여부 컬럼 UI 숨김 (#132) — 정책 확정 시 주석 해제 + approval-table.html colspan 복원 -->
+                    <!-- <td class="text-center">${isPublicBtn}</td> -->
                     <td class="text-center">${HtmlUtils.escape(row.beginningDate || '-')}</td>
                     <td class="text-center ${expiredCls}">${HtmlUtils.escape(row.expiredDate || '-')}</td>
                     <td class="text-center small">${HtmlUtils.escape(row.lastModifiedDtime || '-')}</td>

--- a/admin/src/main/resources/templates/pages/cms-approval/cms-approval-script.html
+++ b/admin/src/main/resources/templates/pages/cms-approval/cms-approval-script.html
@@ -93,7 +93,7 @@
             const $tbody = $('#approvalTableBody');
             if (!rows || rows.length === 0) {
                 this.rowsByPageId = {};
-                $tbody.html('<tr><td colspan="10" class="text-center py-4 text-body-secondary">조회된 데이터가 없습니다.</td></tr>');
+                $tbody.html('<tr><td colspan="9" class="text-center py-4 text-body-secondary">조회된 데이터가 없습니다.</td></tr>');
                 return;
             }
 
@@ -137,7 +137,7 @@
                     <td class="text-center">${HtmlUtils.escape(row.viewMode || '')}</td>
                     <td>${HtmlUtils.escape(row.createUserName || '')}</td>
                     <td class="text-center">${badge}</td>
-                    <!-- 공개여부 컬럼 UI 숨김 (#132) — 정책 확정 시 주석 해제 + approval-table.html colspan 복원 -->
+                    <!-- 공개여부 컬럼 UI 숨김 (#132) — 정책 확정 시 주석 해제 + 두 곳의 colspan 9→10 복원 (approval-table.html:23, 이 파일 96행) -->
                     <!-- <td class="text-center">${isPublicBtn}</td> -->
                     <td class="text-center">${HtmlUtils.escape(row.beginningDate || '-')}</td>
                     <td class="text-center ${expiredCls}">${HtmlUtils.escape(row.expiredDate || '-')}</td>

--- a/admin/src/main/resources/templates/pages/cms-approval/cms-approval-table.html
+++ b/admin/src/main/resources/templates/pages/cms-approval/cms-approval-table.html
@@ -10,7 +10,8 @@
                 <th class="col-w-80 sortable" data-sort="viewMode">뷰모드</th>
                 <th class="col-w-90 sortable" data-sort="createUserName">작성자</th>
                 <th class="col-w-100 sortable" data-sort="approveState">승인상태</th>
-                <th class="col-w-80 sortable" data-sort="isPublic">공개여부</th>
+                <!-- 공개여부 컬럼: 정책 확정 전까지 UI 숨김 (#132). 복원 시 주석 해제 + 아래 colspan="9" → "10" -->
+                <!-- <th class="col-w-80 sortable" data-sort="isPublic">공개여부</th> -->
                 <th class="col-w-100 sortable" data-sort="beginningDate">노출시작일</th>
                 <th class="col-w-100 sortable" data-sort="expiredDate">노출종료일</th>
                 <th class="col-w-150 sortable" data-sort="lastModifiedDtime">최종수정일시</th>
@@ -20,7 +21,7 @@
         </thead>
         <tbody id="approvalTableBody">
             <tr>
-                <td colspan="10" class="text-center py-4 text-body-secondary">
+                <td colspan="9" class="text-center py-4 text-body-secondary">
                     조회 버튼을 클릭하여 데이터를 불러오세요.
                 </td>
             </tr>


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
- Closes #132

## ✨ 변경 사항 (Changes)

공개/비공개 기능 정책이 확정되기 전까지 `/cms-admin/approvals` 테이블에서 **공개여부 컬럼만 UI 에서 비노출**.
백엔드·DB·토글 로직은 그대로 유지하여 정책 확정 시 주석 해제만으로 즉시 복원 가능한 상태로 둔다.

### UI 변경
- **`cms-approval-table.html`**
  - `<th data-sort="isPublic">공개여부</th>` 주석 처리
  - 빈 데이터 안내 행 `colspan="10"` → `"9"` 조정
- **`cms-approval-script.html`**
  - `renderTable` 내부 `<td>${isPublicBtn}</td>` 주석 처리

### 유지되는 것 (의도적으로 건드리지 않음)
- `CmsApprovalPage.togglePublicState()` 함수 전체
- 백엔드 공개 상태 토글 API / Service / Mapper / DTO
- `row.isPublic` 참조 로직, 특히 **승인 버튼 활성 조건 `row.isPublic !== 'N'`** — 공개여부 컬럼 숨김과 독립적인 내부 가드라 그대로 둠
- `isPublicBtn` 문자열 생성 로직 — 변수는 생성되지만 렌더 안 됨 (복원 편의)

## ⚠️ 고려 및 주의 사항

- **임시 조치**. 정책 확정 후에는 주석 해제 + colspan 복원으로 10초 내 되돌림 가능.
- `isPublic='N'` 인 행은 여전히 승인 버튼이 비활성이지만 화면에 이유가 안 보임 → 정책 미확정 상태 취지와 일치해 별도 UX 보완 없음.

## 💬 리뷰 포인트
- 주석 해제 힌트 코멘트(`#132` 참조)가 복원 시 찾기 쉬운 형태로 들어갔는지.
- 다른 컬럼 정렬/승인/이력 버튼 회귀 없음 (로컬 확인 필요).

## 🔗 참고 사항
- PR 변경량 매우 작음 (+5 / -3). 백엔드 무변경.