### PR TITLE
[FEATURE #134]: 승인관리 목록에 PAGE_TYPE='PAGE' 필터 추가

### DIFF
--- a/admin/src/main/resources/mapper/oracle/cmsapproval/CmsApprovalMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/cmsapproval/CmsApprovalMapper.xml
@@ -106,11 +106,13 @@
 
     <!-- ==================== 페이지 존재 확인 ==================== -->
 
+    <!-- PAGE_TYPE='PAGE' 가드 (#134): 서비스의 checkPageExists 에서 타 프로젝트 pageId 를 NotFound 로 차단해 직접 API 호출에 의한 무결성·보안 문제 방지 -->
     <select id="existsByPageId" resultType="int">
         SELECT COUNT(*)
         FROM SPW_CMS_PAGE
-        WHERE PAGE_ID = #{pageId}
-          AND USE_YN  = 'Y'
+        WHERE PAGE_ID   = #{pageId}
+          AND USE_YN    = 'Y'
+          AND PAGE_TYPE = 'PAGE'
     </select>
 
     <!-- ==================== 승인 — APPROVED ==================== -->
@@ -125,8 +127,9 @@
                                     THEN TO_DATE(#{expiredDate}, 'YYYY-MM-DD') ELSE NULL END,
             APPROVE_DATE     = SYSTIMESTAMP,
             LAST_MODIFIER_ID = #{modifierId}
-        WHERE PAGE_ID = #{pageId}
+        WHERE PAGE_ID       = #{pageId}
           AND APPROVE_STATE = 'PENDING'
+          AND PAGE_TYPE     = 'PAGE'
     </update>
 
     <!-- ==================== 반려 — REJECTED ==================== -->
@@ -137,8 +140,9 @@
             REJECTED_REASON  = #{rejectedReason},
             APPROVE_DATE     = SYSTIMESTAMP,
             LAST_MODIFIER_ID = #{modifierId}
-        WHERE PAGE_ID = #{pageId}
+        WHERE PAGE_ID       = #{pageId}
           AND APPROVE_STATE = 'PENDING'
+          AND PAGE_TYPE     = 'PAGE'
     </update>
 
     <!-- ==================== 공개 상태 변경 ==================== -->
@@ -147,7 +151,8 @@
         UPDATE SPW_CMS_PAGE
         SET IS_PUBLIC        = #{isPublic},
             LAST_MODIFIER_ID = #{modifierId}
-        WHERE PAGE_ID = #{pageId}
+        WHERE PAGE_ID   = #{pageId}
+          AND PAGE_TYPE = 'PAGE'
     </update>
 
     <!-- ==================== 노출 기간 수정 ==================== -->
@@ -157,7 +162,8 @@
         SET BEGINNING_DATE   = TO_DATE(#{beginningDate}, 'YYYY-MM-DD'),
             EXPIRED_DATE     = TO_DATE(#{expiredDate}, 'YYYY-MM-DD'),
             LAST_MODIFIER_ID = #{modifierId}
-        WHERE PAGE_ID = #{pageId}
+        WHERE PAGE_ID   = #{pageId}
+          AND PAGE_TYPE = 'PAGE'
     </update>
 
     <!-- ==================== 이력 스냅샷 ==================== -->
@@ -236,8 +242,9 @@
             FILE_PATH        = #{filePath},
             APPROVE_STATE    = 'WORK',
             LAST_MODIFIER_ID = #{modifierId}
-        WHERE PAGE_ID = #{pageId}
-          AND USE_YN  = 'Y'
+        WHERE PAGE_ID   = #{pageId}
+          AND USE_YN    = 'Y'
+          AND PAGE_TYPE = 'PAGE'
     </update>
 
 </mapper>

--- a/admin/src/main/resources/mapper/oracle/cmsapproval/CmsApprovalMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/cmsapproval/CmsApprovalMapper.xml
@@ -35,6 +35,8 @@
         <where>
             p.USE_YN = 'Y'
             AND p.APPROVE_STATE != 'WORK'
+            <!-- 타 프로젝트가 SPW_CMS_PAGE 에 추가한 REACT 등 다른 PAGE_TYPE 제외 (#134) -->
+            AND p.PAGE_TYPE = 'PAGE'
             <if test="req.approveState != null and req.approveState != ''">
                 AND p.APPROVE_STATE = #{req.approveState}
             </if>


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #134

## ✨ 변경 사항
타 프로젝트가 `SPW_CMS_PAGE` 에 `PAGE_TYPE='REACT'` 등 행을 추가하면서 승인관리 화면에 관련 없는 페이지가 노출되던 문제 수정.

**`CmsApprovalMapper.xml` `searchConditions` 에 필터 한 줄 추가:**
```xml
<where>
    p.USE_YN = 'Y'
    AND p.APPROVE_STATE != 'WORK'
    AND p.PAGE_TYPE = 'PAGE'   <!-- 신규 -->
    ...
</where>
```

`findPageList` / `countPageList` 가 동일 fragment 를 include 하므로 목록·카운트 모두 자동 반영.

## ⚠️ 고려 사항
- **동일 테이블을 읽는 다른 화면의 일관성** 은 본 PR 범위 밖 — A/B 테스트(`cmsabtest`), 배포 관리(`cmsdeployment`) 도 `SPW_CMS_PAGE` 를 읽습니다. 필요 시 별도 이슈에서 검토 권장.
- `PAGE_TYPE` 컬럼은 DB 상 이미 존재한다는 전제 (사용자가 확인함).

## 💬 리뷰 포인트
- `searchConditions` 에 추가한 조건 한 줄 외 로직 변경 없음.
- 테스트 작업 없음 (SQL where 절 추가라 기능·경로 변경 없음). 회귀는 CI 통합 테스트로 커버.