### PR TITLE
fix: CMS 배포 미리보기 포트 변경(3001→8080) 및 asset deploy x-deploy-token 헤더 추가

### DIFF
--- a/admin/.env.example
+++ b/admin/.env.example
@@ -56,7 +56,7 @@ CMS_PREVIEW_URL=http://133.186.135.23
 # === CMS Deploy ===
 CMS_APP_BASE_URL=http://localhost:3000/cms
 # CMS push API URL — HTML 조립·파일 저장·이력 기록을 CMS가 담당
-CMS_DEPLOY_PUSH_URL=http://133.186.135.23:3001/api/deploy/push
+CMS_DEPLOY_PUSH_URL=http://133.186.135.23/cms/api/deploy/push
 CMS_DEPLOY_SECRET=your-deploy-secret-token
 
 # === React Approval (React 코드 승인 — 파일 저장 경로) ===

--- a/admin/docs/sql/oracle/03_insert_initial_data.sql
+++ b/admin/docs/sql/oracle/03_insert_initial_data.sql
@@ -687,9 +687,9 @@ INSERT INTO FWK_CMS_SERVER_INSTANCE (
 ) VALUES (
     'prod-operation-01',
     '운영 서버',
-    '운영 배포 서버 (133.186.135.23:3001)',
+    '운영 배포 서버 (133.186.135.23:8080)',
     '133.186.135.23',
-    3001,
+    8080,
     'WEB',
     'Y',
     'system'

--- a/admin/docs/sql/oracle/04_alter_tables.sql
+++ b/admin/docs/sql/oracle/04_alter_tables.sql
@@ -102,5 +102,20 @@ ALTER TABLE SPW_CMS_PAGE ADD (
 ALTER TABLE SPW_CMS_PAGE ADD CONSTRAINT CHK_SPW_PAGE_TYPE
     CHECK (PAGE_TYPE IN ('PAGE', 'TEMPLATE', 'REACT'));
 
+-- =============================================================
+-- CMS 배포 서버 인스턴스 포트 변경: 3001(Next.js 직접) → 8080(nginx)
+-- =============================================================
+-- 생성일: 2026-04-22
+-- ※ 아래 쿼리는 개발자가 DB에서 직접 실행해야 합니다.
+-- =============================================================
+
+-- 미리보기 URL이 http://{ip}:{INSTANCE_PORT}/cms/deployed/{pageId}.html 형태로 구성되므로
+-- INSTANCE_PORT를 8080으로 변경해야 nginx를 통해 정적 파일에 접근할 수 있다.
+UPDATE FWK_CMS_SERVER_INSTANCE
+SET INSTANCE_PORT = 8080,
+    INSTANCE_DESC = '운영 배포 서버 (133.186.135.23:8080)'
+WHERE INSTANCE_ID = 'prod-operation-01';
+
+COMMIT;
 
 COMMIT;

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/config/CmsBuilderConfig.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/config/CmsBuilderConfig.java
@@ -32,10 +32,14 @@ public class CmsBuilderConfig {
      *
      * <p>파일 이동은 CMS 내부 I/O 라 수 초 내 완료되어야 하므로 업로드용(60초) 보다 훨씬 짧은
      * read-timeout 을 적용한다. 지연 시 Admin 의 HTTP 스레드와 사용자 UI 가 오래 묶이는 것을 방지.
+     * CMS deploy 엔드포인트는 x-deploy-token 헤더 인증을 요구하므로 defaultHeader 로 고정 주입한다.
      */
     @Bean
     public RestClient cmsBuilderDeployRestClient() {
-        return buildClient(properties.getDeployConnectTimeoutSeconds(), properties.getDeployReadTimeoutSeconds());
+        return buildClient(properties.getDeployConnectTimeoutSeconds(), properties.getDeployReadTimeoutSeconds())
+                .mutate()
+                .defaultHeader("x-deploy-token", properties.getDeploySecret())
+                .build();
     }
 
     /** baseUrl 공유 + 타임아웃만 다르게 RestClient 를 생성. */

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/config/CmsBuilderProperties.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/config/CmsBuilderProperties.java
@@ -39,4 +39,7 @@ public class CmsBuilderProperties {
      * Admin HTTP 스레드·사용자 UI 대기 시간을 과다하게 잡기 때문에 짧게 둔다 (Issue #55, Gemini 리뷰 반영).
      */
     private int deployReadTimeoutSeconds = 10;
+
+    /** x-deploy-token 헤더값. 페이지 배포(cms.deploy.secret)와 동일한 CMS DEPLOY_SECRET 을 공유한다. */
+    private String deploySecret;
 }

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -127,6 +127,8 @@ cms:
     # 배포(deploy) 전용 — 파일 이동은 CMS 내부 I/O 라 수초 내 완료 기대, 짧게 둔다 (#55)
     deploy-connect-timeout-seconds: ${CMS_BUILDER_DEPLOY_CONNECT_TIMEOUT:5}
     deploy-read-timeout-seconds: ${CMS_BUILDER_DEPLOY_READ_TIMEOUT:10}
+    # CMS /cms/api/assets/{id}/deploy 엔드포인트 인증 토큰 — 페이지 배포와 동일한 CMS DEPLOY_SECRET 사용
+    deploy-secret: ${CMS_DEPLOY_SECRET:}
 
 # Scheduling Configuration (배치 이력 정리 스케줄러)
 scheduling:

--- a/admin/src/test/java/com/example/admin_demo/domain/cmsdeployment/controller/CmsDeployControllerTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/cmsdeployment/controller/CmsDeployControllerTest.java
@@ -217,7 +217,7 @@ class CmsDeployControllerTest {
                 .pageId(PAGE_ID)
                 .pageName("테스트 페이지")
                 .createUserName("홍길동")
-                .deployedUrl("http://133.186.135.23:3001/cms/deployed/" + PAGE_ID + ".html")
+                .deployedUrl("http://133.186.135.23:8080/cms/deployed/" + PAGE_ID + ".html")
                 .build();
     }
 
@@ -226,7 +226,7 @@ class CmsDeployControllerTest {
                 .instanceId("INST-001")
                 .instanceName("배포서버-1")
                 .instanceIp("133.186.135.23")
-                .instancePort("3001")
+                .instancePort("8080")
                 .fileId(PAGE_ID + "_v1.html")
                 .fileSize(1024L)
                 .fileCrcValue("abc123def456abcd")

--- a/admin/src/test/java/com/example/admin_demo/domain/cmsdeployment/service/CmsDeployServiceTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/cmsdeployment/service/CmsDeployServiceTest.java
@@ -177,7 +177,7 @@ class CmsDeployServiceTest {
                 .pageId(PAGE_ID)
                 .pageName("테스트 페이지")
                 .createUserName("홍길동")
-                .deployedUrl("http://133.186.135.23:3001/cms/deployed/" + PAGE_ID + ".html")
+                .deployedUrl("http://133.186.135.23:8080/cms/deployed/" + PAGE_ID + ".html")
                 .build();
     }
 
@@ -186,7 +186,7 @@ class CmsDeployServiceTest {
                 .instanceId("INST-001")
                 .instanceName("배포서버-1")
                 .instanceIp("133.186.135.23")
-                .instancePort("3001")
+                .instancePort("8080")
                 .fileId(PAGE_ID + "_v1.html")
                 .fileSize(1024L)
                 .fileCrcValue("abc123def456abcd")


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #152

## ✨ 변경 사항 (Changes)

### 1. CMS 배포 미리보기 URL 포트 3001 → 8080 변경
- 미리보기 URL의 포트가 DB `FWK_CMS_SERVER_INSTANCE.INSTANCE_PORT`에서 오므로 SQL로 수정
- `docs/sql/oracle/04_alter_tables.sql` — 기존 DB 대상 UPDATE 쿼리 추가 (**개발자가 DB에서 직접 실행 필요**)
- `docs/sql/oracle/03_insert_initial_data.sql` — 신규 설치용 INSERT 포트 수정
- 테스트 픽스처 `deployedUrl`, `instancePort` 3001 → 8080 수정

### 2. `CmsBuilderClient.deployAsset()` x-deploy-token 헤더 추가
- `CmsBuilderProperties`에 `deploySecret` 필드 추가
- `application.yml` `cms.builder.deploy-secret: ${CMS_DEPLOY_SECRET:}` 추가 (기존 환경변수 재사용)
- `CmsBuilderConfig.cmsBuilderDeployRestClient()`에 `.mutate().defaultHeader("x-deploy-token", ...)` 추가

## ⚠️ 고려 및 주의 사항 (선택)
- 포트 변경은 `04_alter_tables.sql` 하단 UPDATE 쿼리를 **직접 DB에서 실행**해야 반영됩니다.

## 💬 리뷰 포인트 (선택)
- `deploySecret`은 페이지 배포(`cms.deploy.secret`)와 동일한 `CMS_DEPLOY_SECRET` 환경변수를 공유합니다. 추후 분리가 필요하다면 별도 환경변수로 관리 가능합니다.