### PR TITLE
[FIX]: FWK_MESSAGE_INSTANCE TRX_TRACKING_NO / MESSAGE_SNO 컬럼 길이 확장

### DIFF
--- a/admin/docs/sql/oracle/04_alter_tables.sql
+++ b/admin/docs/sql/oracle/04_alter_tables.sql
@@ -204,3 +204,16 @@ INSERT INTO FWK_COMPONENT (
 );
 
 COMMIT;
+
+-- =============================================================
+-- #169 FWK_MESSAGE_INSTANCE TRX_TRACKING_NO / MESSAGE_SNO 컬럼 길이 확장
+-- =============================================================
+-- 배경: MessageInstanceRecorder 가 requestId(UUID, 36자)를 TRX_TRACKING_NO 에 그대로 저장하는데
+--       컬럼이 VARCHAR2(30) 으로 정의되어 있어 6자리가 잘려서 저장됨.
+--       → REQ/RES 거래 체인 추적 오류 및 Admin 거래추적로그조회 불일치 발생 가능.
+--       MESSAGE_SNO 는 현재 시퀀스(NEXTVAL) 사용으로 즉각 문제는 없으나 향후 UUID 전환 대비 함께 확장.
+-- ⚠ 개발자가 DB에서 직접 실행해야 합니다.
+ALTER TABLE FWK_MESSAGE_INSTANCE MODIFY TRX_TRACKING_NO VARCHAR2(36);
+ALTER TABLE FWK_MESSAGE_INSTANCE MODIFY MESSAGE_SNO     VARCHAR2(36);
+
+COMMIT;


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #169

## ✨ 변경 사항 (Changes)

`admin/docs/sql/oracle/04_alter_tables.sql`에 DDL 추가

```sql
ALTER TABLE FWK_MESSAGE_INSTANCE MODIFY TRX_TRACKING_NO VARCHAR2(36);
ALTER TABLE FWK_MESSAGE_INSTANCE MODIFY MESSAGE_SNO     VARCHAR2(36);
```

| 컬럼 | 변경 전 | 변경 후 | 사유 |
|------|--------|--------|------|
| `TRX_TRACKING_NO` | VARCHAR2(30) | VARCHAR2(36) | UUID 36자 그대로 저장 — 6자리 잘림 해소 |
| `MESSAGE_SNO` | VARCHAR2(30) | VARCHAR2(36) | 향후 UUID 전환 대비 선제적 확장 |

## ⚠️ 고려 및 주의 사항

- **개발자가 DB에서 직접 실행 필요** (ALTER TABLE은 런타임에 자동 적용되지 않음)
- 컬럼 확장(넓히기)이므로 기존 데이터 영향 없음
- 코드 변경 없음 — `MessageInstanceRecorder`는 이미 UUID를 그대로 사용 중

## 🔗 참고 사항

- 관련 클래스: `spider-link/MessageInstanceRecorder.java` — `trackingNo()` 메서드에서 requestId 그대로 사용
- `01_create_tables.sql` DDL도 신규 환경 구축 대비 별도 동기화 필요 (후속 작업)