### PR TITLE
[FEATURE #158]: CMS 이미지 승인요청·승인관리 썸네일·미리보기 이미지 연동

### DIFF
--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
@@ -10,6 +10,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -146,6 +147,29 @@ public class CmsBuilderClient {
      * @param assetId 배포 대상 자산 식별자
      * @throws BaseException 배포 실패 시 (HTTP 502)
      */
+    /**
+     * CMS 이미지를 바이트 배열로 가져온다.
+     *
+     * <p>CMS의 {@code GET /cms/api/assets/{assetId}/image} 는 DB에서 현재 파일 위치를 읽어 302 redirect 한다.
+     * 미승인(임시 경로)·승인(운영 경로) 상태 구분 없이 동일 URL로 접근 가능하다.
+     * Admin → CMS 서버 간 호출이므로 x-deploy-token 인증(defaultHeader 주입)을 사용한다.
+     *
+     * @param assetId 이미지 자산 ID
+     * @return 이미지 바이트 및 Content-Type. CMS 오류 시 빈 404 반환
+     */
+    public ResponseEntity<byte[]> fetchImage(String assetId) {
+        try {
+            return cmsBuilderDeployRestClient
+                    .get()
+                    .uri("/cms/api/assets/{assetId}/image", assetId)
+                    .retrieve()
+                    .toEntity(byte[].class);
+        } catch (RestClientException e) {
+            log.warn("CMS 이미지 조회 실패: assetId={}", assetId, e);
+            return ResponseEntity.notFound().build();
+        }
+    }
+
     public void deployAsset(String assetId) {
         try {
             cmsBuilderDeployRestClient

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/controller/CmsAssetApprovalController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/controller/CmsAssetApprovalController.java
@@ -1,5 +1,6 @@
 package com.example.admin_demo.domain.cmsasset.controller;
 
+import com.example.admin_demo.domain.cmsasset.client.CmsBuilderClient;
 import com.example.admin_demo.domain.cmsasset.dto.CmsAssetApprovalListRequest;
 import com.example.admin_demo.domain.cmsasset.dto.CmsAssetDetailResponse;
 import com.example.admin_demo.domain.cmsasset.dto.CmsAssetListResponse;
@@ -11,6 +12,8 @@ import com.example.admin_demo.global.dto.PageResponse;
 import com.example.admin_demo.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -27,10 +30,11 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * <h4>API 엔드포인트:</h4>
  * <ul>
- *   <li>GET  /api/cms-admin/asset-approvals                   — PENDING 기본 필터 목록</li>
- *   <li>GET  /api/cms-admin/asset-approvals/{assetId}         — 모달 프리뷰용 상세</li>
- *   <li>POST /api/cms-admin/asset-approvals/{assetId}/approve — PENDING → APPROVED (DB만, CMS API 연동은 #55)</li>
- *   <li>POST /api/cms-admin/asset-approvals/{assetId}/reject  — PENDING → REJECTED + 반려 사유(선택)</li>
+ *   <li>GET  /api/cms-admin/asset-approvals                        — PENDING 기본 필터 목록</li>
+ *   <li>GET  /api/cms-admin/asset-approvals/{assetId}              — 모달 프리뷰용 상세</li>
+ *   <li>GET  /api/cms-admin/asset-approvals/{assetId}/image        — CMS 이미지 프록시 (썸네일·미리보기)</li>
+ *   <li>POST /api/cms-admin/asset-approvals/{assetId}/approve      — PENDING → APPROVED</li>
+ *   <li>POST /api/cms-admin/asset-approvals/{assetId}/reject       — PENDING → REJECTED + 반려 사유(선택)</li>
  * </ul>
  */
 @Slf4j
@@ -39,6 +43,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CmsAssetApprovalController {
 
     private final CmsAssetService cmsAssetService;
+    private final CmsBuilderClient cmsBuilderClient;
 
     /** 승인 대기 이미지 목록 (기본 PENDING 필터) */
     @GetMapping("/api/cms-admin/asset-approvals")
@@ -52,6 +57,28 @@ public class CmsAssetApprovalController {
                 PageRequest.builder().page(Math.max(0, page - 1)).size(size).build();
 
         return ResponseEntity.ok(ApiResponse.success(cmsAssetService.findApprovalList(req, pageRequest)));
+    }
+
+    /**
+     * CMS 이미지 프록시 — 썸네일·미리보기용.
+     *
+     * <p>CMS의 {@code GET /cms/api/assets/{assetId}/image} 를 중계한다.
+     * CMS가 현재 파일 위치로 302 redirect 하므로 미승인·승인 상태와 무관하게 동일 URL로 동작한다.
+     * 브라우저에서 직접 CMS를 호출하면 x-deploy-token 인증이 불가하므로 Admin이 중계한다.
+     */
+    @GetMapping("/api/cms-admin/asset-approvals/{assetId}/image")
+    @PreAuthorize("hasAuthority('CMS:R')")
+    public ResponseEntity<byte[]> proxyImage(@PathVariable String assetId) {
+        ResponseEntity<byte[]> cmsResponse = cmsBuilderClient.fetchImage(assetId);
+        byte[] body = cmsResponse.getBody();
+        if (body == null || !cmsResponse.getStatusCode().is2xxSuccessful()) {
+            return ResponseEntity.notFound().build();
+        }
+        String contentType = cmsResponse.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE);
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(
+                        contentType != null ? contentType : MediaType.APPLICATION_OCTET_STREAM_VALUE))
+                .body(body);
     }
 
     /** 이미지 상세 (프리뷰 모달용) */

--- a/admin/src/main/resources/templates/pages/asset/approval-script.html
+++ b/admin/src/main/resources/templates/pages/asset/approval-script.html
@@ -19,7 +19,6 @@
         itemsPerPage: 10,
         sortBy: null,
         sortDirection: null,
-        // 썸네일은 #53 범위에서 placeholder 사용
         PLACEHOLDER_SRC: '/images/asset-placeholder.svg',
 
         STATE_BADGE: {
@@ -117,7 +116,7 @@
 
                 return `<tr>
                     <td class="text-center">
-                        <img src="${placeholder}" alt="placeholder" class="asset-thumb"
+                        <img src="/api/cms-admin/asset-approvals/${aid}/image" alt="미리보기" class="asset-thumb"
                              style="width:48px;height:48px;object-fit:cover;border-radius:4px;cursor:pointer;"
                              onclick="CmsAssetApprovalPage.openPreview('${aid}')"
                              onerror="this.src='${placeholder}'"/>
@@ -216,7 +215,7 @@
             $('#previewAssetState').text('-');
             $('#previewCreateUser').text('-');
             $('#previewCreateDate').text('-');
-            $('#previewImg').attr('src', this.PLACEHOLDER_SRC);
+            $('#previewImg').attr('src', `/api/cms-admin/asset-approvals/${encodeURIComponent(assetId)}/image`);
 
             new bootstrap.Modal('#assetPreviewModal').show();
 
@@ -233,7 +232,6 @@
                     $('#previewAssetState').html(this.STATE_BADGE[d.assetState] || HtmlUtils.escape(d.assetState || ''));
                     $('#previewCreateUser').text((d.createUserName || '-') + ' (' + (d.createUserId || '-') + ')');
                     $('#previewCreateDate').text(d.createDate || '-');
-                    // ASSET_URL 연동은 후속 이슈 — 현재는 placeholder 유지
                 })
                 .catch(() => Toast.error('상세 조회 중 오류가 발생했습니다.'));
         },

--- a/admin/src/main/resources/templates/pages/asset/approval.html
+++ b/admin/src/main/resources/templates/pages/asset/approval.html
@@ -41,7 +41,8 @@
                         <div class="col-md-5 text-center">
                             <img id="previewImg" src="/images/asset-placeholder.svg" alt="preview"
                                  class="img-fluid border rounded"
-                                 style="max-height:320px;object-fit:contain;background:#f8f9fa;"/>
+                                 style="max-height:320px;object-fit:contain;background:#f8f9fa;"
+                                 onerror="this.src='/images/asset-placeholder.svg'; this.onerror=null;"/>
                         </div>
                         <div class="col-md-7">
                             <table class="table table-sm mb-0">

--- a/admin/src/main/resources/templates/pages/asset/request-script.html
+++ b/admin/src/main/resources/templates/pages/asset/request-script.html
@@ -18,7 +18,6 @@
         itemsPerPage: 10,
         sortBy: null,
         sortDirection: null,
-        // 썸네일은 #53 범위에서 placeholder 사용 — 실제 ASSET_URL 연동은 후속 이슈
         PLACEHOLDER_SRC: '/images/asset-placeholder.svg',
 
         STATE_BADGE: {
@@ -121,7 +120,7 @@
 
                 return `<tr>
                     <td class="text-center">
-                        <img src="${placeholder}" alt="placeholder" class="asset-thumb"
+                        <img src="/api/cms-admin/asset-approvals/${aid}/image" alt="미리보기" class="asset-thumb"
                              style="width:48px;height:48px;object-fit:cover;border-radius:4px;"
                              onerror="this.src='${placeholder}'"/>
                     </td>


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #158

## ✨ 변경 사항 (Changes)

### Admin → CMS 이미지 프록시 추가
- `CmsBuilderClient.fetchImage(assetId)` — CMS `GET /cms/api/assets/{assetId}/image` 중계 (x-deploy-token 인증)
- `CmsAssetApprovalController` — `GET /api/cms-admin/asset-approvals/{assetId}/image` 엔드포인트 추가, byte[] + Content-Type 반환

### 프론트엔드 이미지 src 교체
- `approval-script.html` — 썸네일·상세 모달 미리보기 src를 프록시 URL로 교체
- `approval.html` — 모달 `#previewImg`에 `onerror` fallback 추가
- `request-script.html` — 썸네일 src를 프록시 URL로 교체

## ⚠️ 고려 및 주의 사항 (선택)
- 브라우저 → CMS 직접 호출 시 `x-deploy-token` 첨부 불가로 Admin이 프록시 중계하는 방식 채택
- CMS 이미지 조회 실패(네트워크 오류, 404 등) 시 `onerror`로 placeholder 자동 fallback
- `cmsBuilderDeployRestClient` 빈의 `defaultHeader("x-deploy-token", ...)` 재사용 — 별도 설정 불필요