### PR TITLE
feat: demo/tcp-backend spider-link 연동 및 Fixed Length 파서 인프라 추가

### DIFF
--- a/admin/docs/sql/oracle/03_insert_initial_data.sql
+++ b/admin/docs/sql/oracle/03_insert_initial_data.sql
@@ -728,4 +728,21 @@ INSERT INTO FWK_USER_MENU (USER_ID, MENU_ID, AUTH_CODE, LAST_UPDATE_DTIME, LAST_
 INSERT INTO FWK_USER_MENU (USER_ID, MENU_ID, AUTH_CODE, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID) VALUES ('reactUser01', 'v3_react_cms_manage',         'W', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), 'system');
 INSERT INTO FWK_USER_MENU (USER_ID, MENU_ID, AUTH_CODE, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID) VALUES ('reactUser01', 'v3_react_cms_user_dashboard',  'W', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), 'system');
 
+-- =============================================================
+-- FWK_CODE_GROUP / FWK_CODE — DEMO 기관 Fixed Length 전문 설정
+-- =============================================================
+-- Fixed Length 전문 도입 시 spider-link가 byte[]에서 messageId를 추출할 때 사용하는 offset 값.
+-- UID_END_OFFSET 값은 FWK_MESSAGE_FIELD 필드 설계 확정 후 실제 messageId 필드 길이로 변경한다.
+-- ※ 현재 DEMO 전문은 전부 JSON 타입이므로 이 코드는 Fixed Length 전문 추가 시점까지 참조되지 않는다.
+-- ⚠ 개발자가 DB에서 직접 실행해야 한다.
+INSERT INTO FWK_CODE_GROUP (CODE_GROUP_ID, CODE_GROUP_NAME, CODE_GROUP_DESC, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID)
+VALUES ('FEPDEMO', 'DEMO 기관 메시지 설정 코드 그룹', 'Fixed Length 전문 messageId 추출 offset 설정', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), 'Admin');
+
+INSERT INTO FWK_CODE (CODE_GROUP_ID, CODE, CODE_NAME, CODE_DESC, SORT_ORDER, USE_YN, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID)
+VALUES ('FEPDEMO', 'UID_START_OFFSET', '0', 'DEMO 기관 전문식별자 시작 offset', 1, 'Y', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), 'Admin');
+
+-- UID_END_OFFSET: Fixed Length 전문의 messageId 필드 길이 확정 후 실제 값으로 변경
+INSERT INTO FWK_CODE (CODE_GROUP_ID, CODE, CODE_NAME, CODE_DESC, SORT_ORDER, USE_YN, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID)
+VALUES ('FEPDEMO', 'UID_END_OFFSET', '20', 'DEMO 기관 전문식별자 끝 offset (임시값 — 필드 설계 확정 후 변경)', 2, 'Y', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), 'Admin');
+
 COMMIT;

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/config/AppProperties.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/config/AppProperties.java
@@ -25,8 +25,12 @@ public class AppProperties {
     @Autowired
     private Auth auth;
 
+    @Autowired
+    private SpiderLink spiderLink;
+
     public Tcp getTcp() { return tcp; }
     public Auth getAuth() { return auth; }
+    public SpiderLink getSpiderLink() { return spiderLink; }
 
     /** TCP 서버 관련 설정 — application.yml의 tcp.* 에 바인딩 */
     @Configuration
@@ -49,6 +53,21 @@ public class AppProperties {
         public void setWorkerThreads(int workerThreads) { this.workerThreads = workerThreads; }
         public int getMaxFrameLength() { return maxFrameLength; }
         public void setMaxFrameLength(int maxFrameLength) { this.maxFrameLength = maxFrameLength; }
+    }
+
+    /** spider-link 미들웨어 접속 정보 — application.yml의 spiderlink.* 에 바인딩 */
+    @Configuration
+    @ConfigurationProperties(prefix = "spiderlink")
+    public static class SpiderLink {
+        /** spider-link TCP 서버 호스트 */
+        private String host = "localhost";
+        /** spider-link TCP 서버 포트 */
+        private int port = 9995;
+
+        public String getHost() { return host; }
+        public void setHost(String host) { this.host = host; }
+        public int getPort() { return port; }
+        public void setPort(int port) { this.port = port; }
     }
 
     /** 인증 관련 설정 — application.yml의 auth.* 에 바인딩 */

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/config/WebConfig.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/config/WebConfig.java
@@ -39,7 +39,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-                .allowedOrigins("http://localhost:5173")
+                .allowedOrigins("http://localhost:5173", "http://localhost:5174")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 // Axios withCredentials: true → 쿠키(Refresh Token) 자동 전송 허용

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/handler/AuthHandler.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/handler/AuthHandler.java
@@ -5,13 +5,13 @@
  */
 package com.example.tcpbackend.handler;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.springframework.stereotype.Component;
 
-import com.example.tcpbackend.domain.auth.AuthService;
-import com.example.tcpbackend.domain.auth.dto.UserRow;
+import com.example.tcpbackend.tcp.SpiderLinkClient;
 import com.example.tcpbackend.tcp.TcpRequest;
 import com.example.tcpbackend.tcp.TcpResponse;
 import com.example.tcpbackend.tcp.session.SessionInfo;
@@ -28,12 +28,12 @@ import io.netty.channel.Channel;
 @Component
 public class AuthHandler {
 
-    private final AuthService authService;
+    private final SpiderLinkClient spiderLinkClient;
     private final TcpSessionManager sessionManager;
 
-    public AuthHandler(AuthService authService, TcpSessionManager sessionManager) {
-        this.authService = authService;
-        this.sessionManager = sessionManager;
+    public AuthHandler(SpiderLinkClient spiderLinkClient, TcpSessionManager sessionManager) {
+        this.spiderLinkClient = spiderLinkClient;
+        this.sessionManager   = sessionManager;
     }
 
     /**
@@ -44,6 +44,7 @@ public class AuthHandler {
      * @param channel 요청을 보낸 Netty 채널 (세션 생성에 사용)
      * @return 로그인 결과 응답 (sessionId 포함)
      */
+    @SuppressWarnings("unchecked")
     public TcpResponse handleLogin(TcpRequest request, Channel channel) {
         JsonNode payload = request.getPayload();
         if (payload == null) {
@@ -57,27 +58,31 @@ public class AuthHandler {
             return TcpResponse.error("LOGIN", "아이디와 비밀번호를 입력하세요.");
         }
 
-        try {
-            UserRow user = authService.login(userId, password);
+        Map<String, Object> reqPayload = new HashMap<>();
+        reqPayload.put("userId",   userId);
+        reqPayload.put("password", password);
 
-            // 세션 생성 — HTTP JWT 역할을 TCP 세션이 대체
-            String sessionId = sessionManager.createSession(
-                    user.userId(), user.userName(), user.userGrade(), channel);
+        Map<String, Object> response = spiderLinkClient.send("DEMO_AUTH_LOGIN", reqPayload);
 
-            Map<String, Object> data = new LinkedHashMap<>();
-            data.put("userId",    user.userId());
-            data.put("userName",  user.userName());
-            data.put("userGrade", user.userGrade());
-            data.put("lastLogin", AuthService.formatLoginDtime(user.lastLoginDtime()));
-
-            return TcpResponse.okWithSession("LOGIN", sessionId, data);
-
-        } catch (IllegalArgumentException e) {
-            return TcpResponse.error("LOGIN", e.getMessage());
-        } catch (IllegalStateException e) {
-            // 비활성 계정
-            return TcpResponse.error("LOGIN", e.getMessage());
+        if (!Boolean.TRUE.equals(response.get("success"))) {
+            return TcpResponse.error("LOGIN", String.valueOf(response.getOrDefault("error", "로그인 실패")));
         }
+
+        Map<String, Object> userData = (Map<String, Object>) response.get("payload");
+        String resUserId   = String.valueOf(userData.get("userId"));
+        String resUserName = String.valueOf(userData.get("userName"));
+        String resGrade    = String.valueOf(userData.getOrDefault("userGrade", ""));
+
+        // 세션 생성 — spider-link 인증 확인 후 tcp-backend 세션 발급
+        String sessionId = sessionManager.createSession(resUserId, resUserName, resGrade, channel);
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("userId",    resUserId);
+        data.put("userName",  resUserName);
+        data.put("userGrade", resGrade);
+        data.put("lastLogin", userData.getOrDefault("lastLoginDtime", ""));
+
+        return TcpResponse.okWithSession("LOGIN", sessionId, data);
     }
 
     /**
@@ -100,12 +105,18 @@ public class AuthHandler {
      * @param session 검증된 세션 정보
      * @return 사용자 프로필 응답
      */
+    @SuppressWarnings("unchecked")
     public TcpResponse handleGetProfile(TcpRequest request, SessionInfo session) {
-        try {
-            Map<String, Object> data = authService.getProfile(session.getUserId());
-            return TcpResponse.ok("GET_PROFILE", data);
-        } catch (IllegalArgumentException e) {
-            return TcpResponse.error("GET_PROFILE", e.getMessage());
+        Map<String, Object> reqPayload = new HashMap<>();
+        reqPayload.put("userId", session.getUserId());
+
+        Map<String, Object> response = spiderLinkClient.send("DEMO_AUTH_ME", reqPayload);
+
+        if (!Boolean.TRUE.equals(response.get("success"))) {
+            return TcpResponse.error("GET_PROFILE", String.valueOf(response.getOrDefault("error", "프로필 조회 실패")));
         }
+
+        Map<String, Object> data = (Map<String, Object>) response.get("payload");
+        return TcpResponse.ok("GET_PROFILE", data);
     }
 }

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/handler/CardHandler.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/handler/CardHandler.java
@@ -5,6 +5,7 @@
  */
 package com.example.tcpbackend.handler;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Component;
 import com.example.tcpbackend.domain.card.CardService;
 import com.example.tcpbackend.domain.card.CardService.BusinessException;
 import com.example.tcpbackend.domain.card.CardService.PinException;
+import com.example.tcpbackend.tcp.SpiderLinkClient;
 import com.example.tcpbackend.tcp.TcpRequest;
 import com.example.tcpbackend.tcp.TcpResponse;
 import com.example.tcpbackend.tcp.session.SessionInfo;
@@ -25,9 +27,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 public class CardHandler {
 
     private final CardService cardService;
+    private final SpiderLinkClient spiderLinkClient;
 
-    public CardHandler(CardService cardService) {
-        this.cardService = cardService;
+    public CardHandler(CardService cardService, SpiderLinkClient spiderLinkClient) {
+        this.cardService      = cardService;
+        this.spiderLinkClient = spiderLinkClient;
     }
 
     /**
@@ -54,6 +58,7 @@ public class CardHandler {
      * @param session 검증된 세션 정보
      * @return { payableAmount, creditLimit } 응답
      */
+    @SuppressWarnings("unchecked")
     public TcpResponse handleGetPayableAmount(TcpRequest request, SessionInfo session) {
         JsonNode payload = request.getPayload();
         String cardId = payload != null ? payload.path("cardId").asText(null) : null;
@@ -62,12 +67,18 @@ public class CardHandler {
             return TcpResponse.error("GET_PAYABLE_AMOUNT", "cardId가 필요합니다.");
         }
 
-        try {
-            Map<String, Object> data = cardService.getPayableAmount(session.getUserId(), cardId);
-            return TcpResponse.ok("GET_PAYABLE_AMOUNT", data);
-        } catch (Exception e) {
-            return TcpResponse.error("GET_PAYABLE_AMOUNT", "가능금액 조회 중 오류가 발생했습니다.");
+        Map<String, Object> reqPayload = new HashMap<>();
+        reqPayload.put("userId", session.getUserId());
+        reqPayload.put("cardId", cardId);
+
+        Map<String, Object> response = spiderLinkClient.send("DEMO_PAYABLE_AMT", reqPayload);
+
+        if (!Boolean.TRUE.equals(response.get("success"))) {
+            return TcpResponse.error("GET_PAYABLE_AMOUNT", String.valueOf(response.getOrDefault("error", "가능금액 조회 실패")));
         }
+
+        Map<String, Object> data = (Map<String, Object>) response.get("payload");
+        return TcpResponse.ok("GET_PAYABLE_AMOUNT", data);
     }
 
     /**

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/SpiderLinkClient.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/tcp/SpiderLinkClient.java
@@ -1,0 +1,97 @@
+/**
+ * @file SpiderLinkClient.java
+ * @description spider-link 미들웨어로 전문을 전송하고 응답을 수신하는 TCP 클라이언트.
+ *              4바이트 big-endian 길이 헤더 + UTF-8 JSON 프로토콜을 사용한다.
+ *
+ * @example
+ * Map<String, Object> payload = Map.of("userId", "user01", "password", "1234");
+ * Map<String, Object> response = spiderLinkClient.send("DEMO_AUTH_LOGIN", payload);
+ * boolean success = Boolean.TRUE.equals(response.get("success"));
+ */
+package com.example.tcpbackend.tcp;
+
+import com.example.tcpbackend.config.AppProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.Socket;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * spider-link 미들웨어 TCP 클라이언트.
+ *
+ * <p>요청마다 새 소켓을 열고 응답을 받은 뒤 닫는 단순 동기 방식으로 동작한다.
+ * POC 수준의 요청 빈도에 적합하며, 고성능이 필요한 경우 커넥션 풀로 전환한다.</p>
+ */
+@Component
+public class SpiderLinkClient {
+
+    private static final Logger log = LoggerFactory.getLogger(SpiderLinkClient.class);
+
+    /** 응답 대기 최대 시간 (ms) */
+    private static final int SOCKET_TIMEOUT_MS = 10_000;
+
+    private final AppProperties appProperties;
+    private final ObjectMapper objectMapper;
+
+    public SpiderLinkClient(AppProperties appProperties, ObjectMapper objectMapper) {
+        this.appProperties = appProperties;
+        this.objectMapper  = objectMapper;
+    }
+
+    /**
+     * spider-link 미들웨어로 전문 요청을 전송하고 응답 Map을 반환한다.
+     *
+     * <p>전송 형식: [4byte 길이(big-endian)] + [UTF-8 JSON]
+     * <br>JSON 구조: { "command": "...", "requestId": "uuid", "payload": {...} }</p>
+     *
+     * @param command spider-link 커맨드명 (예: "DEMO_AUTH_LOGIN")
+     * @param payload 커맨드별 요청 데이터
+     * @return 응답 Map. success(boolean), payload(Map), error(String) 포함
+     */
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> send(String command, Map<String, Object> payload) {
+        String host = appProperties.getSpiderLink().getHost();
+        int    port = appProperties.getSpiderLink().getPort();
+
+        Map<String, Object> request = new HashMap<>();
+        request.put("command",   command);
+        request.put("requestId", UUID.randomUUID().toString());
+        request.put("payload",   payload);
+
+        log.debug("[SpiderLinkClient] 전송: command={}, host={}:{}", command, host, port);
+
+        try (Socket socket = new Socket(host, port)) {
+            socket.setSoTimeout(SOCKET_TIMEOUT_MS);
+
+            byte[] reqBytes = objectMapper.writeValueAsBytes(request);
+
+            DataOutputStream dos = new DataOutputStream(socket.getOutputStream());
+            dos.writeInt(reqBytes.length);
+            dos.write(reqBytes);
+            dos.flush();
+
+            DataInputStream dis = new DataInputStream(socket.getInputStream());
+            int    length   = dis.readInt();
+            byte[] resBytes = new byte[length];
+            dis.readFully(resBytes);
+
+            Map<String, Object> response = objectMapper.readValue(resBytes, Map.class);
+            log.debug("[SpiderLinkClient] 수신: command={}, success={}", command, response.get("success"));
+            return response;
+
+        } catch (IOException e) {
+            log.error("[SpiderLinkClient] 전문 전송 실패: command={}, error={}", command, e.getMessage());
+            Map<String, Object> errorResponse = new HashMap<>();
+            errorResponse.put("success", false);
+            errorResponse.put("error", "미들웨어 연결 오류: " + e.getMessage());
+            return errorResponse;
+        }
+    }
+}

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/web/controller/AuthController.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/web/controller/AuthController.java
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.tcpbackend.domain.auth.AuthService;
-import com.example.tcpbackend.domain.auth.dto.UserRow;
+import com.example.tcpbackend.tcp.SpiderLinkClient;
 import com.example.tcpbackend.tcp.session.SessionInfo;
 import com.example.tcpbackend.tcp.session.TcpSessionManager;
 
@@ -52,11 +52,14 @@ public class AuthController {
     private static final String REFRESH_COOKIE = "hnc_refresh";
 
     private final AuthService authService;
+    private final SpiderLinkClient spiderLinkClient;
     private final TcpSessionManager sessionManager;
 
-    public AuthController(AuthService authService, TcpSessionManager sessionManager) {
-        this.authService = authService;
-        this.sessionManager = sessionManager;
+    public AuthController(AuthService authService, SpiderLinkClient spiderLinkClient,
+                          TcpSessionManager sessionManager) {
+        this.authService      = authService;
+        this.spiderLinkClient = spiderLinkClient;
+        this.sessionManager   = sessionManager;
     }
 
     // ── 엔드포인트 ────────────────────────────────────────────────────────────
@@ -68,31 +71,36 @@ public class AuthController {
      * @param body     { userId, password }
      * @param response Refresh Token 쿠키 설정용
      */
+    @SuppressWarnings("unchecked")
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody LoginRequest body, HttpServletResponse response) {
-        try {
-            UserRow user = authService.login(body.userId(), body.password());
-            String sessionId = sessionManager.createSession(
-                    user.userId(), user.userName(), user.userGrade());
+        Map<String, Object> slResponse = spiderLinkClient.send(
+                "DEMO_AUTH_LOGIN", Map.of("userId", body.userId(), "password", body.password()));
 
-            // httpOnly 쿠키에 Refresh Token 설정 (브라우저가 /api/auth/* 요청 시 자동 전송)
-            response.addCookie(buildRefreshCookie(sessionId, 7 * 24 * 3600));
-
-            Map<String, Object> data = new LinkedHashMap<>();
-            data.put("success", true);
-            data.put("userId", user.userId());
-            data.put("userName", user.userName());
-            data.put("userGrade", user.userGrade());
-            data.put("token", sessionId);  // 프론트엔드가 localStorage에 저장하는 Access Token
-            data.put("lastLogin", AuthService.formatLoginDtime(user.lastLoginDtime()));
-
-            return ResponseEntity.ok(data);
-
-        } catch (IllegalArgumentException | IllegalStateException e) {
-            // 아이디/비밀번호 오류 or 비활성 계정 → 401
+        if (!Boolean.TRUE.equals(slResponse.get("success"))) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(Map.of("success", false, "error", e.getMessage()));
+                    .body(Map.of("success", false,
+                            "error", slResponse.getOrDefault("error", "로그인 실패")));
         }
+
+        Map<String, Object> userData = (Map<String, Object>) slResponse.get("payload");
+        String userId    = String.valueOf(userData.get("userId"));
+        String userName  = String.valueOf(userData.get("userName"));
+        String userGrade = String.valueOf(userData.getOrDefault("userGrade", ""));
+
+        String sessionId = sessionManager.createSession(userId, userName, userGrade);
+        response.addCookie(buildRefreshCookie(sessionId, 7 * 24 * 3600));
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("success", true);
+        data.put("userId",    userId);
+        data.put("userName",  userName);
+        data.put("userGrade", userGrade);
+        data.put("token",     sessionId);
+        data.put("lastLogin", AuthService.formatLoginDtime(
+                String.valueOf(userData.getOrDefault("lastLoginDtime", ""))));
+
+        return ResponseEntity.ok(data);
     }
 
     /**
@@ -143,16 +151,20 @@ public class AuthController {
      * 현재 사용자 프로필 조회.
      * 대시보드 진입 시 lastLogin이 없는 경우를 보완하는 용도로 사용된다.
      */
+    @SuppressWarnings("unchecked")
     @GetMapping("/me")
     public ResponseEntity<?> me(HttpServletRequest request) {
         SessionInfo session = (SessionInfo) request.getAttribute("session");
-        try {
-            Map<String, Object> profile = authService.getProfile(session.getUserId());
-            return ResponseEntity.ok(profile);
-        } catch (IllegalArgumentException e) {
+
+        Map<String, Object> slResponse = spiderLinkClient.send(
+                "DEMO_AUTH_ME", Map.of("userId", session.getUserId()));
+
+        if (!Boolean.TRUE.equals(slResponse.get("success"))) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(Map.of("error", e.getMessage()));
+                    .body(Map.of("error", slResponse.getOrDefault("error", "프로필 조회 실패")));
         }
+
+        return ResponseEntity.ok((Map<String, Object>) slResponse.get("payload"));
     }
 
     // ── 내부 유틸 ────────────────────────────────────────────────────────────

--- a/demo/tcp-backend/src/main/java/com/example/tcpbackend/web/controller/CardController.java
+++ b/demo/tcp-backend/src/main/java/com/example/tcpbackend/web/controller/CardController.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import com.example.tcpbackend.domain.card.CardService;
 import com.example.tcpbackend.domain.card.CardService.BusinessException;
 import com.example.tcpbackend.domain.card.CardService.PinException;
+import com.example.tcpbackend.tcp.SpiderLinkClient;
 import com.example.tcpbackend.tcp.session.SessionInfo;
 
 /**
@@ -51,9 +52,11 @@ public class CardController {
     private static final Logger log = LoggerFactory.getLogger(CardController.class);
 
     private final CardService cardService;
+    private final SpiderLinkClient spiderLinkClient;
 
-    public CardController(CardService cardService) {
-        this.cardService = cardService;
+    public CardController(CardService cardService, SpiderLinkClient spiderLinkClient) {
+        this.cardService      = cardService;
+        this.spiderLinkClient = spiderLinkClient;
     }
 
     /**
@@ -79,17 +82,21 @@ public class CardController {
      * @param cardId 카드번호 (URL 경로 변수)
      * @return { payableAmount, creditLimit }
      */
+    @SuppressWarnings("unchecked")
     @GetMapping("/{cardId}/payable-amount")
     public ResponseEntity<?> getPayableAmount(@PathVariable String cardId,
                                                HttpServletRequest request) {
         SessionInfo session = (SessionInfo) request.getAttribute("session");
-        try {
-            Map<String, Object> data = cardService.getPayableAmount(session.getUserId(), cardId);
-            return ResponseEntity.ok(data);
-        } catch (Exception e) {
+
+        Map<String, Object> slResponse = spiderLinkClient.send(
+                "DEMO_PAYABLE_AMT", Map.of("userId", session.getUserId(), "cardId", cardId));
+
+        if (!Boolean.TRUE.equals(slResponse.get("success"))) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(Map.of("error", "가능금액 조회 중 오류가 발생했습니다."));
+                    .body(Map.of("error", slResponse.getOrDefault("error", "가능금액 조회 실패")));
         }
+
+        return ResponseEntity.ok((Map<String, Object>) slResponse.get("payload"));
     }
 
     /**

--- a/demo/tcp-backend/src/main/resources/application.yml
+++ b/demo/tcp-backend/src/main/resources/application.yml
@@ -26,6 +26,10 @@ auth:
   pin-max-attempts: 3                 # PIN 최대 허용 실패 횟수 (3회 초과 시 잠금)
   admin-secret: ${ADMIN_SECRET:admin-secret}  # Admin 전용 커맨드 인증 비밀 키
 
+spiderlink:
+  host: ${SPIDERLINK_HOST:localhost}  # spider-link 미들웨어 TCP 호스트
+  port: ${SPIDERLINK_PORT:9995}       # spider-link 미들웨어 TCP 포트
+
 logging:
   level:
     com.example.tcpbackend: DEBUG

--- a/spider-link/src/main/java/com/example/spiderlink/domain/message/dto/MessageFieldMeta.java
+++ b/spider-link/src/main/java/com/example/spiderlink/domain/message/dto/MessageFieldMeta.java
@@ -1,0 +1,71 @@
+package com.example.spiderlink.domain.message.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * FWK_MESSAGE_FIELD 조회 결과 DTO.
+ *
+ * <p>MessageStructurePool이 DB에서 전문 필드 메타데이터를 로드할 때 사용한다.</p>
+ */
+@Data
+@NoArgsConstructor
+public class MessageFieldMeta {
+
+    /** 기관 ID (FWK_MESSAGE_FIELD.ORG_ID) */
+    private String orgId;
+
+    /** 전문 ID (FWK_MESSAGE_FIELD.MESSAGE_ID) */
+    private String messageId;
+
+    /**
+     * 필드 ID (FWK_MESSAGE_FIELD.MESSAGE_FIELD_ID).
+     * "_BeginLoop_xxx" 이면 반복 구조 시작, "_EndLoop_" 이면 반복 구조 종료.
+     */
+    private String messageFieldId;
+
+    /** 필드 표시 이름 (FWK_MESSAGE_FIELD.MESSAGE_FIELD_NAME) */
+    private String messageFieldName;
+
+    /** 정렬 순서 (FWK_MESSAGE_FIELD.SORT_ORDER) */
+    private Integer sortOrder;
+
+    /**
+     * 데이터 타입 (FWK_MESSAGE_FIELD.DATA_TYPE).
+     * C=문자, N=숫자, H=헥사, B=바이너리, K=한글
+     */
+    private String dataType;
+
+    /** 필드 바이트 길이 (FWK_MESSAGE_FIELD.DATA_LENGTH) */
+    private Long dataLength;
+
+    /** 소수점 자릿수 (FWK_MESSAGE_FIELD.SCALE) */
+    private Integer scale;
+
+    /**
+     * 정렬 방향 (FWK_MESSAGE_FIELD.ALIGN).
+     * L=왼쪽정렬(문자), R=오른쪽정렬(숫자)
+     */
+    private String align;
+
+    /** 여백 채우기 문자 (FWK_MESSAGE_FIELD.FILLER) */
+    private String filler;
+
+    /** 로그 마스킹 시 대체 문자 (FWK_MESSAGE_FIELD.REMARK) */
+    private String remark;
+
+    /** 로그 출력 여부 (FWK_MESSAGE_FIELD.LOG_YN) */
+    private String logYn;
+
+    /**
+     * 기본값 (FWK_MESSAGE_FIELD.DEFAULT_VALUE).
+     * LoopField에서 반복 횟수를 담고 있는 다른 필드명을 지정할 때 사용.
+     */
+    private String defaultValue;
+
+    /**
+     * 최대 반복 횟수 (FWK_MESSAGE_FIELD.FIELD_REPEAT_CNT).
+     * LoopField의 길이 필드가 0일 때 고정 반복 횟수로 사용.
+     */
+    private Integer fieldRepeatCnt;
+}

--- a/spider-link/src/main/java/com/example/spiderlink/domain/message/mapper/MessageMetaMapper.java
+++ b/spider-link/src/main/java/com/example/spiderlink/domain/message/mapper/MessageMetaMapper.java
@@ -1,0 +1,33 @@
+package com.example.spiderlink.domain.message.mapper;
+
+import com.example.spiderlink.domain.message.dto.MessageFieldMeta;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+/**
+ * FWK_MESSAGE / FWK_MESSAGE_FIELD 조회 전용 Mapper.
+ *
+ * <p>MessageStructurePool이 전문 구조를 DB에서 로드할 때만 사용한다.</p>
+ */
+@Mapper
+public interface MessageMetaMapper {
+
+    /**
+     * 기관·전문 ID에 해당하는 전문 타입 코드를 반환한다.
+     *
+     * @param orgId     기관 ID
+     * @param messageId 전문 ID
+     * @return MESSAGE_TYPE 코드 (J/F/X/I/C/D), 없으면 null
+     */
+    String selectMessageType(@Param("orgId") String orgId, @Param("messageId") String messageId);
+
+    /**
+     * 전문 필드 목록을 SORT_ORDER 오름차순으로 반환한다.
+     *
+     * @param orgId     기관 ID
+     * @param messageId 전문 ID
+     * @return 필드 메타데이터 목록
+     */
+    List<MessageFieldMeta> selectFields(@Param("orgId") String orgId, @Param("messageId") String messageId);
+}

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/parser/FixedLengthParser.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/parser/FixedLengthParser.java
@@ -1,0 +1,213 @@
+package com.example.spiderlink.infra.tcp.parser;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 고정길이(Fixed Length) 전문 파서.
+ *
+ * <p>MessageStructure(FWK_MESSAGE_FIELD 메타데이터)를 기반으로 byte[] 를
+ * {@code Map<String, Object>}로 파싱한다.</p>
+ *
+ * <p>IBKFixedLengthMessageParserBiz(spiderlink_Admin 원본 소스) 로직을
+ * Spring Boot 스타일로 재구현하였다.</p>
+ *
+ * <h4>지원 데이터 타입</h4>
+ * <pre>
+ * C (문자)   → String (trim 없이 원본 유지)
+ * N (숫자)   → String (scale > 0 이면 소수점 포함)
+ * H (헥사)   → String (hex 문자열)
+ * B (바이너리)→ Integer (4byte) / Short (2byte)
+ * K (한글)   → String (EUC-KR 디코딩)
+ * </pre>
+ */
+@Slf4j
+@Component
+public class FixedLengthParser {
+
+    /**
+     * byte[] 를 MessageStructure 기반으로 파싱하여 Map으로 반환한다.
+     *
+     * @param structure 전문 구조 (필드 메타데이터 포함)
+     * @param bytes     수신 raw bytes
+     * @return 필드명 → 값 Map (반복 구조는 List<Map> 로 담김)
+     */
+    public Map<String, Object> parse(MessageStructure structure, byte[] bytes) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        int[] offset = {0}; // 배열로 감싸서 람다 내 변경 허용
+
+        for (MessageField field : structure.getFields()) {
+            if (offset[0] >= bytes.length) {
+                log.debug("[FixedLengthParser] 전문 끝 도달, 남은 필드 생략: field={}", field.getName());
+                break;
+            }
+
+            if (field instanceof LoopField loop) {
+                Object loopResult = parseLoopField(loop, bytes, offset, result);
+                result.put(loop.getName(), loopResult);
+            } else {
+                Object value = parseField(field, bytes, offset);
+                result.put(field.getName(), value);
+            }
+        }
+
+        return result;
+    }
+
+    /** 반복 구조 파싱 — 반복 횟수만큼 하위 필드를 List<Map>으로 반환 */
+    private List<Map<String, Object>> parseLoopField(
+            LoopField loop, byte[] bytes, int[] offset, Map<String, Object> context) {
+
+        int count = resolveLoopCount(loop, bytes, offset, context);
+        List<Map<String, Object>> rows = new ArrayList<>(count);
+
+        for (int i = 0; i < count; i++) {
+            if (offset[0] >= bytes.length) {
+                log.debug("[FixedLengthParser] 반복 {} 중 전문 끝 도달 ({}/{})", loop.getName(), i, count);
+                break;
+            }
+
+            Map<String, Object> row = new LinkedHashMap<>();
+            for (MessageField child : loop.getChildren()) {
+                if (child instanceof LoopField nestedLoop) {
+                    // 중첩 반복 구조 지원
+                    row.put(nestedLoop.getName(), parseLoopField(nestedLoop, bytes, offset, context));
+                } else {
+                    row.put(child.getName(), parseField(child, bytes, offset));
+                }
+            }
+            rows.add(row);
+        }
+        return rows;
+    }
+
+    /**
+     * 반복 횟수 결정.
+     *
+     * <ul>
+     *   <li>loop.length > 0: 해당 바이트 읽어 숫자로 파싱</li>
+     *   <li>loop.length == 0 && defaultValue 있음: context Map에서 값 조회</li>
+     *   <li>loop.length == 0 && maxOccurs > 0: maxOccurs 고정</li>
+     * </ul>
+     */
+    private int resolveLoopCount(LoopField loop, byte[] bytes, int[] offset, Map<String, Object> context) {
+        if (loop.getLength() > 0) {
+            // 전문에 반복 횟수가 직접 기술된 경우
+            String raw = readString(bytes, offset[0], loop.getLength());
+            offset[0] += loop.getLength();
+            try {
+                return Integer.parseInt(raw.trim());
+            } catch (NumberFormatException e) {
+                log.warn("[FixedLengthParser] 반복 횟수 파싱 실패: loop={}, raw='{}', 0으로 처리", loop.getName(), raw);
+                return 0;
+            }
+        }
+
+        if (loop.getDefaultValue() != null && !loop.getDefaultValue().isBlank()) {
+            // 이미 파싱된 다른 필드에서 반복 횟수 참조
+            Object refValue = context.get(loop.getDefaultValue());
+            if (refValue != null) {
+                try {
+                    return Integer.parseInt(refValue.toString().trim());
+                } catch (NumberFormatException e) {
+                    log.warn("[FixedLengthParser] 참조 필드 반복 횟수 변환 실패: ref={}, val={}", loop.getDefaultValue(), refValue);
+                }
+            }
+        }
+
+        return loop.getMaxOccurs();
+    }
+
+    /** 단일 필드 파싱 — offset 을 field.length 만큼 전진시킴 */
+    private Object parseField(MessageField field, byte[] bytes, int[] offset) {
+        // 실제 남은 길이가 정의 길이보다 짧으면 남은 길이만큼만 읽음
+        int actualLen = Math.min(field.getLength(), bytes.length - offset[0]);
+        Object value  = parseByteField(field, bytes, offset[0], actualLen);
+
+        if (log.isDebugEnabled() && field.isLogMode()) {
+            String display = field.getRemark() != null
+                    ? "*".repeat(actualLen)   // 마스킹 필드는 별표로 표시
+                    : String.valueOf(value);
+            log.debug("[FixedLengthParser] offset={}, field={}, value={}", offset[0], field.getName(), display);
+        }
+
+        offset[0] += field.getLength(); // 정의 길이만큼 전진 (짧아도 동일)
+        return value;
+    }
+
+    /** 바이트 배열을 데이터 타입에 맞게 파싱 */
+    private Object parseByteField(MessageField field, byte[] bytes, int offset, int len) {
+        return switch (field.getDataType()) {
+            case MessageField.CHR    -> readString(bytes, offset, len);
+            case MessageField.NUM    -> readNumeric(field, bytes, offset, len);
+            case MessageField.HEXA   -> toHex(bytes, offset, len);
+            case MessageField.BINARY -> readBinary(bytes, offset, len);
+            case MessageField.KOREAN -> readKorean(bytes, offset, len);
+            default -> {
+                log.warn("[FixedLengthParser] 알 수 없는 데이터 타입: {}, 문자열로 처리", field.getDataType());
+                yield readString(bytes, offset, len);
+            }
+        };
+    }
+
+    /** C 타입: trim 없이 원본 문자열 반환 */
+    private String readString(byte[] bytes, int offset, int len) {
+        return new String(bytes, offset, len);
+    }
+
+    /**
+     * N 타입: scale 처리 포함.
+     * scale > 0 이면 소수점 자릿수 만큼 뒤에서 분리하여 정수부.소수부 형식으로 반환.
+     */
+    private String readNumeric(MessageField field, byte[] bytes, int offset, int len) {
+        if (field.getScale() == 0) {
+            return new String(bytes, offset, len).trim();
+        }
+        // 끝에서 scale 자리만큼이 소수부
+        String intPart  = new String(bytes, offset, len - field.getScale());
+        String fracPart = new String(bytes, offset + len - field.getScale(), field.getScale());
+        return (intPart + fracPart).trim(); // 소수점 삽입 없이 원본 보존 (원본 SpiderLink와 동일)
+    }
+
+    /** H 타입: 각 바이트를 2자리 16진수 문자열로 변환 */
+    private String toHex(byte[] bytes, int offset, int len) {
+        StringBuilder sb = new StringBuilder(len * 2);
+        for (int i = 0; i < len; i++) {
+            sb.append(String.format("%02X", bytes[offset + i]));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * B 타입: big-endian 바이너리.
+     * 4바이트 → int, 2바이트 → short, 그 외 → hex 문자열
+     */
+    private Object readBinary(byte[] bytes, int offset, int len) {
+        if (len == 4) {
+            return ((bytes[offset] & 0xFF) << 24)
+                 | ((bytes[offset + 1] & 0xFF) << 16)
+                 | ((bytes[offset + 2] & 0xFF) << 8)
+                 |  (bytes[offset + 3] & 0xFF);
+        }
+        if (len == 2) {
+            return (short) (((bytes[offset] & 0xFF) << 8) | (bytes[offset + 1] & 0xFF));
+        }
+        // 그 외 길이는 hex로 fallback
+        return toHex(bytes, offset, len);
+    }
+
+    /**
+     * K 타입: 한글(EUC-KR) 바이트 배열을 문자열로 디코딩.
+     * 실제 운영 환경에 따라 charset 이 다를 수 있으므로 필요 시 수정.
+     */
+    private String readKorean(byte[] bytes, int offset, int len) {
+        byte[] buf = new byte[len];
+        System.arraycopy(bytes, offset, buf, 0, len);
+        return new String(buf, Charset.forName("EUC-KR"));
+    }
+}

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/parser/LoopField.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/parser/LoopField.java
@@ -1,0 +1,59 @@
+package com.example.spiderlink.infra.tcp.parser;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 고정길이 전문의 반복 구조 필드 (_BeginLoop_xxx).
+ *
+ * <p>FWK_MESSAGE_FIELD에서 MESSAGE_FIELD_ID가 "_BeginLoop_xxx"인 행에 대응한다.
+ * "_EndLoop_" 까지의 하위 필드를 children으로 보유한다.</p>
+ *
+ * <h4>반복 횟수 결정 규칙</h4>
+ * <pre>
+ * length > 0  → 해당 길이만큼 바이트를 읽어 반복 횟수로 파싱
+ * length == 0 AND defaultValue 있음 → dataMap에서 defaultValue 키로 횟수 조회
+ * length == 0 AND maxOccurs > 0     → maxOccurs 고정 사용
+ * </pre>
+ */
+public class LoopField extends MessageField {
+
+    /**
+     * 최대 반복 횟수 (FIELD_REPEAT_CNT).
+     * length == 0 이고 defaultValue 가 없을 때 고정 반복 횟수로 사용.
+     */
+    private final int maxOccurs;
+
+    /**
+     * 반복 횟수를 담고 있는 다른 필드명 (DEFAULT_VALUE).
+     * length == 0 일 때 이 이름으로 이미 파싱된 dataMap에서 횟수를 가져온다.
+     */
+    private final String defaultValue;
+
+    /** 반복 구조 내 하위 필드 목록 */
+    private final List<MessageField> children = new ArrayList<>();
+
+    public LoopField(String name, int loopCountLength, int maxOccurs, String defaultValue) {
+        // LoopField 자체의 dataType·align·filler는 파싱에 쓰이지 않고 count 읽기에만 사용
+        super(name, MessageField.NUM, loopCountLength, 0, MessageField.RIGHT, '0', null, true);
+        this.maxOccurs    = maxOccurs;
+        this.defaultValue = defaultValue;
+    }
+
+    public int getMaxOccurs() {
+        return maxOccurs;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void addChild(MessageField field) {
+        children.add(field);
+    }
+
+    public List<MessageField> getChildren() {
+        return Collections.unmodifiableList(children);
+    }
+}

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/parser/MessageField.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/parser/MessageField.java
@@ -1,0 +1,61 @@
+package com.example.spiderlink.infra.tcp.parser;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 고정길이 전문의 단일 필드 모델.
+ *
+ * <p>FWK_MESSAGE_FIELD 한 행에 대응하며, FixedLengthParser가
+ * byte[] 파싱 시 오프셋·길이·타입 정보로 사용한다.</p>
+ */
+@Getter
+@AllArgsConstructor
+public class MessageField {
+
+    /** DATA_TYPE: 문자 */
+    public static final String CHR = "C";
+    /** DATA_TYPE: 숫자 */
+    public static final String NUM = "N";
+    /** DATA_TYPE: 헥사 */
+    public static final String HEXA = "H";
+    /** DATA_TYPE: 바이너리 (4byte=int, 2byte=short) */
+    public static final String BINARY = "B";
+    /** DATA_TYPE: 한글 (DBCS) */
+    public static final String KOREAN = "K";
+
+    /** ALIGN: 왼쪽 정렬 (문자형 기본) */
+    public static final String LEFT = "L";
+    /** ALIGN: 오른쪽 정렬 (숫자형 기본) */
+    public static final String RIGHT = "R";
+
+    /** MESSAGE_FIELD_ID — DataMap 키로 사용 */
+    private final String name;
+
+    /** DATA_TYPE */
+    private final String dataType;
+
+    /** DATA_LENGTH (byte 단위) */
+    private final int length;
+
+    /** SCALE (소수점 자릿수, 0이면 정수) */
+    private final int scale;
+
+    /** ALIGN */
+    private final String align;
+
+    /**
+     * FILLER 문자.
+     * 숫자형은 보통 '0', 문자형은 ' '(공백).
+     */
+    private final char filler;
+
+    /**
+     * REMARK — 로그 마스킹 시 이 문자로 해당 필드를 덮어 씀.
+     * null 이면 마스킹 없음.
+     */
+    private final String remark;
+
+    /** LOG_YN — false 면 파싱 결과를 디버그 로그에 출력하지 않음 */
+    private final boolean logMode;
+}

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/parser/MessageStructure.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/parser/MessageStructure.java
@@ -1,0 +1,60 @@
+package com.example.spiderlink.infra.tcp.parser;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 전문 구조 모델 — FWK_MESSAGE + FWK_MESSAGE_FIELD 를 파서가 사용하는 형태로 조합한 객체.
+ *
+ * <p>MessageStructurePool이 DB에서 로드 후 캐시하며,
+ * FixedLengthParser가 파싱 시 참조한다.</p>
+ */
+public class MessageStructure {
+
+    private final String orgId;
+    private final String messageId;
+
+    /**
+     * 전문 타입 코드 (FWK_MESSAGE.MESSAGE_TYPE).
+     * F=고정길이, J=JSON, X=XML, I=ISO8583, D=구분자, C=CSV
+     */
+    private final String messageType;
+
+    /** 최상위 필드 목록 (LoopField 포함) */
+    private final List<MessageField> fields = new ArrayList<>();
+
+    public MessageStructure(String orgId, String messageId, String messageType) {
+        this.orgId       = orgId;
+        this.messageId   = messageId;
+        this.messageType = messageType;
+    }
+
+    public void addField(MessageField field) {
+        fields.add(field);
+    }
+
+    public String getOrgId() {
+        return orgId;
+    }
+
+    public String getMessageId() {
+        return messageId;
+    }
+
+    public String getMessageType() {
+        return messageType;
+    }
+
+    public List<MessageField> getFields() {
+        return Collections.unmodifiableList(fields);
+    }
+
+    /**
+     * 단순 필드의 총 바이트 길이.
+     * LoopField가 포함된 전문은 반복 횟수에 따라 실제 길이가 달라지므로 참고용으로만 사용.
+     */
+    public int getStaticTotalLength() {
+        return fields.stream().mapToInt(MessageField::getLength).sum();
+    }
+}

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/parser/MessageStructurePool.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/parser/MessageStructurePool.java
@@ -1,0 +1,169 @@
+package com.example.spiderlink.infra.tcp.parser;
+
+import com.example.spiderlink.domain.message.dto.MessageFieldMeta;
+import com.example.spiderlink.domain.message.mapper.MessageMetaMapper;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 전문 구조(MessageStructure) 캐시 풀.
+ *
+ * <p>최초 요청 시 DB(FWK_MESSAGE + FWK_MESSAGE_FIELD)에서 로드하고,
+ * 이후에는 메모리 캐시에서 반환한다.</p>
+ *
+ * <p>FWK_MESSAGE_FIELD 변경 후 반영하려면 {@link #evict} 또는 {@link #clear}를 호출한다.</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MessageStructurePool {
+
+    private static final String BEGIN_LOOP_PREFIX = "_BeginLoop_";
+    private static final String END_LOOP          = "_EndLoop_";
+
+    private final MessageMetaMapper messageMetaMapper;
+
+    /** 캐시 키: "orgId:messageId" */
+    private final ConcurrentHashMap<String, MessageStructure> cache = new ConcurrentHashMap<>();
+
+    /**
+     * DB 조회 후 등록되지 않은 것으로 확인된 키 집합.
+     * 반복 DB 조회를 방지한다.
+     */
+    private final Set<String> notFoundKeys = ConcurrentHashMap.newKeySet();
+
+    /**
+     * 전문 구조를 반환한다. 캐시 미스 시 DB에서 로드한다.
+     *
+     * @param orgId     기관 ID
+     * @param messageId 전문 ID
+     * @return 전문 구조, FWK_MESSAGE 에 등록되지 않았으면 empty
+     */
+    public Optional<MessageStructure> get(String orgId, String messageId) {
+        String key = cacheKey(orgId, messageId);
+
+        // 이미 없다고 확인된 키는 DB 재조회 생략
+        if (notFoundKeys.contains(key)) {
+            return Optional.empty();
+        }
+
+        MessageStructure cached = cache.get(key);
+        if (cached != null) {
+            return Optional.of(cached);
+        }
+
+        // DB 로드 후 캐시 등록
+        MessageStructure loaded = load(orgId, messageId);
+        if (loaded == null) {
+            notFoundKeys.add(key);
+            return Optional.empty();
+        }
+
+        cache.put(key, loaded);
+        return Optional.of(loaded);
+    }
+
+    /**
+     * 특정 전문의 캐시를 무효화한다.
+     * FWK_MESSAGE_FIELD 변경 후 재로드할 때 호출한다.
+     */
+    public void evict(String orgId, String messageId) {
+        String key = cacheKey(orgId, messageId);
+        cache.remove(key);
+        notFoundKeys.remove(key);
+        log.info("[MessageStructurePool] 캐시 제거: orgId={}, messageId={}", orgId, messageId);
+    }
+
+    /** 전체 캐시 초기화 */
+    public void clear() {
+        cache.clear();
+        notFoundKeys.clear();
+        log.info("[MessageStructurePool] 전체 캐시 초기화");
+    }
+
+    /** DB에서 전문 구조를 로드하여 빌드 */
+    private MessageStructure load(String orgId, String messageId) {
+        String messageType = messageMetaMapper.selectMessageType(orgId, messageId);
+        if (messageType == null) {
+            log.warn("[MessageStructurePool] FWK_MESSAGE 미등록 전문: orgId={}, messageId={}", orgId, messageId);
+            return null;
+        }
+
+        List<MessageFieldMeta> fieldMetas = messageMetaMapper.selectFields(orgId, messageId);
+        MessageStructure structure = buildStructure(orgId, messageId, messageType, fieldMetas);
+        log.info("[MessageStructurePool] 전문 구조 로드: orgId={}, messageId={}, type={}, fields={}",
+                orgId, messageId, messageType, fieldMetas.size());
+        return structure;
+    }
+
+    /**
+     * 평탄 필드 목록을 트리 구조로 변환.
+     *
+     * <p>_BeginLoop_xxx ~ _EndLoop_ 구간을 LoopField 로 묶는다.
+     * 단일 뎁스 루프만 지원한다.</p>
+     */
+    private MessageStructure buildStructure(
+            String orgId, String messageId, String messageType, List<MessageFieldMeta> metas) {
+
+        MessageStructure structure = new MessageStructure(orgId, messageId, messageType);
+        LoopField currentLoop = null;
+
+        for (MessageFieldMeta meta : metas) {
+            String fieldId = meta.getMessageFieldId();
+
+            if (fieldId.length() > BEGIN_LOOP_PREFIX.length()
+                    && fieldId.substring(0, BEGIN_LOOP_PREFIX.length())
+                              .equalsIgnoreCase(BEGIN_LOOP_PREFIX)) {
+
+                String loopName = fieldId.substring(BEGIN_LOOP_PREFIX.length());
+                currentLoop = new LoopField(
+                        loopName,
+                        meta.getDataLength() != null ? meta.getDataLength().intValue() : 0,
+                        meta.getFieldRepeatCnt() != null ? meta.getFieldRepeatCnt() : 0,
+                        meta.getDefaultValue()
+                );
+                structure.addField(currentLoop);
+
+            } else if (END_LOOP.equalsIgnoreCase(fieldId)) {
+                currentLoop = null;
+
+            } else {
+                MessageField field = toMessageField(meta);
+                if (currentLoop != null) {
+                    currentLoop.addChild(field);
+                } else {
+                    structure.addField(field);
+                }
+            }
+        }
+
+        return structure;
+    }
+
+    private MessageField toMessageField(MessageFieldMeta meta) {
+        return new MessageField(
+                meta.getMessageFieldId(),
+                meta.getDataType() != null ? meta.getDataType() : MessageField.CHR,
+                meta.getDataLength() != null ? meta.getDataLength().intValue() : 0,
+                meta.getScale() != null ? meta.getScale() : 0,
+                meta.getAlign() != null ? meta.getAlign() : MessageField.LEFT,
+                resolveFillerChar(meta.getFiller()),
+                meta.getRemark(),
+                "Y".equalsIgnoreCase(meta.getLogYn())
+        );
+    }
+
+    private char resolveFillerChar(String filler) {
+        if (filler == null || filler.isEmpty()) return ' ';
+        return filler.charAt(0);
+    }
+
+    private String cacheKey(String orgId, String messageId) {
+        return orgId + ":" + messageId;
+    }
+}

--- a/spider-link/src/main/resources/mapper/oracle/message/MessageMetaMapper.xml
+++ b/spider-link/src/main/resources/mapper/oracle/message/MessageMetaMapper.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.example.spiderlink.domain.message.mapper.MessageMetaMapper">
+
+    <!-- 전문 타입 코드 조회 -->
+    <select id="selectMessageType" resultType="string">
+        SELECT MESSAGE_TYPE
+        FROM FWK_MESSAGE
+        WHERE ORG_ID   = #{orgId}
+          AND MESSAGE_ID = #{messageId}
+    </select>
+
+    <!-- 전문 필드 목록 조회 (SORT_ORDER 오름차순) -->
+    <select id="selectFields" resultType="com.example.spiderlink.domain.message.dto.MessageFieldMeta">
+        SELECT
+            ORG_ID              AS orgId,
+            MESSAGE_ID          AS messageId,
+            MESSAGE_FIELD_ID    AS messageFieldId,
+            MESSAGE_FIELD_NAME  AS messageFieldName,
+            SORT_ORDER          AS sortOrder,
+            DATA_TYPE           AS dataType,
+            DATA_LENGTH         AS dataLength,
+            "SCALE"             AS scale,
+            ALIGN               AS align,
+            FILLER              AS filler,
+            REMARK              AS remark,
+            LOG_YN              AS logYn,
+            DEFAULT_VALUE       AS defaultValue,
+            FIELD_REPEAT_CNT    AS fieldRepeatCnt
+        FROM FWK_MESSAGE_FIELD
+        WHERE ORG_ID    = #{orgId}
+          AND MESSAGE_ID = #{messageId}
+        ORDER BY SORT_ORDER ASC
+    </select>
+
+</mapper>


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

Closes #114

## ✨ 변경 사항 (Changes)

### 1. demo/tcp-backend ↔ spider-link 미들웨어 연동

**SpiderLinkClient 신규 추가**
- 4바이트 big-endian 길이 헤더 + UTF-8 JSON 동기 TCP 클라이언트
- 요청마다 새 소켓 생성, 소켓 타임아웃 10초

**HTTP/TCP 양쪽 경로 3개 전문 spider-link 경유 전환**

| 커맨드 | HTTP 경로 | TCP 경로 |
|--------|-----------|----------|
| `DEMO_AUTH_LOGIN` | `AuthController.login()` | `AuthHandler.handleLogin()` |
| `DEMO_AUTH_ME` | `AuthController.me()` | `AuthHandler.handleGetProfile()` |
| `DEMO_PAYABLE_AMT` | `CardController.getPayableAmount()` | `CardHandler.handleGetPayableAmount()` |

> 나머지 전문(카드목록, 즉시결제, 이용내역 등)은 로컬 DB 직접 접근 유지

**기타**
- `AppProperties`에 `spiderlink.host/port` 설정 바인딩 추가
- `WebConfig` CORS 허용 origin에 `localhost:5174` 추가 (Vite 포트 충돌 대응)

### 2. spider-link Fixed Length 파서 인프라 추가

향후 Fixed Length 타입 전문 처리를 위한 파서 기반 구조 추가 (TCP 파이프라인 연동은 미완료)

| 파일 | 역할 |
|------|------|
| `FixedLengthParser` | 바이트 배열 → Map 역직렬화 |
| `MessageStructurePool` | 전문 구조 캐싱 (startup 로딩) |
| `MessageField`, `LoopField`, `MessageStructure` | 필드 메타 모델 |
| `MessageMetaMapper` | FWK_MESSAGE / FWK_MESSAGE_FIELD DB 조회 |

### 3. admin 초기 데이터

- `03_insert_initial_data.sql`에 FEPDEMO 코드 그룹 INSERT 추가 (Fixed Length 전문 도입 시 사용)

## ⚠️ 고려 및 주의 사항

- `TRX_TRACKING_NO` / `MESSAGE_SNO` 컬럼이 VARCHAR2(30)으로 UUID 32자리를 2자리 truncate하여 저장 중 → 별도 이슈 처리 예정
- Fixed Length 파서는 인프라만 추가된 상태 (TCP 파이프라인 연동, MessageParserFactory 구현은 후속 작업)
- FEPDEMO 코드 그룹 SQL은 Fixed Length 전문 추가 시점에 DB에서 직접 실행 필요

## 💬 리뷰 포인트

- `SpiderLinkClient`: 요청마다 새 소켓을 여는 단순 동기 방식 — POC 수준 빈도에는 적합하나, 성능 요구 시 커넥션 풀 전환 필요
- HTTP 경로(`AuthController`, `CardController`)와 TCP 경로(`AuthHandler`, `CardHandler`) 양쪽 모두 동일한 spider-link 전문을 경유하도록 통일

## 🔗 참고 사항

- 설계 문서: `00-2. Demo 전문통신 및 미들웨어 설계.md`
- 동작 확인: demo 앱(5174) 로그인 → Admin 거래추적로그조회(DB) > 글로벌ID `MDW` 필터로 REQ/RES 로그 조회 확인