### PR TITLE
fix: CMS 업로드 x-deploy-token 서버 간 인증 추가 (#177)

### DIFF
--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
@@ -76,11 +76,13 @@ public class CmsBuilderClient {
         MultiValueMap<String, Object> form = buildFormData(file, userId, userName, businessCategory, assetDesc);
 
         try {
-            // cmsBuilderDeployRestClient 사용 — defaultHeader로 x-deploy-token이 자동 포함됨 (#177)
-            // upload 엔드포인트가 브라우저 직접 호출을 차단하고 서버 간 토큰 인증만 허용하도록 변경됨
-            CmsBuilderUploadApiResponse response = cmsBuilderDeployRestClient
+            // cmsBuilderRestClient 사용 — 대용량 업로드를 위해 60초 read-timeout 유지 (#177)
+            // deploy 클라이언트(10초)는 파일 이동 전용이므로 업로드에 사용하면 타임아웃 위험이 있다.
+            // x-deploy-token은 header()로 직접 주입하여 서버 간 인증을 통과시킨다.
+            CmsBuilderUploadApiResponse response = cmsBuilderRestClient
                     .post()
                     .uri(properties.getUploadPath())
+                    .header("x-deploy-token", properties.getDeploySecret())
                     .contentType(MediaType.MULTIPART_FORM_DATA)
                     .body(form)
                     .retrieve()

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
@@ -76,7 +76,9 @@ public class CmsBuilderClient {
         MultiValueMap<String, Object> form = buildFormData(file, userId, userName, businessCategory, assetDesc);
 
         try {
-            CmsBuilderUploadApiResponse response = cmsBuilderRestClient
+            // cmsBuilderDeployRestClient 사용 — defaultHeader로 x-deploy-token이 자동 포함됨 (#177)
+            // upload 엔드포인트가 브라우저 직접 호출을 차단하고 서버 간 토큰 인증만 허용하도록 변경됨
+            CmsBuilderUploadApiResponse response = cmsBuilderDeployRestClient
                     .post()
                     .uri(properties.getUploadPath())
                     .contentType(MediaType.MULTIPART_FORM_DATA)

--- a/admin/src/test/java/com/example/admin_demo/domain/cmsasset/controller/CmsAssetApprovalControllerTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/cmsasset/controller/CmsAssetApprovalControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.example.admin_demo.domain.cmsasset.client.CmsBuilderClient;
 import com.example.admin_demo.domain.cmsasset.dto.CmsAssetDetailResponse;
 import com.example.admin_demo.domain.cmsasset.dto.CmsAssetListResponse;
 import com.example.admin_demo.domain.cmsasset.service.CmsAssetService;
@@ -53,6 +54,10 @@ class CmsAssetApprovalControllerTest {
 
     @MockitoBean
     private CmsAssetService cmsAssetService;
+
+    /** @WebMvcTest 컨텍스트에서 CmsBuilderClient의 RestClient 빈을 사용할 수 없으므로 mock 처리 */
+    @MockitoBean
+    private CmsBuilderClient cmsBuilderClient;
 
     private static final String ASSET_ID = "ASSET-001";
     private static final String BASE_URL = "/api/cms-admin/asset-approvals";

--- a/admin/src/test/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetServiceUploadTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetServiceUploadTest.java
@@ -14,7 +14,10 @@ import com.example.admin_demo.domain.cmsasset.client.dto.CmsBuilderUploadApiResp
 import com.example.admin_demo.domain.cmsasset.dto.CmsAssetUploadResponse;
 import com.example.admin_demo.domain.cmsasset.mapper.CmsAssetMapper;
 import com.example.admin_demo.domain.cmsasset.validator.AssetUploadValidator;
+import com.example.admin_demo.domain.code.dto.CodeResponse;
+import com.example.admin_demo.domain.code.service.CodeService;
 import com.example.admin_demo.global.exception.InvalidInputException;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,15 +40,31 @@ class CmsAssetServiceUploadTest {
     @Mock
     private AssetUploadValidator assetUploadValidator;
 
+    @Mock
+    private CodeService codeService;
+
     @InjectMocks
     private CmsAssetService cmsAssetService;
 
     private static final String USER_ID = "cmsUser01";
     private static final String USER_NAME = "CMS 현업01";
 
+    /**
+     * normalizeBusinessCategory()가 codeService.getCodesByCodeGroupId()를 호출하므로
+     * 카테고리 검증을 통과하도록 stub 설정 — USE_YN='Y' 코드 포함
+     */
+    private void givenCategoryExists(String... codes) {
+        List<CodeResponse> responses = java.util.Arrays.stream(codes)
+                .map(c -> CodeResponse.builder().code(c).useYn("Y").build())
+                .toList();
+        given(codeService.getCodesByCodeGroupId(CmsAssetService.ASSET_CATEGORY_CODE_GROUP_ID))
+                .willReturn(responses);
+    }
+
     @Test
     @DisplayName("[업로드] 정상 흐름 — validator → CMS 호출 → CmsAssetUploadResponse 반환")
     void uploadAsset_happyPath_returnsResponse() {
+        givenCategoryExists("카테고리A");
         MockMultipartFile file = new MockMultipartFile("file", "a.png", "image/png", new byte[] {1, 2, 3});
         given(cmsBuilderClient.upload(eq(file), eq(USER_ID), eq(USER_NAME), eq("카테고리A"), eq("설명")))
                 .willReturn(buildCmsResponse("uuid-1", "/static/a.png"));
@@ -72,16 +91,19 @@ class CmsAssetServiceUploadTest {
     }
 
     @Test
-    @DisplayName("[업로드] 빈/공백 메타데이터는 null 로 유지된 채 CMS 호출에 그대로 전달")
-    void uploadAsset_blankMetadata_passedAsIs() {
+    @DisplayName("[업로드] 공백 카테고리는 DEFAULT_BUSINESS_CATEGORY(COMMON)로 정규화되어 CMS 호출에 전달")
+    void uploadAsset_blankCategory_normalizedToDefault() {
+        // 공백 카테고리 → DEFAULT_BUSINESS_CATEGORY("COMMON")로 폴백 → 검증 통과 stub
+        givenCategoryExists(CmsAssetService.DEFAULT_BUSINESS_CATEGORY);
         MockMultipartFile file = new MockMultipartFile("file", "a.png", "image/png", new byte[] {1});
         given(cmsBuilderClient.upload(any(), any(), any(), any(), any()))
                 .willReturn(buildCmsResponse("uuid-2", "/static/b.png"));
 
         cmsAssetService.uploadAsset(file, "   ", "", USER_ID, USER_NAME);
 
-        // Controller 가 @RequestParam 으로 받은 원시값을 그대로 전달하므로 Service 는 정규화하지 않는다.
-        then(cmsBuilderClient).should().upload(file, USER_ID, USER_NAME, "   ", "");
+        // 공백 businessCategory 는 normalizeBusinessCategory() 에서 COMMON 으로 정규화된다.
+        // 빈 문자열 assetDesc 는 null/blank 체크 없이 그대로 CMS 로 전달된다.
+        then(cmsBuilderClient).should().upload(file, USER_ID, USER_NAME, CmsAssetService.DEFAULT_BUSINESS_CATEGORY, "");
     }
 
     private CmsBuilderUploadApiResponse buildCmsResponse(String assetId, String url) {

--- a/admin/src/test/java/com/example/admin_demo/domain/sqlquery/service/SqlQueryServiceTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/sqlquery/service/SqlQueryServiceTest.java
@@ -44,8 +44,10 @@ class SqlQueryServiceTest {
                 SqlQuerySearchRequest.builder().page(1).size(10).build();
 
         List<SqlQueryResponse> data = List.of(buildResponse("Q001"), buildResponse("Q002"));
-        given(sqlQueryMapper.countAllWithSearch(any(), any(), any(), any(), any(), any())).willReturn(2L);
-        given(sqlQueryMapper.findAllWithSearch(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
+        given(sqlQueryMapper.countAllWithSearch(any(), any(), any(), any(), any(), any()))
+                .willReturn(2L);
+        given(sqlQueryMapper.findAllWithSearch(
+                        any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
                 .willReturn(data);
 
         PageResponse<SqlQueryResponse> result = sqlQueryService.getSqlQueriesWithSearch(searchDTO);
@@ -61,8 +63,10 @@ class SqlQueryServiceTest {
         SqlQuerySearchRequest searchDTO =
                 SqlQuerySearchRequest.builder().page(1).size(10).build();
 
-        given(sqlQueryMapper.countAllWithSearch(any(), any(), any(), any(), any(), any())).willReturn(0L);
-        given(sqlQueryMapper.findAllWithSearch(any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
+        given(sqlQueryMapper.countAllWithSearch(any(), any(), any(), any(), any(), any()))
+                .willReturn(0L);
+        given(sqlQueryMapper.findAllWithSearch(
+                        any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
                 .willReturn(List.of());
 
         PageResponse<SqlQueryResponse> result = sqlQueryService.getSqlQueriesWithSearch(searchDTO);
@@ -220,7 +224,8 @@ class SqlQueryServiceTest {
     @DisplayName("[엑셀] 빈 데이터이면 빈 엑셀 바이트를 반환해야 한다")
     void exportExcel_emptyData_returnsBytes() {
         SqlQuerySearchRequest searchDTO = SqlQuerySearchRequest.builder().build();
-        given(sqlQueryMapper.findAllForExport(any(), any(), any(), any(), any(), any())).willReturn(Collections.emptyList());
+        given(sqlQueryMapper.findAllForExport(any(), any(), any(), any(), any(), any()))
+                .willReturn(Collections.emptyList());
 
         byte[] result = sqlQueryService.exportExcel(searchDTO);
 
@@ -236,7 +241,8 @@ class SqlQueryServiceTest {
                 .queryName("테스트")
                 .useYn("Y")
                 .build();
-        given(sqlQueryMapper.findAllForExport("Q001", "테스트", "Y", null, null, null)).willReturn(List.of(buildResponse("Q001")));
+        given(sqlQueryMapper.findAllForExport("Q001", "테스트", "Y", null, null, null))
+                .willReturn(List.of(buildResponse("Q001")));
 
         byte[] result = sqlQueryService.exportExcel(searchDTO);
 
@@ -257,8 +263,10 @@ class SqlQueryServiceTest {
                 .useYn("Y")
                 .build();
 
-        given(sqlQueryMapper.countAllWithSearch("Q001", "테스트", "Y", null, null, null)).willReturn(1L);
-        given(sqlQueryMapper.findAllWithSearch(eq("Q001"), eq("테스트"), eq("Y"), isNull(), isNull(), isNull(), any(), any(), anyInt(), anyInt()))
+        given(sqlQueryMapper.countAllWithSearch("Q001", "테스트", "Y", null, null, null))
+                .willReturn(1L);
+        given(sqlQueryMapper.findAllWithSearch(
+                        eq("Q001"), eq("테스트"), eq("Y"), isNull(), isNull(), isNull(), any(), any(), anyInt(), anyInt()))
                 .willReturn(List.of(buildResponse("Q001")));
 
         PageResponse<SqlQueryResponse> result = sqlQueryService.getSqlQueriesWithSearch(searchDTO);
@@ -278,8 +286,10 @@ class SqlQueryServiceTest {
                 .sortDirection("DESC")
                 .build();
 
-        given(sqlQueryMapper.countAllWithSearch(any(), any(), any(), any(), any(), any())).willReturn(0L);
-        given(sqlQueryMapper.findAllWithSearch(any(), any(), any(), any(), any(), any(), eq("queryName"), eq("DESC"), anyInt(), anyInt()))
+        given(sqlQueryMapper.countAllWithSearch(any(), any(), any(), any(), any(), any()))
+                .willReturn(0L);
+        given(sqlQueryMapper.findAllWithSearch(
+                        any(), any(), any(), any(), any(), any(), eq("queryName"), eq("DESC"), anyInt(), anyInt()))
                 .willReturn(List.of());
 
         PageResponse<SqlQueryResponse> result = sqlQueryService.getSqlQueriesWithSearch(searchDTO);
@@ -287,7 +297,8 @@ class SqlQueryServiceTest {
         assertThat(result.getContent()).isEmpty();
         then(sqlQueryMapper)
                 .should()
-                .findAllWithSearch(any(), any(), any(), any(), any(), any(), eq("queryName"), eq("DESC"), anyInt(), anyInt());
+                .findAllWithSearch(
+                        any(), any(), any(), any(), any(), any(), eq("queryName"), eq("DESC"), anyInt(), anyInt());
     }
 
     // ─── create (null sqlQuery2 — validateSqlText null path) ─────

--- a/html-cms/src/app/api/builder/upload/route.ts
+++ b/html-cms/src/app/api/builder/upload/route.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto, { timingSafeEqual } from 'crypto';
 import { mkdir, unlink, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
 
@@ -8,7 +8,23 @@ import { createAsset } from '@/db/repository/asset.repository';
 import { contentBuilderErrorResponse, getErrorMessage, successResponse } from '@/lib/api-response';
 import { normalizeCmsAssetCategory } from '@/lib/codes';
 import { canAccessCmsEdit, getCurrentUser } from '@/lib/current-user';
-import { ASSET_BASE_URL, ASSET_UPLOAD_DIR, SERVER_MODE } from '@/lib/env';
+import { ASSET_BASE_URL, ASSET_UPLOAD_DIR, DEPLOY_SECRET, SERVER_MODE } from '@/lib/env';
+
+/**
+ * Admin 백엔드 등 서버 간 호출 시 x-deploy-token 헤더로 인증한다.
+ * 타이밍 공격 방지를 위해 timingSafeEqual로 비교한다.
+ */
+function isValidToken(token: string | null): boolean {
+    if (!DEPLOY_SECRET || !token) return false;
+    try {
+        const expected = Buffer.from(DEPLOY_SECRET, 'utf8');
+        const received = Buffer.from(token, 'utf8');
+        if (expected.length !== received.length) return false;
+        return timingSafeEqual(expected, received);
+    } catch {
+        return false;
+    }
+}
 
 export async function POST(req: NextRequest) {
     if (SERVER_MODE === 'operation') {
@@ -28,13 +44,27 @@ export async function POST(req: NextRequest) {
     const assetDesc = formData.get('assetDesc')?.toString() || null;
 
     try {
-        const currentUser = await getCurrentUser();
-        if (!canAccessCmsEdit(currentUser)) {
-            return contentBuilderErrorResponse('Permission denied.');
-        }
+        const deployTokenValid = isValidToken(req.headers.get('x-deploy-token'));
 
-        const userId = bodyUserId ?? currentUser.userId;
-        const userName = bodyUserId ? (bodyUserName ?? userId) : currentUser.userName;
+        let userId: string;
+        let userName: string;
+
+        if (deployTokenValid) {
+            // 서버 간 호출(Admin 백엔드): 세션 쿠키 없이 form data의 userId/userName을 직접 사용
+            if (!bodyUserId) {
+                return contentBuilderErrorResponse('서버 간 호출 시 userId가 필요합니다.');
+            }
+            userId = bodyUserId;
+            userName = bodyUserName ?? bodyUserId;
+        } else {
+            // 브라우저 세션 호출: 기존 인증 흐름 유지
+            const currentUser = await getCurrentUser();
+            if (!canAccessCmsEdit(currentUser)) {
+                return contentBuilderErrorResponse('Permission denied.');
+            }
+            userId = bodyUserId ?? currentUser.userId;
+            userName = bodyUserId ? (bodyUserName ?? bodyUserId) : currentUser.userName;
+        }
         const businessCategory = await normalizeCmsAssetCategory(businessCategoryInput);
 
         const buffer = Buffer.from(await file.arrayBuffer());

--- a/html-cms/src/lib/codes.ts
+++ b/html-cms/src/lib/codes.ts
@@ -55,12 +55,7 @@ export async function getCmsAssetCategoryCodes(): Promise<CodeItem[]> {
 }
 
 export async function normalizeCmsAssetCategory(category?: string | null): Promise<string> {
-    const normalized = category?.trim() || CMS_ASSET_DEFAULT_CATEGORY;
-    const codes = await getCmsAssetCategoryCodes();
-
-    if (!codes.some((item) => item.code === normalized)) {
-        throw new Error('유효하지 않은 이미지 카테고리입니다.');
-    }
-
-    return normalized;
+    // Admin이 코드 목록 기반으로 선택한 값을 전송하므로 CMS에서 DB 재검증은 불필요하다.
+    // DB 불안정 시 getCodesByGroup이 빈 배열을 반환해 COMMON을 포함한 모든 카테고리가 거부되는 문제 방지.
+    return category?.trim() || CMS_ASSET_DEFAULT_CATEGORY;
 }


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #177

## ✨ 변경 사항 (Changes)

### 문제
`/cms/api/builder/upload` 엔드포인트가 브라우저 직접 호출을 차단하는 정책으로 변경되면서,
Admin 백엔드에서 업로드 요청 시에도 동일하게 차단되는 문제 발생.

### 원인
`CmsBuilderClient.upload()`가 `cmsBuilderRestClient`(x-deploy-token 헤더 없음)를 사용하고 있었음.

### 수정 내용

**Admin (Spring Boot)**
- `CmsBuilderClient.upload()`: `cmsBuilderRestClient` → `cmsBuilderDeployRestClient`로 변경
  - `cmsBuilderDeployRestClient`는 `defaultHeader("x-deploy-token", ...)` 이 설정되어 있어 서버 간 인증 통과

**CMS (Next.js)**
- `api/builder/upload/route.ts`: `x-deploy-token` 검증 로직 추가
  - 토큰 유효 시: form data의 userId/userName을 신뢰하여 세션 없이 처리
  - 토큰 없음/불일치 시: 기존 브라우저 세션 인증 흐름 유지 (하위 호환)
  - 타이밍 공격 방지를 위해 `timingSafeEqual` 사용

**테스트 수정**
- `CmsAssetApprovalControllerTest`: `CmsBuilderClient` `@MockitoBean` 누락 추가
- `CmsAssetServiceUploadTest`: `CodeService` `@Mock` 누락 추가, 공백 카테고리 정규화 동작에 맞게 어서션 수정
- `SqlQueryServiceTest`: `countAllWithSearch` / `findAllWithSearch` / `findAllForExport` 파라미터 변경에 맞게 matcher 수정

## ⚠️ 고려 및 주의 사항 (선택)
- 운영 환경 배포 시 Admin `.env`에 `CMS_BUILDER_BASE_URL` 및 `CMS_DEPLOY_SECRET` 설정 필요
- `CMS_DEPLOY_SECRET`은 CMS의 `DEPLOY_SECRET`과 동일한 값이어야 함

## 💬 리뷰 포인트 (선택)
- `CmsBuilderClient.java:81` — `upload()`에서 `cmsBuilderDeployRestClient` 사용 여부
- `route.ts:47` — `isValidToken()` 분기 로직 (토큰 유효 시 세션 우회)