### PR TITLE
feat: CMS 배포 관리 — 노출기간 컬럼 및 만료수동처리 기능 추가 (#147)

### DIFF
--- a/admin/docs/sql/oracle/04_alter_tables.sql
+++ b/admin/docs/sql/oracle/04_alter_tables.sql
@@ -118,4 +118,16 @@ WHERE INSTANCE_ID = 'prod-operation-01';
 
 COMMIT;
 
+-- =============================================================
+-- #147 CMS 배포 관리 — 만료수동처리 기능 추가
+-- ⚠ 개발자가 DB에서 직접 실행해야 합니다.
+-- =============================================================
+
+-- SPW_CMS_PAGE.BEGINNING_DATE / EXPIRED_DATE / IS_PUBLIC / FILE_PATH_BACK 컬럼은
+-- 01_create_tables.sql 에 이미 정의되어 있으므로 별도 ALTER 불필요.
+-- FWK_CMS_FILE_SEND_HIS 의 만료 전용 이력 조회 예시 (운영 확인용):
+--   SELECT * FROM FWK_CMS_FILE_SEND_HIS
+--   WHERE FILE_ID LIKE '%_expired.html'
+--   ORDER BY LAST_MODIFIED_DTIME DESC;
+
 COMMIT;

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsdeployment/config/CmsDeployProperties.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsdeployment/config/CmsDeployProperties.java
@@ -33,4 +33,11 @@ public class CmsDeployProperties {
      * 운영 환경에 따라 경로가 다를 경우 변경
      */
     private String deployedPathPrefix = "/deployed";
+
+    /**
+     * 만료 배포 시 전송할 page-expired.html URL
+     * CMS Next.js 서버의 public/system/page-expired.html을 HTTP로 읽어온다.
+     * Admin 내부에 파일을 복사하지 않아 단일 소스를 유지한다.
+     */
+    private String expiredHtmlUrl;
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsdeployment/controller/CmsDeployController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsdeployment/controller/CmsDeployController.java
@@ -28,9 +28,10 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * <h4>API 엔드포인트:</h4>
  * <ul>
- *   <li>GET  /api/cms-admin/deployments/pages  — 배포 대상 페이지 목록 (APPROVED)</li>
- *   <li>GET  /api/cms-admin/deployments        — 배포 이력 조회 (모달용)</li>
- *   <li>POST /api/cms-admin/deployments/push   — 배포 실행</li>
+ *   <li>GET  /api/cms-admin/deployments/pages         — 배포 대상 페이지 목록 (APPROVED)</li>
+ *   <li>GET  /api/cms-admin/deployments               — 배포 이력 조회 (모달용)</li>
+ *   <li>POST /api/cms-admin/deployments/push          — 배포 실행</li>
+ *   <li>POST /api/cms-admin/deployments/push-expired  — 만료수동처리 배포</li>
  * </ul>
  */
 @Slf4j
@@ -76,5 +77,15 @@ public class CmsDeployController {
 
         cmsDeployService.push(req.getPageId(), userDetails.getUserId());
         return ResponseEntity.ok(ApiResponse.success("배포가 완료되었습니다.", null));
+    }
+
+    /** 만료수동처리 배포 — EXPIRED_DATE 경과 페이지에 page-expired.html 전송 (CMS:W) */
+    @PostMapping("/api/cms-admin/deployments/push-expired")
+    @PreAuthorize("hasAuthority('CMS:W')")
+    public ResponseEntity<ApiResponse<Void>> pushExpired(
+            @Valid @RequestBody CmsDeployPushRequest req, @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        cmsDeployService.pushExpired(req.getPageId(), userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.success("만료 배포가 완료되었습니다.", null));
     }
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsdeployment/dto/CmsDeployPageResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsdeployment/dto/CmsDeployPageResponse.java
@@ -27,4 +27,19 @@ public class CmsDeployPageResponse {
 
     /** 최근 배포된 파일 URL (배포 이력 없으면 null) */
     private String deployedUrl;
+
+    /** 노출 시작일 (yyyy-MM-dd, null 가능) */
+    private String beginningDate;
+
+    /** 노출 종료일 (yyyy-MM-dd, null 가능) */
+    private String expiredDate;
+
+    /**
+     * 만료 여부 — "Y": EXPIRED_DATE &lt; SYSDATE AND IS_PUBLIC='Y', 그 외 "N"
+     * 만료수동처리 버튼 표시 조건으로 사용
+     */
+    private String isExpired;
+
+    /** 공개 여부 — "Y"/"N" (SPW_CMS_PAGE.IS_PUBLIC) */
+    private String isPublic;
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsdeployment/dto/CmsServerInstanceResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsdeployment/dto/CmsServerInstanceResponse.java
@@ -1,0 +1,28 @@
+package com.example.admin_demo.domain.cmsdeployment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * CMS 배포 서버 인스턴스 응답 DTO (FWK_CMS_SERVER_INSTANCE, ALIVE_YN='Y' 조회 결과)
+ *
+ * <p>만료수동처리 배포 시 순차 전송 대상 서버 목록을 담는다.
+ * URL 조합: {@code http://{instanceIp}:{instancePort}/cms/api/deploy/receive}</p>
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CmsServerInstanceResponse {
+
+    /** 서버 인스턴스 ID */
+    private String instanceId;
+
+    /** 서버 IP */
+    private String instanceIp;
+
+    /** 서버 포트 */
+    private String instancePort;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsdeployment/mapper/CmsDeployMapper.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsdeployment/mapper/CmsDeployMapper.java
@@ -4,6 +4,7 @@ import com.example.admin_demo.domain.cmsdeployment.dto.CmsDeployHistoryRequest;
 import com.example.admin_demo.domain.cmsdeployment.dto.CmsDeployHistoryResponse;
 import com.example.admin_demo.domain.cmsdeployment.dto.CmsDeployPageRequest;
 import com.example.admin_demo.domain.cmsdeployment.dto.CmsDeployPageResponse;
+import com.example.admin_demo.domain.cmsdeployment.dto.CmsServerInstanceResponse;
 import java.util.List;
 import org.apache.ibatis.annotations.Param;
 
@@ -32,4 +33,40 @@ public interface CmsDeployMapper {
      * 페이지 미존재 시 null 반환.
      */
     String findApprovedPageHtml(@Param("pageId") String pageId);
+
+    // ── 만료수동처리 ────────────────────────────────────────────────────────
+
+    /**
+     * 만료 처리 대상 검증 및 FILE_PATH 반환.
+     * 조건: EXPIRED_DATE &lt; SYSDATE AND IS_PUBLIC='Y' AND USE_YN='Y'
+     * 조건 미충족 시 null 반환 → 서비스에서 NotFoundException 처리.
+     */
+    String findExpirableFilePath(@Param("pageId") String pageId);
+
+    /**
+     * pageId에 대한 최신 배포 FILE_ID 반환 (예: PAGE001_v3.html).
+     * 만료 FILE_ID 조합 시 버전 추출 용도.
+     * 이력 없으면 null 반환.
+     */
+    String findLatestDeployedFileId(@Param("pageId") String pageId);
+
+    /** ALIVE_YN='Y' 서버 인스턴스 목록 조회 — 만료 배포 전송 대상 */
+    List<CmsServerInstanceResponse> findAliveServerInstances();
+
+    /**
+     * FWK_CMS_FILE_SEND_HIS UPSERT (MERGE ON INSTANCE_ID + FILE_ID).
+     * MATCHED → UPDATE, NOT MATCHED → INSERT
+     */
+    void upsertFileSendHis(
+            @Param("instanceId") String instanceId,
+            @Param("fileId") String fileId,
+            @Param("fileSize") long fileSize,
+            @Param("crcValue") String crcValue,
+            @Param("userId") String userId);
+
+    /**
+     * 만료 처리 완료 후 페이지 상태 업데이트.
+     * IS_PUBLIC='N', FILE_PATH_BACK=FILE_PATH, LAST_MODIFIER_ID=userId
+     */
+    void expirePage(@Param("pageId") String pageId, @Param("userId") String userId);
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsdeployment/service/CmsDeployService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsdeployment/service/CmsDeployService.java
@@ -5,6 +5,7 @@ import com.example.admin_demo.domain.cmsdeployment.dto.CmsDeployHistoryRequest;
 import com.example.admin_demo.domain.cmsdeployment.dto.CmsDeployHistoryResponse;
 import com.example.admin_demo.domain.cmsdeployment.dto.CmsDeployPageRequest;
 import com.example.admin_demo.domain.cmsdeployment.dto.CmsDeployPageResponse;
+import com.example.admin_demo.domain.cmsdeployment.dto.CmsServerInstanceResponse;
 import com.example.admin_demo.domain.cmsdeployment.mapper.CmsDeployMapper;
 import com.example.admin_demo.global.dto.PageRequest;
 import com.example.admin_demo.global.dto.PageResponse;
@@ -68,6 +69,110 @@ public class CmsDeployService {
         // HTML 조립·파일 저장·이력 기록은 CMS push API가 담당
         callCmsPush(pageId, userId);
         log.info("CMS 배포 요청 완료: pageId={}, userId={}", pageId, userId);
+    }
+
+    /**
+     * 만료수동처리 배포.
+     *
+     * <p>CMS 서버에서 page-expired.html을 읽어와 ALIVE_YN='Y' 인 모든 서버에 순차 전송한다.
+     * 전송 성공 후 FWK_CMS_FILE_SEND_HIS에 이력을 기록하고 IS_PUBLIC='N' 으로 상태를 변경한다.</p>
+     *
+     * <p>만료 FILE_ID 패턴: {pageId}_v{version}_expired.html
+     * — 정상 배포 이력({pageId}_v{n}.html)을 덮어쓰지 않도록 별도 키 사용</p>
+     */
+    @Transactional
+    public void pushExpired(String pageId, String userId) {
+        // 1. 만료 처리 대상 검증 (EXPIRED_DATE < SYSDATE AND IS_PUBLIC='Y' AND USE_YN='Y')
+        String filePath = cmsDeployMapper.findExpirableFilePath(pageId);
+        if (filePath == null) {
+            throw new NotFoundException("만료 처리 대상이 아닙니다. pageId=" + pageId);
+        }
+
+        // 2. 최신 배포 FILE_ID에서 버전 추출 → 만료 전용 FILE_ID 조합
+        //    예: PAGE001_v3.html → PAGE001_v3_expired.html
+        //    이력 없으면 v0 폴백 사용
+        String latestFileId = cmsDeployMapper.findLatestDeployedFileId(pageId);
+        String expiredFileId;
+        if (latestFileId != null && latestFileId.endsWith(".html")) {
+            expiredFileId = latestFileId.replace(".html", "_expired.html");
+        } else {
+            expiredFileId = pageId + "_v0_expired.html";
+        }
+
+        // 3. CMS 서버에서 page-expired.html 취득
+        String expiredHtml = fetchExpiredHtml();
+
+        // 4. ALIVE_YN='Y' 서버 목록 조회
+        List<CmsServerInstanceResponse> servers = cmsDeployMapper.findAliveServerInstances();
+        if (servers.isEmpty()) {
+            throw new InternalException("배포 가능한 서버 인스턴스가 없습니다.");
+        }
+
+        // 5. 각 서버에 순차 전송 → 성공 시 이력 UPSERT
+        for (CmsServerInstanceResponse server : servers) {
+            callReceiveApi(server, pageId, expiredHtml);
+            cmsDeployMapper.upsertFileSendHis(
+                    server.getInstanceId(),
+                    expiredFileId,
+                    expiredHtml.length(),
+                    null, // CRC 계산 불필요 — 만료 HTML은 고정 콘텐츠
+                    userId);
+        }
+
+        // 6. 페이지 상태 업데이트: IS_PUBLIC='N', FILE_PATH_BACK=FILE_PATH
+        cmsDeployMapper.expirePage(pageId, userId);
+        log.info("만료 배포 완료: pageId={}, expiredFileId={}, userId={}", pageId, expiredFileId, userId);
+    }
+
+    /** CMS 서버에서 page-expired.html을 HTTP GET으로 취득 */
+    private String fetchExpiredHtml() {
+        try {
+            ResponseEntity<String> response =
+                    restTemplate.getForEntity(deployProperties.getExpiredHtmlUrl(), String.class);
+            String body = response.getBody();
+            if (body == null || body.isBlank()) {
+                throw new InternalException("page-expired.html 응답이 비어있습니다.");
+            }
+            return body;
+        } catch (InternalException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new InternalException("page-expired.html 취득 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /** /cms/api/deploy/receive 호출 — 만료 HTML을 서버 인스턴스에 전송 */
+    private void callReceiveApi(CmsServerInstanceResponse server, String pageId, String html) {
+        String url = "http://" + server.getInstanceIp() + ":" + server.getInstancePort() + "/cms/api/deploy/receive";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("x-deploy-token", deployProperties.getSecret());
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("pageId", pageId);
+        body.put("html", html);
+
+        try {
+            ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.POST,
+                    new HttpEntity<>(body, headers),
+                    new ParameterizedTypeReference<Map<String, Object>>() {});
+
+            Map<String, Object> responseBody = response.getBody();
+            if (responseBody == null) {
+                throw new InternalException("만료 배포 서버(" + server.getInstanceId() + ")에서 빈 응답을 반환했습니다.");
+            }
+            if (!Boolean.TRUE.equals(responseBody.get("ok"))) {
+                Object error = responseBody.get("error");
+                throw new InternalException("만료 배포 서버(" + server.getInstanceId() + ") 오류: " + error);
+            }
+        } catch (InternalException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new InternalException("만료 배포 서버(" + server.getInstanceId() + ") 전송 오류: " + e.getMessage(), e);
+        }
     }
 
     /** CMS push API 호출 — x-deploy-token 서버 간 인증 사용 */

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsdeployment/service/CmsDeployService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsdeployment/service/CmsDeployService.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -24,6 +26,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
@@ -37,6 +40,15 @@ public class CmsDeployService {
     private final CmsDeployMapper cmsDeployMapper;
     private final RestTemplate restTemplate;
     private final CmsDeployProperties deployProperties;
+
+    /**
+     * 자기 자신의 프록시 참조 — self-invocation 문제 해결용.
+     * {@code this.saveExpiredResult()} 직접 호출 시 AOP 프록시가 우회돼 {@code @Transactional}이
+     * 적용되지 않으므로, {@code @Lazy}로 주입받은 프록시를 통해 호출한다.
+     */
+    @Lazy
+    @Autowired
+    private CmsDeployService self;
 
     /** 배포 대상 페이지 목록 조회 (APPROVE_STATE = 'APPROVED') */
     public PageResponse<CmsDeployPageResponse> findApprovedPageList(CmsDeployPageRequest req, PageRequest pageRequest) {
@@ -81,10 +93,11 @@ public class CmsDeployService {
      * <p>만료 FILE_ID 패턴: {pageId}_v{version}_expired.html
      * — 정상 배포 이력({pageId}_v{n}.html)을 덮어쓰지 않도록 별도 키 사용</p>
      *
-     * <p>@Transactional 미적용 — 외부 HTTP 통신(fetchExpiredHtml, callReceiveApi)을 트랜잭션 밖에서
-     * 수행해 DB 커넥션 장시간 점유를 방지한다. DB 쓰기(upsertFileSendHis, expirePage)는
-     * saveExpiredResult()에서 별도 트랜잭션으로 처리한다.</p>
+     * <p>클래스 레벨 {@code readOnly=true} 트랜잭션을 중단(NOT_SUPPORTED)하고 비트랜잭션 상태로
+     * HTTP 통신을 수행한다. DB 쓰기는 {@code self.saveExpiredResult()}를 프록시로 호출해
+     * 별도 쓰기 트랜잭션을 시작한다 (self-invocation 우회).</p>
      */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void pushExpired(String pageId, String userId) {
         // 1. 만료 처리 대상 검증 (EXPIRED_DATE < SYSDATE AND IS_PUBLIC='Y' AND USE_YN='Y')
         String result = cmsDeployMapper.findExpirableFilePath(pageId);
@@ -119,8 +132,8 @@ public class CmsDeployService {
             callReceiveApi(server, pageId, expiredHtml);
         }
 
-        // 6. 전송 완료 후 DB 반영 — 별도 트랜잭션으로 커넥션 점유 최소화
-        saveExpiredResult(pageId, expiredFileId, htmlByteSize, userId);
+        // 6. 전송 완료 후 DB 반영 — self 프록시를 통해 쓰기 트랜잭션 시작 (self-invocation 우회)
+        self.saveExpiredResult(pageId, expiredFileId, htmlByteSize, userId);
         log.info("만료 배포 완료: pageId={}, expiredFileId={}, userId={}", pageId, expiredFileId, userId);
     }
 

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsdeployment/service/CmsDeployService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsdeployment/service/CmsDeployService.java
@@ -149,7 +149,7 @@ public class CmsDeployService {
                     server.getInstanceId(),
                     expiredFileId,
                     htmlByteSize,
-                    null, // CRC 계산 불필요 — 만료 HTML은 고정 콘텐츠
+                    ".", // 만료 HTML은 CRC 계산 불필요 — NOT NULL 제약 대응 플레이스홀더
                     userId);
         }
         // IS_PUBLIC='N', FILE_PATH_BACK=FILE_PATH

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsdeployment/service/CmsDeployService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsdeployment/service/CmsDeployService.java
@@ -11,6 +11,7 @@ import com.example.admin_demo.global.dto.PageRequest;
 import com.example.admin_demo.global.dto.PageResponse;
 import com.example.admin_demo.global.exception.InternalException;
 import com.example.admin_demo.global.exception.NotFoundException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -79,12 +80,15 @@ public class CmsDeployService {
      *
      * <p>만료 FILE_ID 패턴: {pageId}_v{version}_expired.html
      * — 정상 배포 이력({pageId}_v{n}.html)을 덮어쓰지 않도록 별도 키 사용</p>
+     *
+     * <p>@Transactional 미적용 — 외부 HTTP 통신(fetchExpiredHtml, callReceiveApi)을 트랜잭션 밖에서
+     * 수행해 DB 커넥션 장시간 점유를 방지한다. DB 쓰기(upsertFileSendHis, expirePage)는
+     * saveExpiredResult()에서 별도 트랜잭션으로 처리한다.</p>
      */
-    @Transactional
     public void pushExpired(String pageId, String userId) {
         // 1. 만료 처리 대상 검증 (EXPIRED_DATE < SYSDATE AND IS_PUBLIC='Y' AND USE_YN='Y')
-        String filePath = cmsDeployMapper.findExpirableFilePath(pageId);
-        if (filePath == null) {
+        String result = cmsDeployMapper.findExpirableFilePath(pageId);
+        if (result == null) {
             throw new NotFoundException("만료 처리 대상이 아닙니다. pageId=" + pageId);
         }
 
@@ -99,8 +103,10 @@ public class CmsDeployService {
             expiredFileId = pageId + "_v0_expired.html";
         }
 
-        // 3. CMS 서버에서 page-expired.html 취득
+        // 3. CMS 서버에서 page-expired.html 취득 (트랜잭션 외부 — HTTP 통신)
         String expiredHtml = fetchExpiredHtml();
+        // UTF-8 바이트 길이로 실제 파일 크기 계산 (멀티바이트 문자 포함 HTML 대비)
+        long htmlByteSize = expiredHtml.getBytes(StandardCharsets.UTF_8).length;
 
         // 4. ALIVE_YN='Y' 서버 목록 조회
         List<CmsServerInstanceResponse> servers = cmsDeployMapper.findAliveServerInstances();
@@ -108,20 +114,33 @@ public class CmsDeployService {
             throw new InternalException("배포 가능한 서버 인스턴스가 없습니다.");
         }
 
-        // 5. 각 서버에 순차 전송 → 성공 시 이력 UPSERT
+        // 5. 각 서버에 순차 전송 (트랜잭션 외부 — HTTP 통신)
         for (CmsServerInstanceResponse server : servers) {
             callReceiveApi(server, pageId, expiredHtml);
+        }
+
+        // 6. 전송 완료 후 DB 반영 — 별도 트랜잭션으로 커넥션 점유 최소화
+        saveExpiredResult(pageId, expiredFileId, htmlByteSize, userId);
+        log.info("만료 배포 완료: pageId={}, expiredFileId={}, userId={}", pageId, expiredFileId, userId);
+    }
+
+    /**
+     * 만료 배포 완료 후 DB 반영 — 이력 UPSERT + 페이지 상태 업데이트.
+     * HTTP 통신과 분리하여 DB 커넥션 점유를 최소화한다.
+     */
+    @Transactional
+    public void saveExpiredResult(String pageId, String expiredFileId, long htmlByteSize, String userId) {
+        List<CmsServerInstanceResponse> servers = cmsDeployMapper.findAliveServerInstances();
+        for (CmsServerInstanceResponse server : servers) {
             cmsDeployMapper.upsertFileSendHis(
                     server.getInstanceId(),
                     expiredFileId,
-                    expiredHtml.length(),
+                    htmlByteSize,
                     null, // CRC 계산 불필요 — 만료 HTML은 고정 콘텐츠
                     userId);
         }
-
-        // 6. 페이지 상태 업데이트: IS_PUBLIC='N', FILE_PATH_BACK=FILE_PATH
+        // IS_PUBLIC='N', FILE_PATH_BACK=FILE_PATH
         cmsDeployMapper.expirePage(pageId, userId);
-        log.info("만료 배포 완료: pageId={}, expiredFileId={}, userId={}", pageId, expiredFileId, userId);
     }
 
     /** CMS 서버에서 page-expired.html을 HTTP GET으로 취득 */

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -117,6 +117,8 @@ cms:
     # 배포 파일 URL 구성용 — 운영 환경에 따라 HTTPS 프로토콜 또는 다른 경로를 사용할 경우 변경
     deployed-protocol: ${CMS_DEPLOYED_PROTOCOL:http}
     deployed-path-prefix: ${CMS_DEPLOYED_PATH_PREFIX:/deployed}
+    # 만료 배포용 HTML — CMS Next.js public/system/page-expired.html HTTP 직접 취득
+    expired-html-url: ${CMS_DEPLOY_EXPIRED_HTML_URL:http://133.186.135.23:3001/system/page-expired.html}
   # CMS Builder (미승인 이미지 업로드) — 내부망 서버-투-서버 호출 (Issue #65)
   # nginx 가 80 → CMS(Next.js) 업스트림으로 프록시하므로 외부에서는 포트 없이 접근한다.
   builder:

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -118,7 +118,7 @@ cms:
     deployed-protocol: ${CMS_DEPLOYED_PROTOCOL:http}
     deployed-path-prefix: ${CMS_DEPLOYED_PATH_PREFIX:/deployed}
     # 만료 배포용 HTML — CMS Next.js public/system/page-expired.html HTTP 직접 취득
-    expired-html-url: ${CMS_DEPLOY_EXPIRED_HTML_URL:http://133.186.135.23:3001/system/page-expired.html}
+    expired-html-url: ${CMS_DEPLOY_EXPIRED_HTML_URL:http://133.186.135.23:3001/cms/system/page-expired.html}
   # CMS Builder (미승인 이미지 업로드) — 내부망 서버-투-서버 호출 (Issue #65)
   # nginx 가 80 → CMS(Next.js) 업스트림으로 프록시하므로 외부에서는 포트 없이 접근한다.
   builder:

--- a/admin/src/main/resources/mapper/oracle/cmsdeployment/CmsDeployMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/cmsdeployment/CmsDeployMapper.xml
@@ -194,12 +194,12 @@
         WHEN MATCHED THEN
             UPDATE SET
                 FILE_SIZE           = #{fileSize},
-                FILE_CRC_VALUE      = #{crcValue, jdbcType=VARCHAR},
+                FILE_CRC_VALUE      = #{crcValue},
                 LAST_MODIFIED_DTIME = TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'),
                 LAST_MODIFIER_ID    = #{userId}
         WHEN NOT MATCHED THEN
             INSERT (INSTANCE_ID, FILE_ID, FILE_SIZE, FILE_CRC_VALUE, LAST_MODIFIED_DTIME, LAST_MODIFIER_ID)
-            VALUES (#{instanceId}, #{fileId}, #{fileSize}, #{crcValue, jdbcType=VARCHAR}, TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), #{userId})
+            VALUES (#{instanceId}, #{fileId}, #{fileSize}, #{crcValue}, TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), #{userId})
     </insert>
 
     <!--

--- a/admin/src/main/resources/mapper/oracle/cmsdeployment/CmsDeployMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/cmsdeployment/CmsDeployMapper.xml
@@ -194,12 +194,12 @@
         WHEN MATCHED THEN
             UPDATE SET
                 FILE_SIZE           = #{fileSize},
-                FILE_CRC_VALUE      = #{crcValue},
+                FILE_CRC_VALUE      = #{crcValue, jdbcType=VARCHAR},
                 LAST_MODIFIED_DTIME = TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'),
                 LAST_MODIFIER_ID    = #{userId}
         WHEN NOT MATCHED THEN
             INSERT (INSTANCE_ID, FILE_ID, FILE_SIZE, FILE_CRC_VALUE, LAST_MODIFIED_DTIME, LAST_MODIFIER_ID)
-            VALUES (#{instanceId}, #{fileId}, #{fileSize}, #{crcValue}, TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), #{userId})
+            VALUES (#{instanceId}, #{fileId}, #{fileSize}, #{crcValue, jdbcType=VARCHAR}, TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), #{userId})
     </insert>
 
     <!--

--- a/admin/src/main/resources/mapper/oracle/cmsdeployment/CmsDeployMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/cmsdeployment/CmsDeployMapper.xml
@@ -159,8 +159,8 @@
         FROM (
             SELECT FILE_ID
             FROM FWK_CMS_FILE_SEND_HIS
-            WHERE FILE_ID LIKE #{pageId} || '_v%.html'
-              AND FILE_ID NOT LIKE '%_expired.html'
+            WHERE FILE_ID LIKE #{pageId} || '\_v%.html' ESCAPE '\'
+              AND FILE_ID NOT LIKE '%\_expired.html' ESCAPE '\'
             ORDER BY LAST_MODIFIED_DTIME DESC
         )
         WHERE ROWNUM = 1

--- a/admin/src/main/resources/mapper/oracle/cmsdeployment/CmsDeployMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/cmsdeployment/CmsDeployMapper.xml
@@ -37,7 +37,16 @@
                     CASE WHEN lh.FILE_ID IS NOT NULL
                         THEN 'http://' || si.INSTANCE_IP || ':' || TO_CHAR(si.INSTANCE_PORT)
                              || '/cms/deployed/' || p.PAGE_ID || '.html'
-                    END                                                         AS deployedUrl
+                    END                                                         AS deployedUrl,
+                    TO_CHAR(p.BEGINNING_DATE, 'YYYY-MM-DD')                    AS beginningDate,
+                    TO_CHAR(p.EXPIRED_DATE,   'YYYY-MM-DD')                    AS expiredDate,
+                    p.IS_PUBLIC                                                 AS isPublic,
+                    <!-- 만료 여부: 종료일 경과 AND 현재 공개 중인 페이지만 "Y" -->
+                    CASE WHEN p.EXPIRED_DATE IS NOT NULL
+                              AND p.EXPIRED_DATE <![CDATA[<]]> SYSDATE
+                              AND p.IS_PUBLIC = 'Y'
+                         THEN 'Y' ELSE 'N'
+                    END                                                         AS isExpired
                 FROM SPW_CMS_PAGE p
                 LEFT JOIN (
                     SELECT
@@ -49,7 +58,9 @@
                             ORDER BY LAST_MODIFIED_DTIME DESC
                         ) AS RN
                     FROM FWK_CMS_FILE_SEND_HIS
+                    <!-- 만료 전용 이력(_expired.html)은 제외하여 정상 배포 이력만 미리보기 URL에 반영 -->
                     WHERE FILE_ID LIKE '%_v%.html'
+                      AND FILE_ID NOT LIKE '%_expired.html'
                 ) lh ON lh.PAGE_ID = p.PAGE_ID AND lh.RN = 1
                 LEFT JOIN FWK_CMS_SERVER_INSTANCE si ON lh.INSTANCE_ID = si.INSTANCE_ID
                 <include refid="approvedPageConditions"/>
@@ -120,5 +131,88 @@
           AND PAGE_TYPE     = 'PAGE'
     </select>
 
+    <!-- ==================== 만료수동처리 ==================== -->
+
+    <!--
+        만료 처리 대상 검증 및 FILE_PATH 반환.
+        조건: EXPIRED_DATE < SYSDATE AND IS_PUBLIC='Y' AND USE_YN='Y'
+        조건 미충족 시 null 반환 → 서비스에서 NotFoundException 처리.
+    -->
+    <select id="findExpirableFilePath" resultType="string">
+        SELECT FILE_PATH
+        FROM SPW_CMS_PAGE
+        WHERE PAGE_ID      = #{pageId}
+          AND USE_YN       = 'Y'
+          AND IS_PUBLIC    = 'Y'
+          AND EXPIRED_DATE IS NOT NULL
+          AND EXPIRED_DATE <![CDATA[<]]> SYSDATE
+    </select>
+
+    <!--
+        pageId에 대한 최신 정상 배포 FILE_ID 반환 (예: PAGE001_v3.html).
+        만료 전용 이력(_expired.html)은 제외하여 정상 배포 버전만 추출.
+        이력 없으면 null 반환 → 서비스에서 v0 폴백 처리.
+    -->
+    <select id="findLatestDeployedFileId" resultType="string">
+        SELECT FILE_ID
+        FROM (
+            SELECT FILE_ID
+            FROM FWK_CMS_FILE_SEND_HIS
+            WHERE FILE_ID LIKE #{pageId} || '_v%.html'
+              AND FILE_ID NOT LIKE '%_expired.html'
+            ORDER BY LAST_MODIFIED_DTIME DESC
+        )
+        WHERE ROWNUM = 1
+    </select>
+
+    <!-- ALIVE_YN='Y' 서버 인스턴스 목록 — 만료 배포 순차 전송 대상 -->
+    <select id="findAliveServerInstances" resultType="com.example.admin_demo.domain.cmsdeployment.dto.CmsServerInstanceResponse">
+        SELECT
+            INSTANCE_ID     AS instanceId,
+            INSTANCE_IP     AS instanceIp,
+            TO_CHAR(INSTANCE_PORT) AS instancePort
+        FROM FWK_CMS_SERVER_INSTANCE
+        WHERE ALIVE_YN = 'Y'
+        ORDER BY INSTANCE_ID
+    </select>
+
+    <!--
+        FWK_CMS_FILE_SEND_HIS UPSERT (MERGE ON INSTANCE_ID + FILE_ID 복합 PK).
+        만료 전용 FILE_ID 패턴: {pageId}_v{version}_expired.html
+        — 정상 배포 이력({pageId}_v{n}.html)을 덮어쓰지 않도록 별도 키 사용 (#147)
+    -->
+    <insert id="upsertFileSendHis">
+        MERGE INTO FWK_CMS_FILE_SEND_HIS tgt
+        USING (
+            SELECT
+                #{instanceId}  AS INSTANCE_ID,
+                #{fileId}      AS FILE_ID
+            FROM DUAL
+        ) src
+        ON (tgt.INSTANCE_ID = src.INSTANCE_ID AND tgt.FILE_ID = src.FILE_ID)
+        WHEN MATCHED THEN
+            UPDATE SET
+                FILE_SIZE           = #{fileSize},
+                FILE_CRC_VALUE      = #{crcValue},
+                LAST_MODIFIED_DTIME = TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'),
+                LAST_MODIFIER_ID    = #{userId}
+        WHEN NOT MATCHED THEN
+            INSERT (INSTANCE_ID, FILE_ID, FILE_SIZE, FILE_CRC_VALUE, LAST_MODIFIED_DTIME, LAST_MODIFIER_ID)
+            VALUES (#{instanceId}, #{fileId}, #{fileSize}, #{crcValue}, TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), #{userId})
+    </insert>
+
+    <!--
+        만료 처리 완료 후 페이지 상태 업데이트.
+        FILE_PATH_BACK: 기존 배포 경로 백업 (복구 시 참조용)
+        IS_PUBLIC: 'N'으로 변경하여 만료수동처리 버튼 재노출 방지
+    -->
+    <update id="expirePage">
+        UPDATE SPW_CMS_PAGE
+        SET
+            IS_PUBLIC        = 'N',
+            FILE_PATH_BACK   = FILE_PATH,
+            LAST_MODIFIER_ID = #{userId}
+        WHERE PAGE_ID = #{pageId}
+    </update>
 
 </mapper>

--- a/admin/src/main/resources/mapper/oracle/cmsdeployment/CmsDeployMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/cmsdeployment/CmsDeployMapper.xml
@@ -134,12 +134,13 @@
     <!-- ==================== 만료수동처리 ==================== -->
 
     <!--
-        만료 처리 대상 검증 및 FILE_PATH 반환.
+        만료 처리 대상 검증.
         조건: EXPIRED_DATE < SYSDATE AND IS_PUBLIC='Y' AND USE_YN='Y'
-        조건 미충족 시 null 반환 → 서비스에서 NotFoundException 처리.
+        조건 충족 시 'Y' 반환, 미충족(row 없음) 시 null 반환 → 서비스에서 NotFoundException 처리.
+        FILE_PATH 가 NULL 인 미배포 페이지도 만료 처리 가능하므로 SELECT 'Y' 로 존재 여부만 확인한다.
     -->
     <select id="findExpirableFilePath" resultType="string">
-        SELECT FILE_PATH
+        SELECT 'Y'
         FROM SPW_CMS_PAGE
         WHERE PAGE_ID      = #{pageId}
           AND USE_YN       = 'Y'

--- a/admin/src/main/resources/templates/pages/cms-deployment/cms-deployment-script.html
+++ b/admin/src/main/resources/templates/pages/cms-deployment/cms-deployment-script.html
@@ -33,7 +33,8 @@
 
         renderTable: function(rows) {
             const $tbody = $('#deployPageTableBody');
-            const colspan = this.canWrite ? 6 : 5;
+            // canWrite: 배포·만료수동처리 2컬럼 추가 → 8컬럼 / 미권한: 6컬럼
+            const colspan = this.canWrite ? 8 : 6;
 
             if (!rows || rows.length === 0) {
                 $tbody.html(`<tr><td colspan="${colspan}" class="text-center py-4 text-body-secondary">조회된 데이터가 없습니다.</td></tr>`);
@@ -41,6 +42,21 @@
             }
 
             const html = rows.map(row => {
+                const pid          = HtmlUtils.escape(row.pageId || '');
+                const escapedName  = HtmlUtils.escape(row.pageName || '').replace(/'/g, '&#39;');
+
+                // 노출기간 셀 — 만료된 경우 종료일 빨간색 + 만료 뱃지
+                const beginStr = row.beginningDate || '-';
+                const expiredBadge = row.isExpired === 'Y'
+                    ? ' <span class="badge bg-danger ms-1" style="font-size:10px;">만료</span>'
+                    : '';
+                const endStr = row.expiredDate
+                    ? (row.isExpired === 'Y'
+                        ? `<span class="text-danger fw-semibold">${HtmlUtils.escape(row.expiredDate)}</span>${expiredBadge}`
+                        : HtmlUtils.escape(row.expiredDate))
+                    : '-';
+                const periodCell = `<td class="small">${HtmlUtils.escape(beginStr)} ~ ${endStr}</td>`;
+
                 const previewBtn = row.deployedUrl
                     ? `<a href="${HtmlUtils.escape(row.deployedUrl)}" target="_blank" rel="noopener"
                           class="btn btn-outline-info btn-xs"><i class="bi bi-box-arrow-up-right"></i> 보기</a>`
@@ -49,21 +65,35 @@
                 const deployBtn = this.canWrite
                     ? `<td class="text-center">
                            <button class="btn btn-primary btn-xs"
-                                   onclick="CmsDeployPage.confirmPush('${HtmlUtils.escape(row.pageId)}', '${HtmlUtils.escape(row.pageName || '')}')">
+                                   onclick="CmsDeployPage.confirmPush('${pid}', '${escapedName}')">
                                <i class="bi bi-send"></i> 배포
                            </button>
                        </td>`
                     : '';
 
+                // 만료수동처리 버튼 — isExpired='Y' AND isPublic='Y' 인 경우에만 표시
+                const expireBtn = this.canWrite
+                    ? `<td class="text-center">
+                           ${row.isExpired === 'Y' && row.isPublic === 'Y'
+                               ? `<button class="btn btn-outline-danger btn-xs"
+                                          onclick="CmsDeployPage.confirmExpirePush('${pid}', '${escapedName}')">
+                                      <i class="bi bi-slash-circle"></i> 만료처리
+                                  </button>`
+                               : '<span class="text-body-secondary small">-</span>'}
+                       </td>`
+                    : '';
+
                 return `<tr>
-                    <td class="small">${HtmlUtils.escape(row.pageId)}</td>
+                    <td class="small">${pid}</td>
                     <td>${HtmlUtils.escape(row.pageName || '')}</td>
                     <td>${HtmlUtils.escape(row.createUserName || '')}</td>
+                    ${periodCell}
                     <td class="text-center">${previewBtn}</td>
                     ${deployBtn}
+                    ${expireBtn}
                     <td class="text-center">
                         <button class="btn btn-outline-secondary btn-xs"
-                                onclick="CmsDeployPage.openHistoryModal('${HtmlUtils.escape(row.pageId)}', '${HtmlUtils.escape(row.pageName || '')}')">
+                                onclick="CmsDeployPage.openHistoryModal('${pid}', '${escapedName}')">
                             <i class="bi bi-clock-history"></i> 이력
                         </button>
                     </td>
@@ -149,6 +179,28 @@
                     }
                 })
                 .catch(() => Toast.error('배포 중 오류가 발생했습니다.'));
+        },
+
+        // ── 만료수동처리 배포 ──
+
+        confirmExpirePush: function(pageId, pageName) {
+            if (!confirm(`[${pageName}] 만료페이지를 배포하시겠습니까?`)) return;
+
+            fetch('/api/cms-admin/deployments/push-expired', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ pageId }),
+            })
+                .then(r => r.json())
+                .then(res => {
+                    if (res.success) {
+                        Toast.success(res.message);
+                        this.load();
+                    } else {
+                        Toast.error(res.message);
+                    }
+                })
+                .catch(() => Toast.error('만료 배포 중 오류가 발생했습니다.'));
         },
 
         // ── 배포이력 상세 모달 ──

--- a/admin/src/main/resources/templates/pages/cms-deployment/cms-deployment-table.html
+++ b/admin/src/main/resources/templates/pages/cms-deployment/cms-deployment-table.html
@@ -9,7 +9,7 @@
                 <th class="col-w-120">페이지 ID</th>
                 <th>페이지명</th>
                 <th class="col-w-100">작성자</th>
-                <th class="col-w-160">노출기간</th>
+                <th class="col-w-200">노출기간</th>
                 <th class="col-w-90">배포 미리보기</th>
                 <th class="col-w-70"
                     th:if="${userAuthorities != null && userAuthorities.contains('CMS:W')}">배포</th>

--- a/admin/src/main/resources/templates/pages/cms-deployment/cms-deployment-table.html
+++ b/admin/src/main/resources/templates/pages/cms-deployment/cms-deployment-table.html
@@ -9,7 +9,7 @@
                 <th class="col-w-120">페이지 ID</th>
                 <th>페이지명</th>
                 <th class="col-w-100">작성자</th>
-                <th class="col-w-200">노출기간</th>
+                <th class="col-w-220">노출기간</th>
                 <th class="col-w-90">배포 미리보기</th>
                 <th class="col-w-70"
                     th:if="${userAuthorities != null && userAuthorities.contains('CMS:W')}">배포</th>

--- a/admin/src/main/resources/templates/pages/cms-deployment/cms-deployment-table.html
+++ b/admin/src/main/resources/templates/pages/cms-deployment/cms-deployment-table.html
@@ -9,15 +9,24 @@
                 <th class="col-w-120">페이지 ID</th>
                 <th>페이지명</th>
                 <th class="col-w-100">작성자</th>
+                <th class="col-w-160">노출기간</th>
                 <th class="col-w-90">배포 미리보기</th>
                 <th class="col-w-70"
                     th:if="${userAuthorities != null && userAuthorities.contains('CMS:W')}">배포</th>
+                <th class="col-w-90"
+                    th:if="${userAuthorities != null && userAuthorities.contains('CMS:W')}">만료수동처리</th>
                 <th class="col-w-80">배포이력 상세</th>
             </tr>
         </thead>
         <tbody id="deployPageTableBody">
             <tr>
-                <td colspan="6" class="text-center py-4 text-body-secondary">
+                <!-- canWrite 기준 8컬럼, 미권한 6컬럼 — JS renderTable()의 colspan과 일치해야 함 -->
+                <td colspan="8" class="text-center py-4 text-body-secondary"
+                    th:if="${userAuthorities != null && userAuthorities.contains('CMS:W')}">
+                    조회 버튼을 클릭하여 데이터를 불러오세요.
+                </td>
+                <td colspan="6" class="text-center py-4 text-body-secondary"
+                    th:unless="${userAuthorities != null && userAuthorities.contains('CMS:W')}">
                     조회 버튼을 클릭하여 데이터를 불러오세요.
                 </td>
             </tr>


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

Closes #147

## ✨ 변경 사항 (Changes)

### Backend

- **`CmsServerInstanceResponse.java`** 신규 — `instanceId`, `instanceIp`, `instancePort` (만료 배포 서버 목록 DTO)
- **`CmsDeployPageResponse.java`** — `beginningDate`, `expiredDate`, `isExpired`, `isPublic` 필드 추가
- **`CmsDeployMapper.java`** — 메서드 5개 추가: `findExpirableFilePath`, `findLatestDeployedFileId`, `findAliveServerInstances`, `upsertFileSendHis`, `expirePage`
- **`CmsDeployMapper.xml`** — `findApprovedPageList` 노출기간·만료여부 컬럼 추가 + 만료수동처리 쿼리 5개 추가
  - MERGE ON `(INSTANCE_ID, FILE_ID)` 복합 PK로 UPSERT
- **`CmsDeployProperties.java`** — `expiredHtmlUrl` 필드 추가
- **`application.yml`** — `cms.deploy.expired-html-url` 설정 추가 (기본값: `http://133.186.135.23:3001/system/page-expired.html`)
- **`CmsDeployService.java`** — `pushExpired()` 추가: page-expired.html HTTP 취득 → ALIVE_YN='Y' 서버 순차 전송 → 이력 UPSERT → IS_PUBLIC='N' 업데이트
- **`CmsDeployController.java`** — `POST /api/cms-admin/deployments/push-expired` 추가 (`CMS:W`, `CmsDeployPushRequest` 재사용)

### Frontend

- **`cms-deployment-table.html`** — 노출기간·만료수동처리 컬럼 추가, colspan `6→8` / `5→6`
- **`cms-deployment-script.html`** — `renderTable()` 노출기간 셀(만료 시 빨간색 + 만료 뱃지) + 만료수동처리 셀 추가, `confirmExpirePush()` 신규 구현

### SQL

- `docs/sql/oracle/04_alter_tables.sql` — #147 참고 쿼리 주석 추가 (별도 DDL 변경 없음)

## ⚠️ 고려 및 주의 사항 (선택)

- 만료 FILE_ID 패턴: `{pageId}_v{version}_expired.html` — 정상 배포 이력(`{pageId}_v{n}.html`) 덮어쓰기 방지
- `/cms/api/deploy/receive` body: `{ pageId, html }` / header: `x-deploy-token`
- `page-expired.html`은 CMS Next.js 서버에서 HTTP로 직접 읽어와 단일 소스 유지

## 💬 리뷰 포인트 (선택)

- `pushExpired()`에서 여러 서버 전송 중 중간 서버 실패 시 트랜잭션 롤백 여부 확인 필요 (현재 전체 롤백)