### PR TITLE
fix: FWK_MESSAGE_INSTANCE 컬럼 길이 확장 및 biz-channel payload null 방어 코드 추가

### DIFF
--- a/admin/docs/sql/oracle/04_alter_tables.sql
+++ b/admin/docs/sql/oracle/04_alter_tables.sql
@@ -204,3 +204,16 @@ INSERT INTO FWK_COMPONENT (
 );
 
 COMMIT;
+
+-- =============================================================
+-- #169 FWK_MESSAGE_INSTANCE TRX_TRACKING_NO / MESSAGE_SNO 컬럼 길이 확장
+-- =============================================================
+-- 배경: MessageInstanceRecorder 가 requestId(UUID, 36자)를 TRX_TRACKING_NO 에 그대로 저장하는데
+--       컬럼이 VARCHAR2(30) 으로 정의되어 있어 6자리가 잘려서 저장됨.
+--       → REQ/RES 거래 체인 추적 오류 및 Admin 거래추적로그조회 불일치 발생 가능.
+--       MESSAGE_SNO 는 현재 시퀀스(NEXTVAL) 사용으로 즉각 문제는 없으나 향후 UUID 전환 대비 함께 확장.
+-- ⚠ 개발자가 DB에서 직접 실행해야 합니다.
+ALTER TABLE FWK_MESSAGE_INSTANCE MODIFY TRX_TRACKING_NO VARCHAR2(36);
+ALTER TABLE FWK_MESSAGE_INSTANCE MODIFY MESSAGE_SNO     VARCHAR2(36);
+
+COMMIT;

--- a/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/controller/AuthController.java
+++ b/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/controller/AuthController.java
@@ -127,6 +127,13 @@ public class AuthController {
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(result);
             }
 
+            // isSuccess=true 이지만 payload가 null인 경우 방어 (인증AP 버그 또는 빈 응답)
+            if (authResp.getPayload() == null) {
+                log.warn("[AuthController] 인증AP 응답 payload null: userId={}", userId);
+                return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+                        .body(Map.of("error", "인증 서버 응답 오류"));
+            }
+
             Map<String, Object> authPayload = authResp.getPayload();
             String userName = (String) authPayload.getOrDefault("userName", "");
             String userGrade = (String) authPayload.getOrDefault("userGrade", "");
@@ -191,6 +198,13 @@ public class AuthController {
             if (!authResp.isSuccess()) {
                 return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                         .body(Map.of("error", authResp.getMessage()));
+            }
+
+            // isSuccess=true 이지만 payload가 null인 경우 방어
+            if (authResp.getPayload() == null) {
+                log.warn("[AuthController] 인증AP 응답 payload null (me): userId={}", userId);
+                return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+                        .body(Map.of("error", "인증 서버 응답 오류"));
             }
 
             Map<String, Object> authPayload = authResp.getPayload();


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #169

## ✨ 변경 사항 (Changes)

### 이슈 A — FWK_MESSAGE_INSTANCE 컬럼 길이 확장
- `admin/docs/sql/oracle/04_alter_tables.sql`에 ALTER TABLE DDL 추가
- `TRX_TRACKING_NO` VARCHAR2(30) → VARCHAR2(36): UUID(36자) 저장 시 6자리 잘림 방지
- `MESSAGE_SNO` VARCHAR2(30) → VARCHAR2(36): 향후 UUID 전환 대비 확장
- ⚠️ DB에서 개발자가 직접 실행 필요

### 이슈 E — biz-channel AuthController TCP 응답 payload null 방어
- `AuthController.login()`: `authResp.getPayload()` null 체크 후 502 반환
- `AuthController.getMe()`: `authResp.getPayload()` null 체크 후 502 반환
- isSuccess=true이지만 payload=null인 경우 NPE → 명확한 502 응답으로 처리

### 이슈 G — ORG_ID 서버별 분리 (기구현 확인)
- `SpiderLinkAutoConfiguration`이 `spring.application.name`을 ORG_ID로 사용하며 각 AP 서버 yml에 이미 서버별 이름 설정되어 있음 — 코드 변경 없음

## ⚠️ 고려 및 주의 사항 (선택)
- `04_alter_tables.sql`의 ALTER TABLE은 개발자가 DB에서 직접 실행해야 합니다.
- `MESSAGE_SNO`는 현재 시퀀스 기반이지만 `MessageInstanceRecorder`가 UUID를 직접 사용하므로 36자 확장 필요.

## 🔗 참고 사항 (선택)
- 관련 이슈사항: `이슈사항.md` 이슈 A, 이슈 E, 이슈 G