### PR TITLE
[FEATURE #136]: A/B 테스트·배포 관리 쿼리에 PAGE_TYPE='PAGE' 가드 추가

### DIFF
--- a/admin/src/main/resources/mapper/oracle/cmsabtest/CmsAbTestMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/cmsabtest/CmsAbTestMapper.xml
@@ -44,6 +44,8 @@
         WHERE p.USE_YN = 'Y'
           AND p.APPROVE_STATE = 'APPROVED'
           AND p.IS_PUBLIC = 'Y'
+          <!-- 타 프로젝트의 REACT 등 다른 PAGE_TYPE 제외 (#136) -->
+          AND p.PAGE_TYPE = 'PAGE'
         <if test="req.search != null and req.search != ''">
           AND (
               p.PAGE_ID LIKE '%' || #{req.search} || '%'
@@ -115,6 +117,7 @@
         WHERE p.USE_YN = 'Y'
           AND p.APPROVE_STATE = 'APPROVED'
           AND p.IS_PUBLIC = 'Y'
+          AND p.PAGE_TYPE = 'PAGE'
           AND p.AB_GROUP_ID IS NOT NULL
         <if test="search != null and search != ''">
           AND (
@@ -134,6 +137,7 @@
         WHERE p.USE_YN = 'Y'
           AND p.APPROVE_STATE = 'APPROVED'
           AND p.IS_PUBLIC = 'Y'
+          AND p.PAGE_TYPE = 'PAGE'
         <if test="search != null and search != ''">
           AND (
               p.PAGE_ID LIKE '%' || #{search} || '%'
@@ -157,7 +161,8 @@
         FROM SPW_CMS_PAGE p
         <include refid="statsJoin"/>
         WHERE p.AB_GROUP_ID = #{groupId}
-          AND p.USE_YN = 'Y'
+          AND p.USE_YN    = 'Y'
+          AND p.PAGE_TYPE = 'PAGE'
         ORDER BY p.AB_WEIGHT DESC NULLS LAST, p.PAGE_NAME
     </select>
 
@@ -165,7 +170,8 @@
         SELECT COUNT(*)
         FROM SPW_CMS_PAGE
         WHERE AB_GROUP_ID = #{groupId}
-          AND USE_YN = 'Y'
+          AND USE_YN    = 'Y'
+          AND PAGE_TYPE = 'PAGE'
     </select>
 
     <select id="countApprovedPagesByIds" resultType="long">
@@ -174,6 +180,7 @@
         WHERE USE_YN = 'Y'
           AND APPROVE_STATE = 'APPROVED'
           AND IS_PUBLIC = 'Y'
+          AND PAGE_TYPE = 'PAGE'
           AND PAGE_ID IN
           <foreach collection="pageIds" item="pageId" open="(" separator="," close=")">
               #{pageId}
@@ -186,6 +193,7 @@
         WHERE USE_YN = 'Y'
           AND AB_GROUP_ID IS NOT NULL
           AND AB_GROUP_ID != #{groupId}
+          AND PAGE_TYPE = 'PAGE'
           AND PAGE_ID IN
           <foreach collection="pageIds" item="pageId" open="(" separator="," close=")">
               #{pageId}
@@ -196,8 +204,9 @@
         SELECT COUNT(*)
         FROM SPW_CMS_PAGE
         WHERE AB_GROUP_ID = #{groupId}
-          AND PAGE_ID = #{pageId}
-          AND USE_YN = 'Y'
+          AND PAGE_ID     = #{pageId}
+          AND USE_YN      = 'Y'
+          AND PAGE_TYPE   = 'PAGE'
     </select>
 
     <update id="updateAbGroup">
@@ -205,8 +214,9 @@
         SET AB_GROUP_ID      = #{groupId},
             AB_WEIGHT        = #{weight},
             LAST_MODIFIER_ID = #{modifierId}
-        WHERE PAGE_ID = #{pageId}
-          AND USE_YN = 'Y'
+        WHERE PAGE_ID   = #{pageId}
+          AND USE_YN    = 'Y'
+          AND PAGE_TYPE = 'PAGE'
           AND (AB_GROUP_ID IS NULL OR AB_GROUP_ID = #{groupId})
     </update>
 
@@ -216,7 +226,8 @@
             AB_WEIGHT        = NULL,
             LAST_MODIFIER_ID = #{modifierId}
         WHERE AB_GROUP_ID = #{groupId}
-          AND USE_YN = 'Y'
+          AND USE_YN      = 'Y'
+          AND PAGE_TYPE   = 'PAGE'
     </update>
 
     <update id="clearPageAbGroup">
@@ -224,8 +235,9 @@
         SET AB_GROUP_ID      = NULL,
             AB_WEIGHT        = NULL,
             LAST_MODIFIER_ID = #{modifierId}
-        WHERE PAGE_ID = #{pageId}
-          AND USE_YN = 'Y'
+        WHERE PAGE_ID   = #{pageId}
+          AND USE_YN    = 'Y'
+          AND PAGE_TYPE = 'PAGE'
           AND AB_GROUP_ID IS NOT NULL
     </update>
 
@@ -234,15 +246,17 @@
         SET AB_WEIGHT        = 0,
             LAST_MODIFIER_ID = #{modifierId}
         WHERE AB_GROUP_ID = #{groupId}
-          AND PAGE_ID != #{winnerPageId}
-          AND USE_YN = 'Y'
+          AND PAGE_ID  != #{winnerPageId}
+          AND USE_YN    = 'Y'
+          AND PAGE_TYPE = 'PAGE'
     </update>
 
     <update id="setWinner">
         UPDATE SPW_CMS_PAGE
         SET AB_WEIGHT        = 1,
             LAST_MODIFIER_ID = #{modifierId}
-        WHERE PAGE_ID = #{winnerPageId}
-          AND USE_YN = 'Y'
+        WHERE PAGE_ID   = #{winnerPageId}
+          AND USE_YN    = 'Y'
+          AND PAGE_TYPE = 'PAGE'
     </update>
 </mapper>

--- a/admin/src/main/resources/mapper/oracle/cmsdeployment/CmsDeployMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/cmsdeployment/CmsDeployMapper.xml
@@ -16,6 +16,8 @@
         <where>
             p.USE_YN = 'Y'
             AND p.APPROVE_STATE = 'APPROVED'
+            <!-- 타 프로젝트의 REACT 등 다른 PAGE_TYPE 제외 (#136) -->
+            AND p.PAGE_TYPE = 'PAGE'
             <if test="req.search != null and req.search != ''">
                 AND (
                     p.PAGE_NAME LIKE '%' || #{req.search} || '%'
@@ -108,12 +110,14 @@
         반환하는데, NOT_SUPPORTED 전파 메서드에서 커넥션이 닫힌 후 읽으면 "Closed Connection" 오류가 발생한다.
         resultType=string 으로 직접 매핑하면 MyBatis가 커넥션이 열려 있는 동안 문자열로 변환한다.
     -->
+    <!-- push 호출에서 REACT 등 타 프로젝트 페이지를 배포 대상으로 삼지 못하도록 PAGE_TYPE 가드 (#136) -->
     <select id="findApprovedPageHtml" resultType="string">
         SELECT PAGE_HTML
         FROM SPW_CMS_PAGE
-        WHERE PAGE_ID      = #{pageId}
+        WHERE PAGE_ID       = #{pageId}
           AND APPROVE_STATE = 'APPROVED'
           AND USE_YN        = 'Y'
+          AND PAGE_TYPE     = 'PAGE'
     </select>
 
 


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #136
- 선행: #134 (승인 관리 PAGE_TYPE 가드 — 동일 정책·패턴)

## ✨ 변경 사항

타 프로젝트가 `SPW_CMS_PAGE` 에 `PAGE_TYPE='REACT'` 등 행을 추가하면서 **A/B 테스트 + 배포 관리** 두 모듈에 노출되거나 pageId 직접 호출로 상태 변경이 가능하던 문제 일괄 수정.

### A/B 테스트 (`CmsAbTestMapper.xml`) — 14곳
**SELECT (9)**
- `approvedPageSearchConditions` sql fragment (findApprovedPages / countApprovedPages 반영)
- `findAbGroupPages`, `findApprovedPageOptions`
- `findGroupPages`, `countGroupPages`, `countPageInGroup`
- `countApprovedPagesByIds`, `countConflictingPages`

**UPDATE (5)** — 심층 방어
- `updateAbGroup`, `clearAbGroup`, `clearPageAbGroup`, `promoteLosers`, `setWinner`

### 배포 관리 (`CmsDeployMapper.xml`) — 2곳
- `approvedPageConditions` sql fragment (findApprovedPageList / countApprovedPageList 반영)
- `findApprovedPageHtml` (push 호출 경로에서 REACT 페이지 배포 차단)

변경 안 함: `findHistoryList` / `countHistoryList` 는 `FWK_CMS_FILE_SEND_HIS` 기반 이력 조회로 `SPW_CMS_PAGE` 참조가 없음.

## 💬 리뷰 포인트
- 각 쿼리가 유사 WHERE 절을 반복하는 구조 그대로 유지하고 필터만 추가 (회귀 위험 최소화). 리팩터는 별개.
- 단위 테스트는 Mapper 모킹이라 SQL 필터 동작 검증 불가 — Oracle 컨테이너 기반 통합 테스트는 후속 이슈.