### PR TITLE
feat: CMS 통계 컴포넌트 클릭 상세 모달 — 가로형 막대 차트 + 요약 테이블 (#85)

### DIFF
--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -238,6 +238,14 @@
 			<artifactId>select2</artifactId>
 			<version>4.1.0-rc.0</version>
 		</dependency>
+		<!-- Chart.js: WebJar 사내 레포 미등록 시 아래 CDN 방식 사용 (cms-statistics.html 참고) -->
+		<!--
+		<dependency>
+			<groupId>org.webjars.npm</groupId>
+			<artifactId>chart.js</artifactId>
+			<version>4.4.2</version>
+		</dependency>
+		-->
 
 		<!-- spider-link 공통 연계엔진 라이브러리 (ManagementContext, TCP 인프라 공유) -->
 		<dependency>

--- a/admin/src/main/resources/templates/pages/cms-statistics/cms-statistics-script.html
+++ b/admin/src/main/resources/templates/pages/cms-statistics/cms-statistics-script.html
@@ -179,8 +179,8 @@
             const maxLabelText = maxClick.toLocaleString() + ' (100.0%)';
             const rightPadding = maxLabelText.length * 7 + 12;
 
-            // 데이터 수에 따라 캔버스 높이 동적 설정 (막대 1개당 40px + 상하 여백)
-            const canvasHeight = Math.max(200, data.length * 40 + 60);
+            // 데이터 수에 따라 캔버스 높이 동적 설정 (막대 1개당 28px + 상하 여백)
+            const canvasHeight = Math.max(120, data.length * 28 + 40);
             $('#detailBarChart').css('height', canvasHeight + 'px');
 
             // 막대 끝 레이블 — 별도 플러그인 없이 afterDraw 훅으로 직접 렌더링
@@ -216,7 +216,7 @@
                         data: values,
                         backgroundColor: colors,
                         borderRadius: 3,
-                        barThickness: 20,
+                        barThickness: 14,
                     }]
                 },
                 options: {

--- a/admin/src/main/resources/templates/pages/cms-statistics/cms-statistics-script.html
+++ b/admin/src/main/resources/templates/pages/cms-statistics/cms-statistics-script.html
@@ -11,6 +11,43 @@
         itemsPerPage: 10,
         /** 모달 재오픈 시 destroy 후 재생성하기 위한 Chart.js 인스턴스 참조 */
         _detailChart: null,
+        /** afterDraw 레이블 계산 시 total 접근용 — _renderDetailChart 실행 시 갱신 */
+        _chartTotal: 0,
+
+        /**
+         * 비율(%) 계산 헬퍼 — afterDraw·tooltip·요약 테이블에서 공통 사용
+         * @param {number} value - 개별 값
+         * @param {number} total - 전체 합계
+         * @returns {string} 소수점 1자리 퍼센트 문자열 (예: "35.3")
+         */
+        _pct: function(value, total) {
+            return total > 0 ? ((value / total) * 100).toFixed(1) : '0.0';
+        },
+
+        /**
+         * 막대 끝 레이블 플러그인 — 함수 호출마다 재생성하지 않도록 객체 수준으로 정의
+         * _chartTotal 을 통해 렌더링 시점의 total 값을 참조한다.
+         */
+        _datalabelsPlugin: {
+            id: 'cmsStatDatalabels',
+            afterDraw(chart) {
+                const ctx = chart.ctx;
+                const total = CmsStatisticsPage._chartTotal;
+                chart.data.datasets.forEach((dataset, i) => {
+                    chart.getDatasetMeta(i).data.forEach((bar, index) => {
+                        const value = dataset.data[index];
+                        const pct = CmsStatisticsPage._pct(value, total);
+                        ctx.save();
+                        ctx.font = '12px sans-serif';
+                        ctx.fillStyle = '#495057';
+                        ctx.textAlign = 'left';
+                        ctx.textBaseline = 'middle';
+                        ctx.fillText(`${value.toLocaleString()} (${pct}%)`, bar.x + 6, bar.y);
+                        ctx.restore();
+                    });
+                });
+            }
+        },
 
         load: function(page) {
             if (page !== undefined) this.currentPage = page;
@@ -139,7 +176,8 @@
             $('#detailSummaryTable').addClass('d-none');
             $('#detailNoData').addClass('d-none').removeClass('text-danger').text('');
 
-            new bootstrap.Modal('#detailModal').show();
+            // getOrCreateInstance — 매 호출마다 새 인스턴스를 생성하지 않아 메모리 누수 방지
+            bootstrap.Modal.getOrCreateInstance('#detailModal').show();
 
             const params = new URLSearchParams({ pageId, startDate, endDate });
             fetch('/api/cms-admin/statistics/detail?' + params)
@@ -171,45 +209,29 @@
             const total = data.reduce((sum, d) => sum + (d.clickCount || 0), 0);
             const maxClick = Math.max(...data.map(d => d.clickCount || 0));
 
+            // afterDraw 플러그인이 클로저 없이 total에 접근할 수 있도록 객체 프로퍼티에 저장
+            this._chartTotal = total;
+
             const labels = data.map(d => d.componentId || '');
             const values = data.map(d => d.clickCount || 0);
             const colors = values.map(v => v === maxClick ? '#0d6efd' : '#adb5bd');
 
-            // 막대 끝 레이블 최대 너비 추정 → 오른쪽 패딩 동적 계산 (글자당 약 7px)
+            // measureText()로 실제 텍스트 픽셀 너비를 측정하여 우측 패딩 계산 (매직 넘버 제거)
             const maxLabelText = maxClick.toLocaleString() + ' (100.0%)';
-            const rightPadding = maxLabelText.length * 7 + 12;
+            const tempCtx = document.createElement('canvas').getContext('2d');
+            tempCtx.font = '12px sans-serif';
+            const rightPadding = tempCtx.measureText(maxLabelText).width + 12;
 
             // 데이터 수에 따라 캔버스 높이 동적 설정 (막대 1개당 22px + 상하 여백)
             const canvasHeight = Math.max(80, data.length * 22 + 30);
             $('#detailBarChart').css('height', canvasHeight + 'px');
-
-            // 막대 끝 레이블 — 별도 플러그인 없이 afterDraw 훅으로 직접 렌더링
-            const datalabelsPlugin = {
-                id: 'cmsStatDatalabels',
-                afterDraw(chart) {
-                    const ctx = chart.ctx;
-                    chart.data.datasets.forEach((dataset, i) => {
-                        chart.getDatasetMeta(i).data.forEach((bar, index) => {
-                            const value = dataset.data[index];
-                            const pct = total > 0 ? ((value / total) * 100).toFixed(1) : '0.0';
-                            ctx.save();
-                            ctx.font = '12px sans-serif';
-                            ctx.fillStyle = '#495057';
-                            ctx.textAlign = 'left';
-                            ctx.textBaseline = 'middle';
-                            ctx.fillText(`${value.toLocaleString()} (${pct}%)`, bar.x + 6, bar.y);
-                            ctx.restore();
-                        });
-                    });
-                }
-            };
 
             const canvas = document.getElementById('detailBarChart');
             $('#detailChartWrapper').removeClass('d-none');
 
             this._detailChart = new Chart(canvas.getContext('2d'), {
                 type: 'bar',
-                plugins: [datalabelsPlugin],
+                plugins: [this._datalabelsPlugin],
                 data: {
                     labels,
                     datasets: [{
@@ -227,10 +249,7 @@
                         legend: { display: false },
                         tooltip: {
                             callbacks: {
-                                label: ctx => {
-                                    const pct = total > 0 ? ((ctx.parsed.x / total) * 100).toFixed(1) : '0.0';
-                                    return ` ${ctx.parsed.x.toLocaleString()} (${pct}%)`;
-                                }
+                                label: ctx => ` ${ctx.parsed.x.toLocaleString()} (${CmsStatisticsPage._pct(ctx.parsed.x, total)}%)`
                             }
                         }
                     },
@@ -257,7 +276,7 @@
         _renderSummaryTable: function(data, total, maxClick) {
             const rows = data.map(d => {
                 const count = d.clickCount || 0;
-                const pct = total > 0 ? ((count / total) * 100).toFixed(1) : '0.0';
+                const pct = this._pct(count, total);
                 const badge = count === maxClick
                     ? ' <span class="badge bg-primary ms-1" style="font-size:10px;">최다</span>'
                     : '';

--- a/admin/src/main/resources/templates/pages/cms-statistics/cms-statistics-script.html
+++ b/admin/src/main/resources/templates/pages/cms-statistics/cms-statistics-script.html
@@ -179,8 +179,8 @@
             const maxLabelText = maxClick.toLocaleString() + ' (100.0%)';
             const rightPadding = maxLabelText.length * 7 + 12;
 
-            // 데이터 수에 따라 캔버스 높이 동적 설정 (막대 1개당 28px + 상하 여백)
-            const canvasHeight = Math.max(120, data.length * 28 + 40);
+            // 데이터 수에 따라 캔버스 높이 동적 설정 (막대 1개당 22px + 상하 여백)
+            const canvasHeight = Math.max(80, data.length * 22 + 30);
             $('#detailBarChart').css('height', canvasHeight + 'px');
 
             // 막대 끝 레이블 — 별도 플러그인 없이 afterDraw 훅으로 직접 렌더링

--- a/admin/src/main/resources/templates/pages/cms-statistics/cms-statistics-script.html
+++ b/admin/src/main/resources/templates/pages/cms-statistics/cms-statistics-script.html
@@ -9,6 +9,8 @@
         currentPage: 1,
         totalItems: 0,
         itemsPerPage: 10,
+        /** 모달 재오픈 시 destroy 후 재생성하기 위한 Chart.js 인스턴스 참조 */
+        _detailChart: null,
 
         load: function(page) {
             if (page !== undefined) this.currentPage = page;
@@ -124,26 +126,157 @@
 
         openDetailModal: function(pageId, pageName, startDate, endDate) {
             $('#detailPageName').text(pageName);
-            $('#detailTableBody').html('<tr><td colspan="2" class="text-center text-body-secondary">불러오는 중...</td></tr>');
+
+            // 모달 재오픈 시 기존 차트 인스턴스 해제 (캔버스 재사용 시 오류 방지)
+            if (this._detailChart) {
+                this._detailChart.destroy();
+                this._detailChart = null;
+            }
+
+            // 로딩 상태로 초기화
+            $('#detailLoading').show();
+            $('#detailChartWrapper').addClass('d-none');
+            $('#detailSummaryTable').addClass('d-none');
+            $('#detailNoData').addClass('d-none').removeClass('text-danger').text('');
+
             new bootstrap.Modal('#detailModal').show();
 
             const params = new URLSearchParams({ pageId, startDate, endDate });
             fetch('/api/cms-admin/statistics/detail?' + params)
                 .then(r => r.json())
                 .then(res => {
+                    $('#detailLoading').hide();
+
                     if (!res.success || !res.data || res.data.length === 0) {
-                        $('#detailTableBody').html('<tr><td colspan="2" class="text-center text-body-secondary">클릭 데이터가 없습니다.</td></tr>');
+                        $('#detailNoData').removeClass('d-none').text('클릭 데이터가 없습니다.');
                         return;
                     }
-                    const html = res.data.map(d => `<tr>
-                        <td class="text-monospace small">${HtmlUtils.escape(d.componentId || '')}</td>
-                        <td class="text-end">${(d.clickCount || 0).toLocaleString()}</td>
-                    </tr>`).join('');
-                    $('#detailTableBody').html(html);
+
+                    this._renderDetailChart(res.data);
                 })
                 .catch(() => {
-                    $('#detailTableBody').html('<tr><td colspan="2" class="text-center text-danger">상세 조회 실패</td></tr>');
+                    $('#detailLoading').hide();
+                    $('#detailNoData').removeClass('d-none').addClass('text-danger').text('상세 조회 실패');
                 });
+        },
+
+        /**
+         * 컴포넌트별 클릭 수를 가로형 막대 차트 + 요약 테이블로 렌더링한다.
+         * - 최대 클릭 컴포넌트: 강조색(#0d6efd), 나머지: 무채색(#adb5bd)
+         * - 막대 끝 afterDraw 플러그인으로 "클릭수 (비율%)" 레이블 표시
+         * - 레이블 길이에 따라 오른쪽 패딩을 동적 계산하여 잘림 방지
+         * - 데이터 수에 따라 캔버스 높이를 동적 설정하여 막대 간격 균일화
+         */
+        _renderDetailChart: function(data) {
+            const total = data.reduce((sum, d) => sum + (d.clickCount || 0), 0);
+            const maxClick = Math.max(...data.map(d => d.clickCount || 0));
+
+            const labels = data.map(d => d.componentId || '');
+            const values = data.map(d => d.clickCount || 0);
+            const colors = values.map(v => v === maxClick ? '#0d6efd' : '#adb5bd');
+
+            // 막대 끝 레이블 최대 너비 추정 → 오른쪽 패딩 동적 계산 (글자당 약 7px)
+            const maxLabelText = maxClick.toLocaleString() + ' (100.0%)';
+            const rightPadding = maxLabelText.length * 7 + 12;
+
+            // 데이터 수에 따라 캔버스 높이 동적 설정 (막대 1개당 40px + 상하 여백)
+            const canvasHeight = Math.max(200, data.length * 40 + 60);
+            $('#detailBarChart').css('height', canvasHeight + 'px');
+
+            // 막대 끝 레이블 — 별도 플러그인 없이 afterDraw 훅으로 직접 렌더링
+            const datalabelsPlugin = {
+                id: 'cmsStatDatalabels',
+                afterDraw(chart) {
+                    const ctx = chart.ctx;
+                    chart.data.datasets.forEach((dataset, i) => {
+                        chart.getDatasetMeta(i).data.forEach((bar, index) => {
+                            const value = dataset.data[index];
+                            const pct = total > 0 ? ((value / total) * 100).toFixed(1) : '0.0';
+                            ctx.save();
+                            ctx.font = '12px sans-serif';
+                            ctx.fillStyle = '#495057';
+                            ctx.textAlign = 'left';
+                            ctx.textBaseline = 'middle';
+                            ctx.fillText(`${value.toLocaleString()} (${pct}%)`, bar.x + 6, bar.y);
+                            ctx.restore();
+                        });
+                    });
+                }
+            };
+
+            const canvas = document.getElementById('detailBarChart');
+            $('#detailChartWrapper').removeClass('d-none');
+
+            this._detailChart = new Chart(canvas.getContext('2d'), {
+                type: 'bar',
+                plugins: [datalabelsPlugin],
+                data: {
+                    labels,
+                    datasets: [{
+                        data: values,
+                        backgroundColor: colors,
+                        borderRadius: 3,
+                        barThickness: 20,
+                    }]
+                },
+                options: {
+                    indexAxis: 'y',
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: {
+                        legend: { display: false },
+                        tooltip: {
+                            callbacks: {
+                                label: ctx => {
+                                    const pct = total > 0 ? ((ctx.parsed.x / total) * 100).toFixed(1) : '0.0';
+                                    return ` ${ctx.parsed.x.toLocaleString()} (${pct}%)`;
+                                }
+                            }
+                        }
+                    },
+                    scales: {
+                        x: {
+                            beginAtZero: true,
+                            grid: { color: 'rgba(0,0,0,0.05)' }
+                        },
+                        y: { grid: { display: false } }
+                    },
+                    layout: { padding: { right: rightPadding } }
+                }
+            });
+
+            // 요약 테이블 렌더링
+            this._renderSummaryTable(data, total, maxClick);
+        },
+
+        /**
+         * 차트 하단 요약 테이블을 렌더링한다.
+         * - 최다 클릭 행에 강조 배지 표시
+         * - 합계 행(tfoot) 추가
+         */
+        _renderSummaryTable: function(data, total, maxClick) {
+            const rows = data.map(d => {
+                const count = d.clickCount || 0;
+                const pct = total > 0 ? ((count / total) * 100).toFixed(1) : '0.0';
+                const badge = count === maxClick
+                    ? ' <span class="badge bg-primary ms-1" style="font-size:10px;">최다</span>'
+                    : '';
+                return `<tr>
+                    <td class="text-monospace small">${HtmlUtils.escape(d.componentId || '')}${badge}</td>
+                    <td class="text-end">${count.toLocaleString()}</td>
+                    <td class="text-end text-body-secondary">${pct}%</td>
+                </tr>`;
+            }).join('');
+
+            $('#detailSummaryBody').html(rows);
+            $('#detailSummaryFoot').html(`
+                <tr>
+                    <td>합계</td>
+                    <td class="text-end">${total.toLocaleString()}</td>
+                    <td class="text-end">100.0%</td>
+                </tr>
+            `);
+            $('#detailSummaryTable').removeClass('d-none');
         },
 
         _today: function() {

--- a/admin/src/main/resources/templates/pages/cms-statistics/cms-statistics.html
+++ b/admin/src/main/resources/templates/pages/cms-statistics/cms-statistics.html
@@ -53,7 +53,7 @@
                     <p id="detailNoData" class="text-center text-body-secondary d-none mb-0 py-4"></p>
 
                     <!-- 차트 영역 — 가운데 정렬, 좌우 여백으로 레이블 잘림 방지 -->
-                    <div id="detailChartWrapper" class="d-none px-2 mb-4">
+                    <div id="detailChartWrapper" class="d-none px-2 mb-4" style="max-width: 600px;">
                         <canvas id="detailBarChart"></canvas>
                     </div>
 

--- a/admin/src/main/resources/templates/pages/cms-statistics/cms-statistics.html
+++ b/admin/src/main/resources/templates/pages/cms-statistics/cms-statistics.html
@@ -35,27 +35,41 @@
 
     <!-- ==================== 컴포넌트 클릭 상세 모달 ==================== -->
     <div class="modal fade" id="detailModal" tabindex="-1">
-        <div class="modal-dialog modal-lg">
+        <div class="modal-dialog modal-xl">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">컴포넌트 클릭 상세</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
-                <div class="modal-body">
-                    <p id="detailPageName" class="mb-2 fw-medium text-body-secondary"></p>
-                    <div class="table-responsive">
-                        <table class="table table-sm table-hover sp-data-grid">
+                <div class="modal-body px-4 py-3">
+                    <p id="detailPageName" class="mb-3 fw-medium text-body-secondary"></p>
+
+                    <!-- 로딩 스피너 -->
+                    <div id="detailLoading" class="text-center py-5 text-body-secondary">
+                        <i class="bi bi-arrow-repeat sp-spin"></i> 불러오는 중...
+                    </div>
+
+                    <!-- 데이터 없음 / 오류 메시지 (기본 숨김) -->
+                    <p id="detailNoData" class="text-center text-body-secondary d-none mb-0 py-4"></p>
+
+                    <!-- 차트 영역 — 가운데 정렬, 좌우 여백으로 레이블 잘림 방지 -->
+                    <div id="detailChartWrapper" class="d-none px-2 mb-4">
+                        <canvas id="detailBarChart"></canvas>
+                    </div>
+
+                    <!-- 요약 테이블 — 차트 하단 구분선 후 표시 -->
+                    <div id="detailSummaryTable" class="d-none">
+                        <hr class="my-3">
+                        <table class="table table-sm table-hover sp-data-grid mb-0">
                             <thead class="table-light">
                                 <tr>
                                     <th>컴포넌트 ID</th>
-                                    <th class="col-w-100 text-end">클릭 수</th>
+                                    <th class="text-end" style="width: 100px;">클릭 수</th>
+                                    <th class="text-end" style="width: 80px;">비율</th>
                                 </tr>
                             </thead>
-                            <tbody id="detailTableBody">
-                                <tr>
-                                    <td colspan="2" class="text-center text-body-secondary">불러오는 중...</td>
-                                </tr>
-                            </tbody>
+                            <tbody id="detailSummaryBody"></tbody>
+                            <tfoot id="detailSummaryFoot" class="table-light fw-semibold"></tfoot>
                         </table>
                     </div>
                 </div>
@@ -65,6 +79,9 @@
             </div>
         </div>
     </div>
+
+    <!-- Chart.js — CMS 통계 상세 모달 가로형 막대 차트용 (CDN) -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js"></script>
 
     <!-- 스크립트 -->
     <th:block th:replace="~{pages/cms-statistics/cms-statistics-script :: script}"/>

--- a/admin/src/main/resources/templates/pages/cms-statistics/cms-statistics.html
+++ b/admin/src/main/resources/templates/pages/cms-statistics/cms-statistics.html
@@ -81,7 +81,7 @@
     </div>
 
     <!-- Chart.js — CMS 통계 상세 모달 가로형 막대 차트용 (CDN) -->
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js" crossorigin="anonymous"></script>
 
     <!-- 스크립트 -->
     <th:block th:replace="~{pages/cms-statistics/cms-statistics-script :: script}"/>


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

Closes #85

## ✨ 변경 사항 (Changes)

### CMS 통계 컴포넌트 클릭 상세 모달 — 가로형 막대 차트 시각화

기존 단순 2컬럼 테이블(`componentId` / `clickCount`)을 Chart.js 가로형 막대 차트 + 요약 테이블로 교체

**`cms-statistics.html`**
- 모달 크기: `modal-lg` → `modal-xl`
- 기존 `<table>` 제거, 아래 구조로 교체:
  - `#detailLoading`: 로딩 스피너 (API 호출 중 표시)
  - `#detailChartWrapper > canvas#detailBarChart`: 차트 영역 (`d-none` → 데이터 수신 후 표시)
  - `#detailSummaryTable`: 요약 테이블 — `#detailSummaryBody` + `#detailSummaryFoot` (합계 행)
- Chart.js 4.4.2 CDN 스크립트 추가 (WebJar 사내 레포 미등록 대응)

**`cms-statistics-script.html`**
- `_detailChart` 상태 변수 추가 — 모달 재오픈 시 `destroy()` 후 재생성 (캔버스 재사용 오류 방지)
- `openDetailModal()`: 로딩 초기화 → 차트·테이블 `d-none` 처리 → 모달 열기 순서 정립
- `_renderDetailChart()` 신규:
  - Y축: `componentId`, X축: `clickCount`
  - 최다 클릭 컴포넌트 강조색(`#0d6efd`), 나머지 무채색(`#adb5bd`)
  - `afterDraw` 플러그인으로 막대 끝에 `"42 (35.3%)"` 레이블 렌더링
  - 데이터 수에 따라 캔버스 높이 동적 계산 (`data.length * 40 + 60`), 레이블 잘림 방지를 위한 우측 패딩 동적 계산
- `_renderSummaryTable()` 신규:
  - 최다 클릭 행에 `최다` 배지 표시
  - 합계 행(`tfoot`) 및 비율(%) 컬럼 추가

**`pom.xml`**
- Chart.js WebJar 의존성 주석으로 추가 (사내 레포 등록 시 CDN → WebJar 전환 가이드)

## ⚠️ 고려 및 주의 사항 (선택)

- Chart.js를 CDN(`cdn.jsdelivr.net`)으로 로드하므로 네트워크 단절 환경에서는 차트가 표시되지 않습니다. 사내 Maven 레포에 `org.webjars.npm:chart.js:4.4.2` 등록 후 `pom.xml` 주석 해제로 전환 가능합니다.

## 💬 리뷰 포인트 (선택)

- `afterDraw` 인라인 플러그인 — Chart.js 공식 `chartjs-plugin-datalabels` 대신 별도 라이브러리 없이 직접 구현했습니다.
- 우측 패딩 계산식(`maxLabelText.length * 7 + 12`)이 폰트 크기 변경 시 레이블 잘림이 발생할 수 있습니다.