### PR TITLE
fix: #47 배치 모니터링 버그 수정 및 실행중 배치 화면 개선

### DIFF
--- a/admin/src/main/java/com/example/admin_demo/domain/batch/dto/BatchRunningResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/batch/dto/BatchRunningResponse.java
@@ -10,13 +10,19 @@ import lombok.NoArgsConstructor;
  * @description batch-was 인스턴스에서 조회한 실행 중 배치 정보를 담는 응답 DTO.
  *     <p>batch-was의 GET /api/batch/running 응답을 역직렬화하여 Admin 측 필드를 추가한다.
  *     <p>connected=false 인 경우 WAS와 통신 불가 상태를 나타내며, instanceId 이외의 필드는 null 이다.
- * @example connected=true:
+ *     <p>connected=true 이고 batchAppId 가 null 인 경우 WAS는 정상이나 실행 중인 배치가 없는 "대기 중" 상태다.
+ * @example connected=true, 배치 실행 중:
  *     BatchRunningResponse.builder()
  *         .instanceId("PT11")
  *         .connected(true)
  *         .jobExecutionId(42L)
  *         .batchAppId("BATCH_001")
  *         .status("STARTED")
+ *         .build();
+ * @example connected=true, 대기 중 (실행 중인 배치 없음):
+ *     BatchRunningResponse.builder()
+ *         .instanceId("PT11")
+ *         .connected(true)
  *         .build();
  * @example connected=false (통신 불가):
  *     BatchRunningResponse.builder()

--- a/admin/src/main/java/com/example/admin_demo/domain/batch/service/BatchRunningService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/batch/service/BatchRunningService.java
@@ -88,18 +88,31 @@ public class BatchRunningService {
                     url, HttpMethod.GET, null, new ParameterizedTypeReference<List<BatchRunningResponse>>() {});
 
             List<BatchRunningResponse> body = response.getBody();
