### PR TITLE
feat: CMS 대시보드 페이지 생성 모달 — 템플릿 목록 동적 로드 (#160)

### DIFF
--- a/admin/src/main/java/com/example/admin_demo/domain/cmsdashboard/controller/CmsDashboardController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsdashboard/controller/CmsDashboardController.java
@@ -5,11 +5,13 @@ import com.example.admin_demo.domain.cmsdashboard.dto.CmsDashboardCreateRequest;
 import com.example.admin_demo.domain.cmsdashboard.dto.CmsDashboardCreateResponse;
 import com.example.admin_demo.domain.cmsdashboard.dto.CmsDashboardListRequest;
 import com.example.admin_demo.domain.cmsdashboard.dto.CmsDashboardPageResponse;
+import com.example.admin_demo.domain.cmsdashboard.dto.CmsTemplateResponse;
 import com.example.admin_demo.domain.cmsdashboard.service.CmsDashboardService;
 import com.example.admin_demo.global.dto.ApiResponse;
 import com.example.admin_demo.global.dto.PageRequest;
 import com.example.admin_demo.global.dto.PageResponse;
 import com.example.admin_demo.global.security.CustomUserDetails;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * <h4>API 엔드포인트:</h4>
  * <ul>
+ *   <li>GET    /api/cms-dashboard/templates                          — 템플릿 목록</li>
  *   <li>GET    /api/cms-dashboard/pages                              — 내 페이지 목록</li>
  *   <li>POST   /api/cms-dashboard/pages                              — 새 페이지 생성</li>
  *   <li>DELETE /api/cms-dashboard/pages/{pageId}                     — 페이지 삭제</li>
@@ -46,6 +49,13 @@ public class CmsDashboardController {
 
     @Value("${cms.user-url}")
     private String cmsUserUrl;
+
+    /** 템플릿 목록 조회 — 페이지 생성 모달 선택 목록용 (PAGE_TYPE = 'TEMPLATE', USE_YN = 'Y') */
+    @GetMapping("/api/cms-dashboard/templates")
+    @PreAuthorize("hasAuthority('CMS:R')")
+    public ResponseEntity<ApiResponse<List<CmsTemplateResponse>>> findTemplateList() {
+        return ResponseEntity.ok(ApiResponse.success(cmsDashboardService.findTemplateList()));
+    }
 
     /** 내 페이지 목록 조회 (CMS:R 권한 보유 사용자) */
     @GetMapping("/api/cms-dashboard/pages")

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsdashboard/dto/CmsTemplateResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsdashboard/dto/CmsTemplateResponse.java
@@ -1,0 +1,25 @@
+package com.example.admin_demo.domain.cmsdashboard.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * CMS 템플릿 목록 응답 DTO (SPW_CMS_PAGE, PAGE_TYPE = 'TEMPLATE')
+ *
+ * <p>페이지 생성 모달의 템플릿 선택 드롭다운에 사용된다.
+ * pageId: 선택 시 createTemplateId hidden input에 저장되는 값 (SPW_CMS_PAGE.PAGE_ID 참조)
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CmsTemplateResponse {
+
+    /** 템플릿 페이지 ID (새 페이지 생성 시 TEMPLATE_ID로 저장되는 값) */
+    private String pageId;
+
+    /** 템플릿 이름 (선택 목록에 표시) */
+    private String pageName;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsdashboard/mapper/CmsDashboardMapper.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsdashboard/mapper/CmsDashboardMapper.java
@@ -2,6 +2,7 @@ package com.example.admin_demo.domain.cmsdashboard.mapper;
 
 import com.example.admin_demo.domain.cmsdashboard.dto.CmsDashboardListRequest;
 import com.example.admin_demo.domain.cmsdashboard.dto.CmsDashboardPageResponse;
+import com.example.admin_demo.domain.cmsdashboard.dto.CmsTemplateResponse;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -33,6 +34,18 @@ public interface CmsDashboardMapper {
             @Param("templateId") String templateId,
             @Param("userId") String userId,
             @Param("userName") String userName);
+
+    /**
+     * 템플릿 목록 조회 — PAGE_TYPE = 'TEMPLATE', USE_YN = 'Y'
+     * 페이지 생성 모달의 템플릿 선택 목록에 사용된다.
+     */
+    List<CmsTemplateResponse> findTemplateList();
+
+    /**
+     * 템플릿 존재 여부 확인 — createPage 시 templateId 유효성 검증용.
+     * PAGE_TYPE = 'TEMPLATE' AND USE_YN = 'Y' 인 페이지인지 확인한다.
+     */
+    int existsTemplate(@Param("templateId") String templateId);
 
     /** 이력 존재 여부 확인 — 삭제 분기(하드/소프트)에 사용 */
     int hasHistory(@Param("pageId") String pageId);

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsdashboard/service/CmsDashboardService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsdashboard/service/CmsDashboardService.java
@@ -4,6 +4,7 @@ import com.example.admin_demo.domain.cmsdashboard.dto.CmsDashboardApproveRequest
 import com.example.admin_demo.domain.cmsdashboard.dto.CmsDashboardCreateRequest;
 import com.example.admin_demo.domain.cmsdashboard.dto.CmsDashboardListRequest;
 import com.example.admin_demo.domain.cmsdashboard.dto.CmsDashboardPageResponse;
+import com.example.admin_demo.domain.cmsdashboard.dto.CmsTemplateResponse;
 import com.example.admin_demo.domain.cmsdashboard.mapper.CmsDashboardMapper;
 import com.example.admin_demo.global.dto.PageRequest;
 import com.example.admin_demo.global.dto.PageResponse;
@@ -29,6 +30,11 @@ public class CmsDashboardService {
 
     private final CmsDashboardMapper cmsDashboardMapper;
 
+    /** 템플릿 목록 조회 — PAGE_TYPE = 'TEMPLATE', USE_YN = 'Y' */
+    public List<CmsTemplateResponse> findTemplateList() {
+        return cmsDashboardMapper.findTemplateList();
+    }
+
     /** 내 페이지 목록 조회 */
     public PageResponse<CmsDashboardPageResponse> findMyPageList(
             CmsDashboardListRequest req, String userId, PageRequest pageRequest) {
@@ -52,6 +58,12 @@ public class CmsDashboardService {
         // CMS 원본(crypto.randomUUID())과 동일한 UUID 방식으로 생성
         String pageId = UUID.randomUUID().toString();
         String templateId = "blank".equals(req.getTemplateId()) ? null : req.getTemplateId();
+
+        // 클라이언트 전달값 검증 — PAGE_TYPE='TEMPLATE' AND USE_YN='Y' 인 페이지인지 확인 (임의 pageId 주입 방지)
+        if (templateId != null && cmsDashboardMapper.existsTemplate(templateId) == 0) {
+            throw new NotFoundException("유효하지 않은 템플릿입니다. templateId=" + templateId);
+        }
+
         cmsDashboardMapper.insertPage(pageId, req.getPageName(), req.getViewMode(), templateId, userId, userName);
         log.info("CMS 페이지 생성: pageId={}, userId={}", pageId, userId);
         return pageId;

--- a/admin/src/main/resources/mapper/oracle/cmsdashboard/CmsDashboardMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/cmsdashboard/CmsDashboardMapper.xml
@@ -118,6 +118,33 @@
         )
     </insert>
 
+    <!-- ==================== 템플릿 목록 조회 ==================== -->
+
+    <!--
+        페이지 생성 모달 템플릿 선택 목록.
+        PAGE_TYPE = 'TEMPLATE' AND USE_YN = 'Y' 인 페이지를 이름 순으로 반환한다.
+    -->
+    <select id="findTemplateList" resultType="com.example.admin_demo.domain.cmsdashboard.dto.CmsTemplateResponse">
+        SELECT PAGE_ID   AS pageId,
+               PAGE_NAME AS pageName
+        FROM SPW_CMS_PAGE
+        WHERE PAGE_TYPE = 'TEMPLATE'
+          AND USE_YN    = 'Y'
+        ORDER BY PAGE_NAME
+    </select>
+
+    <!--
+        템플릿 존재 여부 확인 — createPage 시 클라이언트 전달 templateId 검증용.
+        PAGE_TYPE = 'TEMPLATE' AND USE_YN = 'Y' 조건을 만족하면 1, 아니면 0 반환.
+    -->
+    <select id="existsTemplate" resultType="int">
+        SELECT COUNT(*)
+        FROM SPW_CMS_PAGE
+        WHERE PAGE_ID   = #{templateId}
+          AND PAGE_TYPE = 'TEMPLATE'
+          AND USE_YN    = 'Y'
+    </select>
+
     <!-- ==================== 이력 존재 확인 ==================== -->
 
     <select id="hasHistory" resultType="int">

--- a/admin/src/main/resources/mapper/oracle/cmsdashboard/CmsDashboardMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/cmsdashboard/CmsDashboardMapper.xml
@@ -105,12 +105,19 @@
     <insert id="insertPage">
         INSERT INTO SPW_CMS_PAGE (
             PAGE_ID, PAGE_NAME, VIEW_MODE, TEMPLATE_ID,
+            PAGE_HTML,
             CREATE_USER_ID, CREATE_USER_NAME,
             LAST_MODIFIER_ID, LAST_MODIFIER_NAME,
             APPROVE_STATE, USE_YN,
             CREATE_DATE, LAST_MODIFIED_DTIME
         ) VALUES (
             #{pageId}, #{pageName}, #{viewMode}, #{templateId},
+            <!--
+                템플릿 선택 시 PAGE_HTML을 복사하여 에디터가 템플릿 내용으로 시작하도록 한다.
+                templateId가 null이면 WHERE PAGE_ID = NULL → 행 없음 → 스칼라 서브쿼리 NULL 반환 → 빈 페이지.
+                templateId가 유효하면 해당 TEMPLATE 페이지의 PAGE_HTML을 그대로 복사한다.
+            -->
+            (SELECT PAGE_HTML FROM SPW_CMS_PAGE WHERE PAGE_ID = #{templateId}),
             #{userId}, #{userName},
             #{userId}, #{userName},
             'WORK', 'Y',

--- a/admin/src/main/resources/templates/pages/cms-dashboard/cms-dashboard-script.html
+++ b/admin/src/main/resources/templates/pages/cms-dashboard/cms-dashboard-script.html
@@ -409,7 +409,7 @@
             CmsDashboardPage.selectCreateViewMode($(this).data('view-mode'));
         });
         // 이벤트 위임 — _loadTemplates()로 동적 추가된 버튼에도 적용
-        $(document).on('click', '.cms-create-template', function() {
+        $('.cms-create-template-list').on('click', '.cms-create-template', function() {
             CmsDashboardPage.selectCreateTemplate($(this).data('template-id'));
         });
         $('#createPageName').on('input', function() {

--- a/admin/src/main/resources/templates/pages/cms-dashboard/cms-dashboard-script.html
+++ b/admin/src/main/resources/templates/pages/cms-dashboard/cms-dashboard-script.html
@@ -252,6 +252,32 @@
             $('.cms-create-template-selected-name').text($template.find('.cms-create-template-title').text());
         },
 
+        /**
+         * 템플릿 목록 동적 로드 — GET /api/cms-dashboard/templates
+         * 페이지 초기화 시 1회 호출. 중복 방지를 위해 blank 외 기존 항목을 먼저 제거한다.
+         * XSS 방지: pageName은 jQuery .text()로 설정하여 HTML 이스케이프 처리.
+         */
+        _loadTemplates: function() {
+            fetch('/api/cms-dashboard/templates')
+                .then(r => r.json())
+                .then(res => {
+                    if (!res.success || !res.data) return;
+                    const $list = $('.cms-create-template-list');
+                    // 이전에 동적으로 추가된 항목 제거 (중복 방지)
+                    $list.find('.cms-create-template:not([data-template-id="blank"])').remove();
+                    res.data.forEach(function(t) {
+                        const $btn = $('<button type="button" class="cms-create-template"></button>');
+                        $btn.attr('data-template-id', t.pageId);
+                        const $radio = $('<span class="cms-create-template-radio"></span>');
+                        const $title = $('<span class="cms-create-template-title"></span>').text(t.pageName);
+                        const $desc  = $('<span class="cms-create-template-desc">미리 구성된 템플릿으로 시작합니다.</span>');
+                        $btn.append($radio).append($('<span></span>').append($title).append($desc));
+                        $list.append($btn);
+                    });
+                })
+                .catch(() => {}); // 로드 실패 시 빈 페이지만으로 정상 동작
+        },
+
         updateCreateButtonState: function(creating) {
             const hasName = !!$('#createPageName').val().trim();
             $('#btnCreatePageConfirm')
@@ -372,6 +398,7 @@
         CmsDashboardPage.itemsPerPage = parseInt($('#limitRows').val()) || 10;
         CmsDashboardPage.attachSortHandlers();
         CmsDashboardPage.load(1);
+        CmsDashboardPage._loadTemplates();
 
         $('#limitRows').on('change', function() {
             CmsDashboardPage.itemsPerPage = parseInt($(this).val()) || 10;
@@ -381,7 +408,8 @@
         $('.cms-create-view-mode').on('click', function() {
             CmsDashboardPage.selectCreateViewMode($(this).data('view-mode'));
         });
-        $('.cms-create-template').on('click', function() {
+        // 이벤트 위임 — _loadTemplates()로 동적 추가된 버튼에도 적용
+        $(document).on('click', '.cms-create-template', function() {
             CmsDashboardPage.selectCreateTemplate($(this).data('template-id'));
         });
         $('#createPageName').on('input', function() {

--- a/admin/src/test/java/com/example/admin_demo/domain/cmsdashboard/controller/CmsDashboardControllerTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/cmsdashboard/controller/CmsDashboardControllerTest.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.admin_demo.domain.cmsdashboard.dto.CmsDashboardPageResponse;
+import com.example.admin_demo.domain.cmsdashboard.dto.CmsTemplateResponse;
 import com.example.admin_demo.domain.cmsdashboard.service.CmsDashboardService;
 import com.example.admin_demo.domain.user.enums.UserState;
 import com.example.admin_demo.global.dto.PageResponse;
@@ -52,6 +53,46 @@ class CmsDashboardControllerTest {
 
     @MockitoBean
     private CmsDashboardService cmsDashboardService;
+
+    @Test
+    @DisplayName("[템플릿] CMS:R 권한으로 템플릿 목록 조회 시 200과 목록을 반환한다")
+    void findTemplateList_withCmsR_returns200() throws Exception {
+        given(cmsDashboardService.findTemplateList())
+                .willReturn(List.of(
+                        CmsTemplateResponse.builder()
+                                .pageId("tmpl-1")
+                                .pageName("기본 템플릿")
+                                .build(),
+                        CmsTemplateResponse.builder()
+                                .pageId("tmpl-2")
+                                .pageName("이벤트 템플릿")
+                                .build()));
+
+        mockMvc.perform(get("/api/cms-dashboard/templates").with(user(customUser("cmsUser01", "cms_user", "CMS:R"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].pageId").value("tmpl-1"))
+                .andExpect(jsonPath("$.data[0].pageName").value("기본 템플릿"));
+    }
+
+    @Test
+    @DisplayName("[템플릿] 템플릿이 없을 경우 빈 배열을 반환한다")
+    void findTemplateList_empty_returnsEmptyList() throws Exception {
+        given(cmsDashboardService.findTemplateList()).willReturn(List.of());
+
+        mockMvc.perform(get("/api/cms-dashboard/templates").with(user(customUser("cmsUser01", "cms_user", "CMS:R"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("[템플릿] CMS:W 권한으로 템플릿 목록 조회 시 403을 반환한다")
+    void findTemplateList_withCmsW_returns403() throws Exception {
+        mockMvc.perform(get("/api/cms-dashboard/templates").with(user(customUser("cmsAdmin01", "cms_admin", "CMS:W"))))
+                .andExpect(status().isForbidden());
+    }
 
     @Test
     @DisplayName("[조회] CMS:R 권한으로 내 페이지 목록 조회 시 200을 반환한다")


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #160

## ✨ 변경 사항 (Changes)

### Backend
- `CmsTemplateResponse.java` DTO 신규 생성 (`pageId`, `pageName`)
- `GET /api/cms-dashboard/templates` 엔드포인트 추가 (권한: `CMS:R`)
- `createPage` 시 `templateId` 서버 검증 추가 — `PAGE_TYPE='TEMPLATE' AND USE_YN='Y'` 여부 확인 (`NotFoundException`)
- `insertPage` 쿼리에 `PAGE_HTML` 스칼라 서브쿼리 추가 — 템플릿 선택 시 HTML 복사, 빈 페이지 시 NULL

### Frontend
- `_loadTemplates()` 추가 — 페이지 초기화 시 AJAX로 템플릿 목록 동적 append
- XSS 방지: `pageName`을 jQuery `.text()`로 설정
- 중복 방지: append 전 `blank` 외 기존 항목 제거
- 이벤트 위임 적용 — 동적 추가된 템플릿 버튼에도 클릭 이벤트 동작

### 테스트
- `CmsDashboardControllerTest` 템플릿 관련 테스트 3개 추가 (성공, 빈 결과, 403)

## ⚠️ 고려 및 주의 사항 (선택)
- 템플릿 페이지(`PAGE_TYPE='TEMPLATE'`)는 `SPW_CMS_PAGE`에 직접 등록되어야 목록에 노출됨
- `insertPage`의 `PAGE_HTML` 서브쿼리는 `templateId=null`(빈 페이지)일 때 `WHERE PAGE_ID = NULL` → 스칼라 서브쿼리 NULL 반환으로 기존 동작 유지

## 💬 리뷰 포인트 (선택)
- `insertPage` 스칼라 서브쿼리 방식으로 Java 코드 변경 없이 HTML 복사 처리한 부분
- `templateId` 검증을 Service에서 수행하여 임의 `pageId` 주입 방지