### PR TITLE
[FIX]: SqlQueryServiceTest Mapper 파라미터 불일치 수정

### DIFF
--- a/admin/src/test/java/com/example/admin_demo/domain/sqlquery/service/SqlQueryServiceTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/sqlquery/service/SqlQueryServiceTest.java
@@ -44,8 +44,10 @@ class SqlQueryServiceTest {
                 SqlQuerySearchRequest.builder().page(1).size(10).build();
 
         List<SqlQueryResponse> data = List.of(buildResponse("Q001"), buildResponse("Q002"));
-        given(sqlQueryMapper.countAllWithSearch(any(), any(), any(), any(), any(), any())).willReturn(2L);
-        given(sqlQueryMapper.findAllWithSearch(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
+        given(sqlQueryMapper.countAllWithSearch(any(), any(), any(), any(), any(), any()))
+                .willReturn(2L);
+        given(sqlQueryMapper.findAllWithSearch(
+                        any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
                 .willReturn(data);
 
         PageResponse<SqlQueryResponse> result = sqlQueryService.getSqlQueriesWithSearch(searchDTO);
@@ -61,8 +63,10 @@ class SqlQueryServiceTest {
         SqlQuerySearchRequest searchDTO =
                 SqlQuerySearchRequest.builder().page(1).size(10).build();
 
-        given(sqlQueryMapper.countAllWithSearch(any(), any(), any(), any(), any(), any())).willReturn(0L);
-        given(sqlQueryMapper.findAllWithSearch(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
+        given(sqlQueryMapper.countAllWithSearch(any(), any(), any(), any(), any(), any()))
+                .willReturn(0L);
+        given(sqlQueryMapper.findAllWithSearch(
+                        any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
                 .willReturn(List.of());
 
         PageResponse<SqlQueryResponse> result = sqlQueryService.getSqlQueriesWithSearch(searchDTO);
@@ -220,7 +224,8 @@ class SqlQueryServiceTest {
     @DisplayName("[엑셀] 빈 데이터이면 빈 엑셀 바이트를 반환해야 한다")
     void exportExcel_emptyData_returnsBytes() {
         SqlQuerySearchRequest searchDTO = SqlQuerySearchRequest.builder().build();
-        given(sqlQueryMapper.findAllForExport(any(), any(), any(), any(), any(), any())).willReturn(Collections.emptyList());
+        given(sqlQueryMapper.findAllForExport(any(), any(), any(), any(), any(), any()))
+                .willReturn(Collections.emptyList());
 
         byte[] result = sqlQueryService.exportExcel(searchDTO);
 
@@ -236,7 +241,8 @@ class SqlQueryServiceTest {
                 .queryName("테스트")
                 .useYn("Y")
                 .build();
-        given(sqlQueryMapper.findAllForExport("Q001", "테스트", "Y", null, null, null)).willReturn(List.of(buildResponse("Q001")));
+        given(sqlQueryMapper.findAllForExport("Q001", "테스트", "Y", null, null, null))
+                .willReturn(List.of(buildResponse("Q001")));
 
         byte[] result = sqlQueryService.exportExcel(searchDTO);
 
@@ -257,8 +263,10 @@ class SqlQueryServiceTest {
                 .useYn("Y")
                 .build();
 
-        given(sqlQueryMapper.countAllWithSearch("Q001", "테스트", "Y", null, null, null)).willReturn(1L);
-        given(sqlQueryMapper.findAllWithSearch(eq("Q001"), eq("테스트"), eq("Y"), isNull(), isNull(), isNull(), any(), any(), anyInt(), anyInt()))
+        given(sqlQueryMapper.countAllWithSearch("Q001", "테스트", "Y", null, null, null))
+                .willReturn(1L);
+        given(sqlQueryMapper.findAllWithSearch(
+                        eq("Q001"), eq("테스트"), eq("Y"), isNull(), isNull(), isNull(), any(), any(), anyInt(), anyInt()))
                 .willReturn(List.of(buildResponse("Q001")));
 
         PageResponse<SqlQueryResponse> result = sqlQueryService.getSqlQueriesWithSearch(searchDTO);
@@ -278,8 +286,10 @@ class SqlQueryServiceTest {
                 .sortDirection("DESC")
                 .build();
 
-        given(sqlQueryMapper.countAllWithSearch(any(), any(), any(), any(), any(), any())).willReturn(0L);
-        given(sqlQueryMapper.findAllWithSearch(any(), any(), any(), any(), any(), any(), eq("queryName"), eq("DESC"), anyInt(), anyInt()))
+        given(sqlQueryMapper.countAllWithSearch(any(), any(), any(), any(), any(), any()))
+                .willReturn(0L);
+        given(sqlQueryMapper.findAllWithSearch(
+                        any(), any(), any(), any(), any(), any(), eq("queryName"), eq("DESC"), anyInt(), anyInt()))
                 .willReturn(List.of());
 
         PageResponse<SqlQueryResponse> result = sqlQueryService.getSqlQueriesWithSearch(searchDTO);
@@ -287,7 +297,8 @@ class SqlQueryServiceTest {
         assertThat(result.getContent()).isEmpty();
         then(sqlQueryMapper)
                 .should()
-                .findAllWithSearch(any(), any(), any(), any(), any(), any(), eq("queryName"), eq("DESC"), anyInt(), anyInt());
+                .findAllWithSearch(
+                        any(), any(), any(), any(), any(), any(), eq("queryName"), eq("DESC"), anyInt(), anyInt());
     }
 
     // ─── create (null sqlQuery2 — validateSqlText null path) ─────

--- a/admin/src/test/java/com/example/admin_demo/domain/sqlquery/service/SqlQueryServiceTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/sqlquery/service/SqlQueryServiceTest.java
@@ -277,6 +277,39 @@ class SqlQueryServiceTest {
     }
 
     @Test
+    @DisplayName("[조회] 신규 필터(sqlGroupId, sqlGroupName, sqlType)가 mapper에 전달되어야 한다")
+    void getSqlQueriesWithSearch_withNewFilters_passesNewFiltersToMapper() {
+        SqlQuerySearchRequest searchDTO = SqlQuerySearchRequest.builder()
+                .page(1)
+                .size(10)
+                .sqlGroupId("GRP01")
+                .sqlGroupName("테스트그룹")
+                .sqlType("SELECT")
+                .build();
+
+        given(sqlQueryMapper.countAllWithSearch(null, null, null, "GRP01", "테스트그룹", "SELECT"))
+                .willReturn(1L);
+        given(sqlQueryMapper.findAllWithSearch(
+                        isNull(),
+                        isNull(),
+                        isNull(),
+                        eq("GRP01"),
+                        eq("테스트그룹"),
+                        eq("SELECT"),
+                        any(),
+                        any(),
+                        anyInt(),
+                        anyInt()))
+                .willReturn(List.of(buildResponse("Q001")));
+
+        PageResponse<SqlQueryResponse> result = sqlQueryService.getSqlQueriesWithSearch(searchDTO);
+
+        assertThat(result.getTotalElements()).isEqualTo(1L);
+        assertThat(result.getContent()).hasSize(1);
+        then(sqlQueryMapper).should().countAllWithSearch(null, null, null, "GRP01", "테스트그룹", "SELECT");
+    }
+
+    @Test
     @DisplayName("[조회] 정렬 조건이 pageRequest를 통해 전달되어야 한다")
     void getSqlQueriesWithSearch_withSort_passesSortToMapper() {
         SqlQuerySearchRequest searchDTO = SqlQuerySearchRequest.builder()

--- a/admin/src/test/java/com/example/admin_demo/domain/sqlquery/service/SqlQueryServiceTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/sqlquery/service/SqlQueryServiceTest.java
@@ -44,8 +44,8 @@ class SqlQueryServiceTest {
                 SqlQuerySearchRequest.builder().page(1).size(10).build();
 
         List<SqlQueryResponse> data = List.of(buildResponse("Q001"), buildResponse("Q002"));
-        given(sqlQueryMapper.countAllWithSearch(any(), any(), any())).willReturn(2L);
-        given(sqlQueryMapper.findAllWithSearch(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+        given(sqlQueryMapper.countAllWithSearch(any(), any(), any(), any(), any(), any())).willReturn(2L);
+        given(sqlQueryMapper.findAllWithSearch(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
                 .willReturn(data);
 
         PageResponse<SqlQueryResponse> result = sqlQueryService.getSqlQueriesWithSearch(searchDTO);
@@ -61,8 +61,8 @@ class SqlQueryServiceTest {
         SqlQuerySearchRequest searchDTO =
                 SqlQuerySearchRequest.builder().page(1).size(10).build();
 
-        given(sqlQueryMapper.countAllWithSearch(any(), any(), any())).willReturn(0L);
-        given(sqlQueryMapper.findAllWithSearch(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+        given(sqlQueryMapper.countAllWithSearch(any(), any(), any(), any(), any(), any())).willReturn(0L);
+        given(sqlQueryMapper.findAllWithSearch(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
                 .willReturn(List.of());
 
         PageResponse<SqlQueryResponse> result = sqlQueryService.getSqlQueriesWithSearch(searchDTO);
@@ -207,7 +207,7 @@ class SqlQueryServiceTest {
     @DisplayName("[엑셀] 정상 데이터가 있으면 바이트 배열을 반환해야 한다")
     void exportExcel_withData_returnsBytes() {
         SqlQuerySearchRequest searchDTO = SqlQuerySearchRequest.builder().build();
-        given(sqlQueryMapper.findAllForExport(any(), any(), any()))
+        given(sqlQueryMapper.findAllForExport(any(), any(), any(), any(), any(), any()))
                 .willReturn(List.of(buildResponse("Q001"), buildResponse("Q002")));
 
         byte[] result = sqlQueryService.exportExcel(searchDTO);
@@ -220,7 +220,7 @@ class SqlQueryServiceTest {
     @DisplayName("[엑셀] 빈 데이터이면 빈 엑셀 바이트를 반환해야 한다")
     void exportExcel_emptyData_returnsBytes() {
         SqlQuerySearchRequest searchDTO = SqlQuerySearchRequest.builder().build();
-        given(sqlQueryMapper.findAllForExport(any(), any(), any())).willReturn(Collections.emptyList());
+        given(sqlQueryMapper.findAllForExport(any(), any(), any(), any(), any(), any())).willReturn(Collections.emptyList());
 
         byte[] result = sqlQueryService.exportExcel(searchDTO);
 
@@ -236,12 +236,12 @@ class SqlQueryServiceTest {
                 .queryName("테스트")
                 .useYn("Y")
                 .build();
-        given(sqlQueryMapper.findAllForExport("Q001", "테스트", "Y")).willReturn(List.of(buildResponse("Q001")));
+        given(sqlQueryMapper.findAllForExport("Q001", "테스트", "Y", null, null, null)).willReturn(List.of(buildResponse("Q001")));
 
         byte[] result = sqlQueryService.exportExcel(searchDTO);
 
         assertThat(result).isNotNull();
-        then(sqlQueryMapper).should().findAllForExport("Q001", "테스트", "Y");
+        then(sqlQueryMapper).should().findAllForExport("Q001", "테스트", "Y", null, null, null);
     }
 
     // ─── getSqlQueriesWithSearch (검색 필터 적용) ─────────────────
@@ -257,15 +257,15 @@ class SqlQueryServiceTest {
                 .useYn("Y")
                 .build();
 
-        given(sqlQueryMapper.countAllWithSearch("Q001", "테스트", "Y")).willReturn(1L);
-        given(sqlQueryMapper.findAllWithSearch(eq("Q001"), eq("테스트"), eq("Y"), any(), any(), anyInt(), anyInt()))
+        given(sqlQueryMapper.countAllWithSearch("Q001", "테스트", "Y", null, null, null)).willReturn(1L);
+        given(sqlQueryMapper.findAllWithSearch(eq("Q001"), eq("테스트"), eq("Y"), isNull(), isNull(), isNull(), any(), any(), anyInt(), anyInt()))
                 .willReturn(List.of(buildResponse("Q001")));
 
         PageResponse<SqlQueryResponse> result = sqlQueryService.getSqlQueriesWithSearch(searchDTO);
 
         assertThat(result.getTotalElements()).isEqualTo(1L);
         assertThat(result.getContent()).hasSize(1);
-        then(sqlQueryMapper).should().countAllWithSearch("Q001", "테스트", "Y");
+        then(sqlQueryMapper).should().countAllWithSearch("Q001", "테스트", "Y", null, null, null);
     }
 
     @Test
@@ -278,8 +278,8 @@ class SqlQueryServiceTest {
                 .sortDirection("DESC")
                 .build();
 
-        given(sqlQueryMapper.countAllWithSearch(any(), any(), any())).willReturn(0L);
-        given(sqlQueryMapper.findAllWithSearch(any(), any(), any(), eq("queryName"), eq("DESC"), anyInt(), anyInt()))
+        given(sqlQueryMapper.countAllWithSearch(any(), any(), any(), any(), any(), any())).willReturn(0L);
+        given(sqlQueryMapper.findAllWithSearch(any(), any(), any(), any(), any(), any(), eq("queryName"), eq("DESC"), anyInt(), anyInt()))
                 .willReturn(List.of());
 
         PageResponse<SqlQueryResponse> result = sqlQueryService.getSqlQueriesWithSearch(searchDTO);
@@ -287,7 +287,7 @@ class SqlQueryServiceTest {
         assertThat(result.getContent()).isEmpty();
         then(sqlQueryMapper)
                 .should()
-                .findAllWithSearch(any(), any(), any(), eq("queryName"), eq("DESC"), anyInt(), anyInt());
+                .findAllWithSearch(any(), any(), any(), any(), any(), any(), eq("queryName"), eq("DESC"), anyInt(), anyInt());
     }
 
     // ─── create (null sqlQuery2 — validateSqlText null path) ─────


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
> 빌드 에러 수정 (이슈 없음)

## ✨ 변경 사항 (Changes)

`SqlQueryMapper`에 `sqlGroupId`, `sqlGroupName`, `sqlType` 파라미터가 추가됐으나 `SqlQueryServiceTest`의 mock 호출부가 기존 인자 수 기준으로 작성되어 있어 빌드 실패 발생.

**수정 대상 메서드:**
- `countAllWithSearch`: 3개 인자 → 6개 인자 (`sqlGroupId`, `sqlGroupName`, `sqlType` 추가)
- `findAllWithSearch`: 7개 인자 → 10개 인자 (`sqlGroupId`, `sqlGroupName`, `sqlType` 추가)
- `findAllForExport`: 3개 인자 → 6개 인자 (`sqlGroupId`, `sqlGroupName`, `sqlType` 추가)

구체적 값 사용 호출부에는 `null` 추가, matcher 혼용 부분에는 `isNull()` 사용.

## ⚠️ 고려 및 주의 사항 (선택)
없음

## 💬 리뷰 포인트 (선택)
없음