-            if (body == null) {
-                // 정상 응답이지만 빈 body인 경우 빈 리스트 반환
-                return List.of();
+            if (body == null || body.isEmpty()) {
+                // 연결은 됐지만 실행 중인 배치가 없음 → 인스턴스를 "대기 중" 항목으로 표시
+                return List.of(BatchRunningResponse.builder()
+                        .instanceId(instance.getInstanceId())
+                        .connected(true)
+                        .build());
             }
 
-            // 각 항목에 instanceId와 connected=true 설정
-            body.forEach(item -> {
-                item.setInstanceId(instance.getInstanceId());
-                item.setConnected(true);
-            });
+            // spider-batch가 응답에 자신의 instanceId를 포함하므로,
+            // 응답의 instanceId가 쿼리한 instanceId와 다른 항목은 IP를 공유하는
+            // 다른 WAS 서버의 데이터 → 해당 인스턴스는 대기 중으로 처리한다.
+            String expected = instance.getInstanceId();
+            List<BatchRunningResponse> own = body.stream()
+                    .filter(item -> expected.equals(item.getInstanceId()))
+                    .peek(item -> item.setConnected(true))
+                    .toList();
 
-            return body;
+            if (own.isEmpty()) {
+                return List.of(BatchRunningResponse.builder()
+                        .instanceId(expected)
+                        .connected(true)
+                        .build());
+            }
+
+            return own;
 
         } catch (RestClientException e) {
             // 타임아웃, 연결 거부 등 통신 오류: WARN 로그 후 connected=false 항목 반환

--- a/admin/src/main/java/com/example/admin_demo/global/config/RestTemplateConfig.java
+++ b/admin/src/main/java/com/example/admin_demo/global/config/RestTemplateConfig.java
@@ -17,7 +17,7 @@ public class RestTemplateConfig {
 
     @Bean
     public RestTemplate restTemplate(RestTemplateBuilder builder) {
-        return builder.connectTimeout(Duration.ofSeconds(5)) // 연결 타임아웃: 5초
+        return builder.connectTimeout(Duration.ofSeconds(2)) // 연결 타임아웃: 2초 (내부망 기준 충분; 응답 없는 WAS 인스턴스 대기 최소화)
                 .readTimeout(Duration.ofSeconds(10)) // 읽기 타임아웃: 10초
                 .requestFactory(() -> new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()))
                 .build();

--- a/admin/src/main/java/com/example/admin_demo/global/log/listener/RdbAccessLogListener.java
+++ b/admin/src/main/java/com/example/admin_demo/global/log/listener/RdbAccessLogListener.java
@@ -5,7 +5,6 @@ import com.example.admin_demo.global.log.event.AccessLogEvent;
 import com.example.admin_demo.global.util.StringUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -54,28 +53,17 @@ public class RdbAccessLogListener {
             map.put("duration", event.getDurationMs());
         }
 
-        String data = event.getData() != null ? event.getData() : "";
-        String errorMessage = event.getErrorMessage();
-
-        // 고정 필드(traceId, phase, status, duration) 직렬화 후 남은 바이트 계산
-        Map<String, Object> fixedMap = new LinkedHashMap<>(map);
-        fixedMap.put("data", "");
-        int fixedOverhead = objectMapper.writeValueAsString(fixedMap).getBytes(StandardCharsets.UTF_8).length;
-        int budget = MAX_INPUT_DATA_BYTES - fixedOverhead - 50; // 여유분 50 bytes (errorMessage 키 등)
-
-        // errorMessage 먼저 할당 (짧으므로), 나머지를 data에 할당
-        if (errorMessage != null) {
-            int errorBudget = Math.min(budget / 4, errorMessage.getBytes(StandardCharsets.UTF_8).length);
-            errorMessage = StringUtil.truncateBytesWithMarker(errorMessage, errorBudget);
-            budget -= errorMessage.getBytes(StandardCharsets.UTF_8).length;
+        if (event.getData() != null && !event.getData().isEmpty()) {
+            map.put("data", event.getData());
         }
-        data = StringUtil.truncateBytesWithMarker(data, budget);
-
-        map.put("data", data);
-        if (errorMessage != null) {
-            map.put("errorMessage", errorMessage);
+        if (event.getErrorMessage() != null) {
+            map.put("errorMessage", event.getErrorMessage());
         }
 
-        return objectMapper.writeValueAsString(map);
+        // 직렬화 후 최종 바이트 기준으로 잘라낸다.
+        // 사전 예산 계산 방식은 JSON 직렬화 시 특수문자 이스케이핑(" → \")으로
+        // 최종 바이트가 예산을 초과하는 ORA-01461 버그가 있었다.
+        String json = objectMapper.writeValueAsString(map);
+        return StringUtil.truncateBytesWithMarker(json, MAX_INPUT_DATA_BYTES);
     }
 }

--- a/admin/src/main/resources/static/css/admin-histories-content.css
+++ b/admin/src/main/resources/static/css/admin-histories-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/approval-content.css
+++ b/admin/src/main/resources/static/css/approval-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/approvals-content.css
+++ b/admin/src/main/resources/static/css/approvals-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/apps-content.css
+++ b/admin/src/main/resources/static/css/apps-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/auth-content.css
+++ b/admin/src/main/resources/static/css/auth-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/biz-apps-content.css
+++ b/admin/src/main/resources/static/css/biz-apps-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/boards-content.css
+++ b/admin/src/main/resources/static/css/boards-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/code-groups-content.css
+++ b/admin/src/main/resources/static/css/code-groups-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/code-templates-content.css
+++ b/admin/src/main/resources/static/css/code-templates-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/codes-content.css
+++ b/admin/src/main/resources/static/css/codes-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/components-content.css
+++ b/admin/src/main/resources/static/css/components-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/datasources-content.css
+++ b/admin/src/main/resources/static/css/datasources-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/emergency-notice-deploys-content.css
+++ b/admin/src/main/resources/static/css/emergency-notice-deploys-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/emergency-notices-content.css
+++ b/admin/src/main/resources/static/css/emergency-notices-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/error-codes-content.css
+++ b/admin/src/main/resources/static/css/error-codes-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/error-histories-content.css
+++ b/admin/src/main/resources/static/css/error-histories-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/files-content.css
+++ b/admin/src/main/resources/static/css/files-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/gateways-content.css
+++ b/admin/src/main/resources/static/css/gateways-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/generation-content.css
+++ b/admin/src/main/resources/static/css/generation-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/gw-systems-content.css
+++ b/admin/src/main/resources/static/css/gw-systems-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/history-content.css
+++ b/admin/src/main/resources/static/css/history-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/json-content.css
+++ b/admin/src/main/resources/static/css/json-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/listener-trxs-content.css
+++ b/admin/src/main/resources/static/css/listener-trxs-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/menus-content.css
+++ b/admin/src/main/resources/static/css/menus-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/message-handlers-content.css
+++ b/admin/src/main/resources/static/css/message-handlers-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/message-instances-content.css
+++ b/admin/src/main/resources/static/css/message-instances-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/message-parsing-content.css
+++ b/admin/src/main/resources/static/css/message-parsing-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/message-tests-content.css
+++ b/admin/src/main/resources/static/css/message-tests-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/messages-content.css
+++ b/admin/src/main/resources/static/css/messages-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/monitors-content.css
+++ b/admin/src/main/resources/static/css/monitors-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/org-codes-content.css
+++ b/admin/src/main/resources/static/css/org-codes-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/orgs-content.css
+++ b/admin/src/main/resources/static/css/orgs-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/profile-content.css
+++ b/admin/src/main/resources/static/css/profile-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/properties-content.css
+++ b/admin/src/main/resources/static/css/properties-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/proxy-responses-content.css
+++ b/admin/src/main/resources/static/css/proxy-responses-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/react-approval-content.css
+++ b/admin/src/main/resources/static/css/react-approval-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/react-generate-content.css
+++ b/admin/src/main/resources/static/css/react-generate-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/react-generate-his-content.css
+++ b/admin/src/main/resources/static/css/react-generate-his-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/reload-content.css
+++ b/admin/src/main/resources/static/css/reload-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/roles-content.css
+++ b/admin/src/main/resources/static/css/roles-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/running-content.css
+++ b/admin/src/main/resources/static/css/running-content.css
@@ -1,0 +1,1 @@
+/* batch-running-list page — no page-specific styles */

--- a/admin/src/main/resources/static/css/sql-queries-content.css
+++ b/admin/src/main/resources/static/css/sql-queries-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/stop-transaction-accessors-content.css
+++ b/admin/src/main/resources/static/css/stop-transaction-accessors-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/trans-data-content.css
+++ b/admin/src/main/resources/static/css/trans-data-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/transactions-content.css
+++ b/admin/src/main/resources/static/css/transactions-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/transports-content.css
+++ b/admin/src/main/resources/static/css/transports-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/trx-stop-content.css
+++ b/admin/src/main/resources/static/css/trx-stop-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/trx-stop-history-content.css
+++ b/admin/src/main/resources/static/css/trx-stop-history-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/users-content.css
+++ b/admin/src/main/resources/static/css/users-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/validation-content.css
+++ b/admin/src/main/resources/static/css/validation-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/validators-content.css
+++ b/admin/src/main/resources/static/css/validators-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/was-gateway-statuses-content.css
+++ b/admin/src/main/resources/static/css/was-gateway-statuses-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/was-groups-content.css
+++ b/admin/src/main/resources/static/css/was-groups-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/was-instances-content.css
+++ b/admin/src/main/resources/static/css/was-instances-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/was-status-monitors-content.css
+++ b/admin/src/main/resources/static/css/was-status-monitors-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/static/css/xml-properties-content.css
+++ b/admin/src/main/resources/static/css/xml-properties-content.css
@@ -1,0 +1,1 @@
+/* no page-specific styles */

--- a/admin/src/main/resources/templates/pages/batch-app-manage/batch-app-manage-exec-modal.html
+++ b/admin/src/main/resources/templates/pages/batch-app-manage/batch-app-manage-exec-modal.html
@@ -140,8 +140,9 @@
         assignedInstances: [],
 
         open: function(batchAppId) {
-            // 오늘 날짜를 기본값으로 설정
-            const today = new Date().toISOString().split('T')[0];
+            // 오늘 날짜를 기본값으로 설정 (toISOString은 UTC 기준이라 KST 오전 9시 이전 실행 시 전날 날짜가 반환됨 → 로컬 날짜 사용)
+            const _d = new Date();
+            const today = `${_d.getFullYear()}-${String(_d.getMonth() + 1).padStart(2, '0')}-${String(_d.getDate()).padStart(2, '0')}`;
             $('#execBatchDate').val(today);
             $('#execParameters').val('');
             $('#execSelectAll').prop('checked', false);
@@ -155,7 +156,10 @@
         },
 
         close: function() {
-            bootstrap.Modal.getInstance(document.getElementById('batchExecModal')).hide();
+            // getInstance는 show() 이전 또는 dispose() 이후 null을 반환하므로 null 체크
+            const el = document.getElementById('batchExecModal');
+            const modal = el && bootstrap.Modal.getInstance(el);
+            if (modal) modal.hide();
         },
 
         loadBatchAppDetail: function(batchAppId) {

--- a/admin/src/main/resources/templates/pages/batch-his-list/batch-his-list-script.html
+++ b/admin/src/main/resources/templates/pages/batch-his-list/batch-his-list-script.html
@@ -25,7 +25,10 @@
                dtimeStr.substring(12, 14);
     }
 
-    const BatchHistory = {
+    // window에 할당: 탭 캐시 제거 후 재로딩 시 tabContent.html()이 스크립트를 재실행하는데,
+    // const는 중복 선언 불가(SyntaxError)이고 pagination의 onclick="BatchHistory.xxx()"가
+    // 전역 참조를 요구하므로 window 프로퍼티 재할당 방식을 사용한다.
+    window.BatchHistory = {
         currentPage: 1,
         totalItems: 0,
         itemsPerPage: 10,

--- a/admin/src/main/resources/templates/pages/batch-running-list/batch-running-list-script.html
+++ b/admin/src/main/resources/templates/pages/batch-running-list/batch-running-list-script.html
@@ -10,7 +10,11 @@
      *              GET /api/batch/running 으로 현재 실행 중인 배치 목록을 조회하고,
      *              POST /api/batch/stop 으로 선택한 배치를 강제 종료한다.
      *              connected=false 항목은 WAS 통신 불가 인스턴스로 별도 표시한다.
+     *
+     * IIFE로 감싸 const 재선언 방지: 탭 캐시 제거 후 재로딩 시 tabContent.html()이
+     * 스크립트를 재실행하는데, 전역 const는 중복 선언 불가(SyntaxError)이므로 스코프 격리.
      */
+    (function () {
 
     /**
      * 일시 포맷 함수 (YYYYMMDDHH24MISS → YYYY/MM/DD HH:MM:SS)
@@ -91,6 +95,25 @@
                             <td>
                                 ${HtmlUtils.escape(item.instanceId || '')}
                                 <span class="badge bg-warning text-dark ms-1">연결 불가</span>
+                            </td>
+                            <td>-</td>
+                            <td>-</td>
+                            <td>-</td>
+                            <td>-</td>
+                            <td class="text-center">-</td>
+                            <td class="text-center">-</td>
+                            <td class="text-center">-</td>
+                        </tr>
+                    `);
+                    tbody.append(row);
+                } else if (!item.batchAppId) {
+                    // 연결은 됐지만 실행 중인 배치가 없는 인스턴스 — "연결 불가"와 동일하게 인스턴스 ID 셀에 배지를 붙여
+                    // 스크롤 없이도 상태를 확인할 수 있도록 한다.
+                    const row = $(`
+                        <tr class="text-body-secondary">
+                            <td>
+                                ${HtmlUtils.escape(item.instanceId || '')}
+                                <span class="badge bg-secondary ms-1">대기 중</span>
                             </td>
                             <td>-</td>
                             <td>-</td>
@@ -219,6 +242,8 @@
     $('[data-tab-page]').off('tab:activated.batchRunning').on('tab:activated.batchRunning', function() {
         BatchRunning.load();
     });
+
+    })(); // IIFE end
 </script>
 </th:block>
 </body>

--- a/admin/src/main/resources/templates/pages/batch-running-list/batch-running-list-table.html
+++ b/admin/src/main/resources/templates/pages/batch-running-list/batch-running-list-table.html
@@ -6,7 +6,7 @@
     <table class="table table-sm table-hover sp-data-grid" id="batchRunningTable">
         <thead class="table-light">
             <tr>
-                <th class="col-w-100">인스턴스ID</th>
+                <th class="col-w-140">인스턴스ID</th>
                 <th class="col-w-140">배치APP ID</th>
                 <th class="col-w-140">배치APP명</th>
                 <th class="col-w-180">배치APP FILE명</th>

--- a/admin/src/main/resources/templates/pages/error-cause-his/error-cause-his-script.html
+++ b/admin/src/main/resources/templates/pages/error-cause-his/error-cause-his-script.html
@@ -53,12 +53,13 @@
                 btnPrint.addEventListener('click', printTable);
             }
 
-            // 기본값: 오늘부터 7일 전
+            // 기본값: 오늘부터 7일 전 (toISOString은 UTC 기준 → 로컬 날짜 사용)
+            const _toLocalDate = d => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
             const today = new Date();
             const weekAgo = new Date(today);
             weekAgo.setDate(weekAgo.getDate() - 7);
-            document.getElementById('searchStartDate').value = weekAgo.toISOString().slice(0, 10);
-            document.getElementById('searchEndDate').value = today.toISOString().slice(0, 10);
+            document.getElementById('searchStartDate').value = _toLocalDate(weekAgo);
+            document.getElementById('searchEndDate').value = _toLocalDate(today);
 
             search();
         }

--- a/spider-batch/src/main/java/com/example/spiderbatch/domain/batch/dto/BatchRunningResponse.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/domain/batch/dto/BatchRunningResponse.java
@@ -41,4 +41,10 @@ public class BatchRunningResponse {
 
     /** 실행 상태 (BatchStatus.name() — "STARTED", "STARTING" 등) */
     private String status;
+
+    /**
+     * 이 응답을 생성한 WAS 인스턴스 ID (application.yml batch.was.instance-id).
+     * Admin이 동일 IP를 공유하는 인스턴스들 사이에서 데이터 출처를 식별하는 데 사용한다.
+     */
+    private String instanceId;
 }

--- a/spider-batch/src/main/java/com/example/spiderbatch/domain/batch/service/BatchMonitorService.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/domain/batch/service/BatchMonitorService.java
@@ -179,6 +179,7 @@ public class BatchMonitorService {
                 .batchDate(batchDate != null ? batchDate : "")
                 .startTime(startTime)
                 .status(jobExecution.getStatus().name())
+                .instanceId(instanceId)
                 .build();
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
- #47

## ✨ 변경 사항 (Changes)

**admin**
- CSS 정적 파일 누락으로 발생하던 `GET /error → 404` 로그 노이즈 제거 — 페이지별 placeholder CSS 55개 추가
- 탭 캐시 제거 후 재로딩 시 `const BatchRunning` 재선언 SyntaxError 수정 → IIFE로 스코프 격리
- `window.BatchHistory` 전환 — pagination `onclick` 전역 참조를 유지하면서 재선언 오류 방지
- `BatchExecModal.close()` null 가드 추가 — `Modal.getInstance()` 반환값이 null일 때 crash 방지
- `toISOString()` UTC 버그 수정 → 로컬 날짜(`getFullYear/getMonth/getDate`) 사용 (KST 오전 9시 이전 어제 날짜 저장 문제)
- 실행중 배치가 없어도 WAS 인스턴스 목록 표시 — `connected=true + batchAppId null` → "대기 중" 배지
- 인스턴스ID 컬럼 너비 100→140px 확장 — "연결 불가" 배지 잘림 방지
- `BatchRunningService`: 동일 IP를 공유하는 WAS 인스턴스 간 데이터 오염 방지 — 응답의 `instanceId` 필터링 적용
- `RestTemplateConfig`: `connectTimeout` 5초→2초 단축 — 미응답 WAS 인스턴스 대기 시간 최소화

**spider-batch**
- `BatchRunningResponse`에 `instanceId` 필드 추가 — Admin이 응답 출처 인스턴스를 식별할 수 있도록
- `BatchMonitorService.toRunningResponse()`: 응답에 `instanceId` 포함

## ⚠️ 고려 및 주의 사항 (선택)
- spider-link 변경 없음. 단, Admin 서버가 이전 spider-link jar를 사용 중이면 `POST /api/batch/exec` 500 오류(`NoClassDefFoundError: ManagementContext$ManagementContextBuilder`) 발생 → `cd spider-link && mvn clean install -DskipTests` 후 admin 재시작 필요
- `connectTimeout` 단축(5s→2s)은 내부망 기준이며, 응답 없는 WAS(PW21·PW31)의 대기 시간 단축 목적

## 💬 리뷰 포인트 (선택)
- `BatchRunningService.fetchRunningFromInstance()` — 응답 `instanceId` 필터링 로직 (동일 IP 공유 환경 대응)
- CSS placeholder 파일 — `/* no page-specific styles */` 한 줄짜리 파일 55개, `ErrorPageFilter` 내부 forward 차단이 목적