### PR TITLE
fix #179: cms 에디터 화면 - 이미지 업로드 모달 버그 수정 및 기능 통일

### DIFF
--- a/html-cms/src/app/api/assets/route.ts
+++ b/html-cms/src/app/api/assets/route.ts
@@ -41,6 +41,8 @@ export async function GET(req: NextRequest) {
         const category = searchParams.get('category') || undefined;
         const search = searchParams.get('search') || undefined;
         const assetState = parseAssetState(searchParams.get('assetState'));
+        // 에디터 이미지 picker(/cms/files)는 배포 완료된 자산만 노출 — totalCount 정합성 때문에 서버 필터로 처리
+        const deployedOnly = searchParams.get('deployedOnly') === 'true';
 
         const { list, totalCount } = await getAssetList({
             businessCategory: category,
@@ -48,6 +50,7 @@ export async function GET(req: NextRequest) {
             search,
             page,
             pageSize,
+            deployedOnly,
         });
 
         const assets = list.map((a) => ({

--- a/html-cms/src/components/edit/EditClient.tsx
+++ b/html-cms/src/components/edit/EditClient.tsx
@@ -36,6 +36,7 @@ import { type BrandTheme } from '@/data/brand-themes';
 import ko from '@/data/ko';
 import useToast from '@/hooks/useToast';
 import { nextApi } from '@/lib/api-url';
+import { attachResizeHandles, centerInitialBox } from '@/lib/resizable-box';
 
 // 기본 블록 타입 — DB SPW_CMS_COMPONENT에서 로드
 export interface BasicBlock {
@@ -342,6 +343,8 @@ export default function EditClient({
     // 별도 브라우저 창(window.open) 대신 에디터 DOM 내부 모달로 표시해
     // 주소창 노출·팝업 차단·별개 창 수명 문제를 제거한다.
     const [imagePickerOpen, setImagePickerOpen] = useState(false);
+    // 모달 박스 ref — 초기 중앙 배치와 8방향 드래그 리사이즈 핸들 부착 대상
+    const imagePickerBoxRef = useRef<HTMLDivElement>(null);
 
     // ── 현재 탭의 뷰 모드 (생성 시 결정, 이후 변경 불가) ─────────────────
     const currentTab = tabs.find((t) => t.id === bank);
@@ -1905,6 +1908,17 @@ export default function EditClient({
     // → 클릭을 캡처 단계에서 가로채서 승인 이미지 브라우저(/files) 모달로 우회
     const imageReplaceTargetRef = useRef<HTMLImageElement | null>(null);
 
+    // 이미지 picker 모달이 열릴 때 초기 크기·중앙 배치 + 8방향 리사이즈 핸들 부착
+    useEffect(() => {
+        if (!imagePickerOpen) return;
+        const box = imagePickerBoxRef.current;
+        if (!box) return;
+
+        centerInitialBox(box, { width: 1280, height: 900 });
+        const detach = attachResizeHandles(box, { minWidth: 480, minHeight: 360 });
+        return detach;
+    }, [imagePickerOpen]);
+
     useEffect(() => {
         const handleFileInputClick = (e: MouseEvent) => {
             const target = e.target as HTMLElement;
@@ -2871,11 +2885,11 @@ export default function EditClient({
             {/* ── 이미지 교체 picker 모달 (iframe으로 /cms/files 렌더) ──
                 - #fileEmbedImage 클릭 인터셉트 시 열림
                 - iframe 내부에서 완료/닫기 시 postMessage로 모달 닫기 요청 수신
-                - 반응형 크기: 기본 1280×900, 화면이 좁으면 95vw/95vh로 제한
+                - 초기 크기: 1280×900 (화면이 좁으면 95vw/95vh로 축소), 이후 8방향 드래그로 리사이즈 가능
                 - z-index: 편집 패널(99998/99999)과 TableEditorModal(100001)보다 위로 → 1,000,000 */}
             {imagePickerOpen && (
                 <div
-                    className="fixed inset-0 z-[1000000] flex items-center justify-center bg-black/50"
+                    className="fixed inset-0 z-[1000000] bg-black/50"
                     onClick={(e) => {
                         // 바깥(오버레이) 클릭 시 닫기 — 내부 iframe 클릭은 제외
                         if (e.target === e.currentTarget) {
@@ -2884,7 +2898,11 @@ export default function EditClient({
                         }
                     }}
                 >
-                    <div className="relative h-[900px] max-h-[95vh] w-[1280px] max-w-[95vw] overflow-hidden rounded-lg bg-white shadow-xl">
+                    <div
+                        ref={imagePickerBoxRef}
+                        // 절대 위치 + 초기 중앙 배치는 useEffect에서 계산
+                        className="absolute overflow-hidden rounded-lg bg-white shadow-xl"
+                    >
                         <iframe src={nextApi('/files')} className="h-full w-full border-0" title="이미지 선택" />
                     </div>
                 </div>

--- a/html-cms/src/components/edit/EditClient.tsx
+++ b/html-cms/src/components/edit/EditClient.tsx
@@ -2871,10 +2871,11 @@ export default function EditClient({
             {/* ── 이미지 교체 picker 모달 (iframe으로 /cms/files 렌더) ──
                 - #fileEmbedImage 클릭 인터셉트 시 열림
                 - iframe 내부에서 완료/닫기 시 postMessage로 모달 닫기 요청 수신
-                - 반응형 크기: 기본 1280×900, 화면이 좁으면 95vw/95vh로 제한 */}
+                - 반응형 크기: 기본 1280×900, 화면이 좁으면 95vw/95vh로 제한
+                - z-index: 편집 패널(99998/99999)과 TableEditorModal(100001)보다 위로 → 1,000,000 */}
             {imagePickerOpen && (
                 <div
-                    className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50"
+                    className="fixed inset-0 z-[1000000] flex items-center justify-center bg-black/50"
                     onClick={(e) => {
                         // 바깥(오버레이) 클릭 시 닫기 — 내부 iframe 클릭은 제외
                         if (e.target === e.currentTarget) {

--- a/html-cms/src/components/edit/EditClient.tsx
+++ b/html-cms/src/components/edit/EditClient.tsx
@@ -2874,11 +2874,7 @@ export default function EditClient({
                     }}
                 >
                     <div className="relative h-[900px] max-h-[95vh] w-[1280px] max-w-[95vw] overflow-hidden rounded-lg bg-white shadow-xl">
-                        <iframe
-                            src={nextApi('/files')}
-                            className="h-full w-full border-0"
-                            title="이미지 선택"
-                        />
+                        <iframe src={nextApi('/files')} className="h-full w-full border-0" title="이미지 선택" />
                     </div>
                 </div>
             )}

--- a/html-cms/src/components/edit/EditClient.tsx
+++ b/html-cms/src/components/edit/EditClient.tsx
@@ -338,6 +338,11 @@ export default function EditClient({
     // 슬라이드 편집 모달 (promo-banner / product-gallery)
     const [slideEditorBlock, setSlideEditorBlock] = useState<HTMLElement | null>(null);
 
+    // 이미지 교체 picker 모달 — #fileEmbedImage 인터셉트 시 /cms/files를 iframe으로 띄움
+    // 별도 브라우저 창(window.open) 대신 에디터 DOM 내부 모달로 표시해
+    // 주소창 노출·팝업 차단·별개 창 수명 문제를 제거한다.
+    const [imagePickerOpen, setImagePickerOpen] = useState(false);
+
     // ── 현재 탭의 뷰 모드 (생성 시 결정, 이후 변경 불가) ─────────────────
     const currentTab = tabs.find((t) => t.id === bank);
     const viewMode: ViewMode = normalizeViewMode(currentTab?.viewMode);
@@ -1897,7 +1902,7 @@ export default function EditClient({
     // ── ContentBuilder 기본 "이미지 변경" 버튼 인터셉트 ─────────────
     // ContentBuilder의 `#fileEmbedImage` (이미지 블록·헤더 이미지 변경) 는
     // filePicker/imageSelect 옵션을 경유하지 않고 OS 파일 선택창을 직접 띄움.
-    // → 클릭을 캡처 단계에서 가로채서 승인 이미지 브라우저(/files) 팝업으로 우회
+    // → 클릭을 캡처 단계에서 가로채서 승인 이미지 브라우저(/files) 모달로 우회
     const imageReplaceTargetRef = useRef<HTMLImageElement | null>(null);
 
     useEffect(() => {
@@ -1915,8 +1920,8 @@ export default function EditClient({
             const activeImg = (builderRef.current as any)?.activeImage as HTMLImageElement | null;
             imageReplaceTargetRef.current = activeImg ?? null;
 
-            // 팝업으로 /files 오픈 (postMessage 타겟은 window.opener 경로 사용)
-            window.open(nextApi('/files'), 'spw-image-browser', 'width=1280,height=900,scrollbars=yes,resizable=yes');
+            // iframe 모달로 /files 오픈 (postMessage 타겟은 window.parent 경로 사용)
+            setImagePickerOpen(true);
         };
 
         document.addEventListener('click', handleFileInputClick, true);
@@ -1928,11 +1933,13 @@ export default function EditClient({
     // - ASSETS_SELECTED: 다건 — 완료 버튼 경유
     //   · 교체 모드 (imageReplaceTargetRef 가 있을 때): 첫 URL 로 activeImage src 교체
     //   · 삽입 모드: selectAsset 루프 호출
+    // - PICKER_CLOSE: iframe 모달 내부 닫기 버튼에서 부모에게 모달 종료 요청
     useEffect(() => {
         const handleMessage = (event: MessageEvent) => {
             switch (event.data.type) {
                 case 'ASSET_SELECTED':
                     builderRef.current?.selectAsset(event.data.url);
+                    setImagePickerOpen(false);
                     window.focus();
                     break;
                 case 'ASSETS_SELECTED': {
@@ -1950,9 +1957,15 @@ export default function EditClient({
                         // 일반 삽입 모드
                         urls.forEach((url) => builderRef.current?.selectAsset(url));
                     }
+                    setImagePickerOpen(false);
                     window.focus();
                     break;
                 }
+                case 'PICKER_CLOSE':
+                    // iframe 내부 AssetBrowser의 닫기(X) 버튼 → 모달 종료
+                    imageReplaceTargetRef.current = null;
+                    setImagePickerOpen(false);
+                    break;
                 default:
                     break;
             }
@@ -2844,6 +2857,31 @@ export default function EditClient({
 
             {/* ── 새 페이지 추가 모달 ── */}
             {showAddTab && <CreatePageModal onClose={() => setShowAddTab(false)} canWrite={canWrite} />}
+
+            {/* ── 이미지 교체 picker 모달 (iframe으로 /cms/files 렌더) ──
+                - #fileEmbedImage 클릭 인터셉트 시 열림
+                - iframe 내부에서 완료/닫기 시 postMessage로 모달 닫기 요청 수신
+                - 반응형 크기: 기본 1280×900, 화면이 좁으면 95vw/95vh로 제한 */}
+            {imagePickerOpen && (
+                <div
+                    className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50"
+                    onClick={(e) => {
+                        // 바깥(오버레이) 클릭 시 닫기 — 내부 iframe 클릭은 제외
+                        if (e.target === e.currentTarget) {
+                            imageReplaceTargetRef.current = null;
+                            setImagePickerOpen(false);
+                        }
+                    }}
+                >
+                    <div className="relative h-[900px] max-h-[95vh] w-[1280px] max-w-[95vw] overflow-hidden rounded-lg bg-white shadow-xl">
+                        <iframe
+                            src={nextApi('/files')}
+                            className="h-full w-full border-0"
+                            title="이미지 선택"
+                        />
+                    </div>
+                </div>
+            )}
 
             {infoToast && <Toast message={infoToast} />}
         </>

--- a/html-cms/src/components/edit/EditClient.tsx
+++ b/html-cms/src/components/edit/EditClient.tsx
@@ -1934,15 +1934,23 @@ export default function EditClient({
     //   · 교체 모드 (imageReplaceTargetRef 가 있을 때): 첫 URL 로 activeImage src 교체
     //   · 삽입 모드: selectAsset 루프 호출
     // - PICKER_CLOSE: iframe 모달 내부 닫기 버튼에서 부모에게 모달 종료 요청
+    //
+    // cms-file-picker 유틸(EventBanner/PopupBanner 등 6개 에디터가 사용)이 동시에
+    // 같은 메시지를 수신하므로, 유틸 모달이 활성이면 이 리스너는 개입하지 않는다.
+    // (그렇지 않으면 슬라이드 업데이트 + 캔버스에 이미지가 추가 삽입되는 이중 처리 발생)
     useEffect(() => {
+        const isCmsFilePickerActive = () => document.getElementById('spw-cms-file-picker-modal') !== null;
+
         const handleMessage = (event: MessageEvent) => {
             switch (event.data.type) {
                 case 'ASSET_SELECTED':
+                    if (isCmsFilePickerActive()) break;
                     builderRef.current?.selectAsset(event.data.url);
                     setImagePickerOpen(false);
                     window.focus();
                     break;
                 case 'ASSETS_SELECTED': {
+                    if (isCmsFilePickerActive()) break;
                     const urls: string[] = Array.isArray(event.data.urls) ? event.data.urls : [];
                     const replaceTarget = imageReplaceTargetRef.current;
 
@@ -1963,6 +1971,8 @@ export default function EditClient({
                 }
                 case 'PICKER_CLOSE':
                     // iframe 내부 AssetBrowser의 닫기(X) 버튼 → 모달 종료
+                    // 유틸 모달이면 유틸이 자체 cleanup하므로 개입하지 않는다.
+                    if (isCmsFilePickerActive()) break;
                     imageReplaceTargetRef.current = null;
                     setImagePickerOpen(false);
                     break;

--- a/html-cms/src/components/edit/EditClient.tsx
+++ b/html-cms/src/components/edit/EditClient.tsx
@@ -1919,6 +1919,10 @@ export default function EditClient({
         return detach;
     }, [imagePickerOpen]);
 
+    // picker iframe 참조 — message 리스너에서 event.source 비교로 "이 모달에서 온 메시지"인지 식별
+    // (DOM 존재 여부 판별은 리스너 실행 순서·DOM 조작 타이밍 레이스에 취약 → event.source 비교가 안전)
+    const imagePickerIframeRef = useRef<HTMLIFrameElement>(null);
+
     useEffect(() => {
         const handleFileInputClick = (e: MouseEvent) => {
             const target = e.target as HTMLElement;
@@ -1946,47 +1950,55 @@ export default function EditClient({
     // - ASSET_SELECTED: 단건 삽입 (하위 호환)
     // - ASSETS_SELECTED: 다건 — 완료 버튼 경유
     //   · 교체 모드 (imageReplaceTargetRef 가 있을 때): 첫 URL 로 activeImage src 교체
-    //   · 삽입 모드: selectAsset 루프 호출
+    //   · 삽입 모드: selectAsset 루프 호출 (ContentBuilder 내장 filePicker/imageSelect 경로)
     // - PICKER_CLOSE: iframe 모달 내부 닫기 버튼에서 부모에게 모달 종료 요청
     //
-    // cms-file-picker 유틸(EventBanner/PopupBanner 등 6개 에디터가 사용)이 동시에
-    // 같은 메시지를 수신하므로, 유틸 모달이 활성이면 이 리스너는 개입하지 않는다.
-    // (그렇지 않으면 슬라이드 업데이트 + 캔버스에 이미지가 추가 삽입되는 이중 처리 발생)
+    // 메시지 출처 식별은 event.source 비교로 처리한다. 이전에는 cms-file-picker 유틸 모달의
+    // DOM 존재 여부(getElementById)로 스킵 판단을 했는데, 이는 리스너 실행 순서·DOM 조작
+    // 타이밍 레이스에 취약해 안전하지 않다. 현재 구현은:
+    //   1) event.source 가 cms-file-picker 유틸 iframe 이면 즉시 스킵 (유틸 자체 리스너가 처리)
+    //   2) isOwnPicker 플래그(이 EditClient 의 React 모달 iframe 에서 온 메시지인지)로
+    //      모달 상태 변경(setImagePickerOpen)·PICKER_CLOSE 처리를 범위 한정
+    //   3) ASSETS_SELECTED 의 selectAsset 삽입 로직은 ContentBuilder 내장 filePicker 에서
+    //      온 경우에도 동작해야 하므로 소스를 더 좁히지 않는다
     useEffect(() => {
-        const isCmsFilePickerActive = () => document.getElementById('spw-cms-file-picker-modal') !== null;
-
         const handleMessage = (event: MessageEvent) => {
+            // cms-file-picker 유틸 모달의 iframe 에서 온 메시지는 유틸이 단독 처리 — 여기서는 무시
+            const utilModalEl = document.getElementById('spw-cms-file-picker-modal');
+            const utilIframe = utilModalEl?.querySelector('iframe') as HTMLIFrameElement | null;
+            if (utilIframe && event.source === utilIframe.contentWindow) return;
+
+            // 이 모달(EditClient) 의 iframe 에서 온 메시지인지 — setImagePickerOpen·PICKER_CLOSE 범위 한정용
+            const isOwnPicker = event.source === imagePickerIframeRef.current?.contentWindow;
+
             switch (event.data.type) {
                 case 'ASSET_SELECTED':
-                    if (isCmsFilePickerActive()) break;
                     builderRef.current?.selectAsset(event.data.url);
-                    setImagePickerOpen(false);
+                    if (isOwnPicker) setImagePickerOpen(false);
                     window.focus();
                     break;
                 case 'ASSETS_SELECTED': {
-                    if (isCmsFilePickerActive()) break;
                     const urls: string[] = Array.isArray(event.data.urls) ? event.data.urls : [];
                     const replaceTarget = imageReplaceTargetRef.current;
 
                     if (replaceTarget && urls[0]) {
-                        // 이미지 교체 모드
+                        // 이미지 교체 모드 — #fileEmbedImage 인터셉트로 연 EditClient 모달 경로
                         replaceTarget.setAttribute('src', urls[0]);
                         imageReplaceTargetRef.current = null;
                         // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ContentBuilder 내부 onChange
                         const onChange = (builderRef.current as any)?.opts?.onChange;
                         if (typeof onChange === 'function') onChange();
                     } else {
-                        // 일반 삽입 모드
+                        // 일반 삽입 모드 — ContentBuilder 내장 filePicker/imageSelect 경유 또는 activeImg 부재 케이스
                         urls.forEach((url) => builderRef.current?.selectAsset(url));
                     }
-                    setImagePickerOpen(false);
+                    if (isOwnPicker) setImagePickerOpen(false);
                     window.focus();
                     break;
                 }
                 case 'PICKER_CLOSE':
-                    // iframe 내부 AssetBrowser의 닫기(X) 버튼 → 모달 종료
-                    // 유틸 모달이면 유틸이 자체 cleanup하므로 개입하지 않는다.
-                    if (isCmsFilePickerActive()) break;
+                    // iframe 내부 AssetBrowser 의 X 버튼 → 이 모달에 한해서만 종료 처리
+                    if (!isOwnPicker) break;
                     imageReplaceTargetRef.current = null;
                     setImagePickerOpen(false);
                     break;
@@ -2903,7 +2915,12 @@ export default function EditClient({
                         // 절대 위치 + 초기 중앙 배치는 useEffect에서 계산
                         className="absolute overflow-hidden rounded-lg bg-white shadow-xl"
                     >
-                        <iframe src={nextApi('/files')} className="h-full w-full border-0" title="이미지 선택" />
+                        <iframe
+                            ref={imagePickerIframeRef}
+                            src={nextApi('/files')}
+                            className="h-full w-full border-0"
+                            title="이미지 선택"
+                        />
                     </div>
                 </div>
             )}

--- a/html-cms/src/components/files/AssetBrowser.tsx
+++ b/html-cms/src/components/files/AssetBrowser.tsx
@@ -32,16 +32,6 @@ function extractFolderName(path: string | null): string {
     return parts[parts.length - 2];
 }
 
-/**
- * 승인 완료 + 배포까지 끝난 자산인지 판별.
- * deploy 흐름이 파일을 `deployed/` 하위로 이동시키므로 경로에 `/deployed/`가 포함되어야 한다.
- * 승인만 되고 아직 배포 전(= 파일이 `uploads/`에 남아 있는) 자산은 /cms/files 선택 모달에 노출하지 않는다.
- */
-function isDeployedAsset(asset: { path: string | null }): boolean {
-    if (!asset.path) return false;
-    return asset.path.replace(/\\/g, '/').includes('/deployed/');
-}
-
 interface CodeItem {
     code: string;
     codeName: string;
@@ -88,24 +78,24 @@ export default function AssetBrowser({ assetOrigin = '' }: AssetBrowserProps) {
     // 향후 여러 폴더로 나뉠 때 API 단에서 경로 필터를 추가하면 이 상태를 활용한다.
     const [folder, setFolder] = useState('');
 
-    // 승인+배포까지 완료된 자산만 대상 (경로에 /deployed/ 포함) — uploads/ 는 제외
-    const deployedAssets = useMemo(() => assets.filter(isDeployedAsset), [assets]);
+    // 승인+배포 필터는 서버(`deployedOnly=true`)가 담당하므로 클라이언트에선 추가 필터 없이 그대로 사용.
+    // (이전에는 클라가 isDeployedAsset 으로 재필터 → 서버 totalCount 와 실제 표시 건수가 어긋나는 버그가 있었음)
 
-    // 현재 페이지 배포 자산에서 추출한 distinct 폴더명 — 사이드바 리스트 소스
+    // 현재 페이지 자산에서 추출한 distinct 폴더명 — 사이드바 리스트 소스
     const folders = useMemo(() => {
         const set = new Set<string>();
-        deployedAssets.forEach((asset) => {
+        assets.forEach((asset) => {
             const name = extractFolderName(asset.path);
             if (name) set.add(name);
         });
         return Array.from(set).sort();
-    }, [deployedAssets]);
+    }, [assets]);
 
     // 선택된 폴더가 있으면 현재 페이지 내에서 클라이언트 필터 — 다중 폴더 대비 placeholder 동작
     const visibleAssets = useMemo(() => {
-        if (!folder) return deployedAssets;
-        return deployedAssets.filter((asset) => extractFolderName(asset.path) === folder);
-    }, [deployedAssets, folder]);
+        if (!folder) return assets;
+        return assets.filter((asset) => extractFolderName(asset.path) === folder);
+    }, [assets, folder]);
 
     const categoryMap = useMemo(
         () =>
@@ -185,6 +175,8 @@ export default function AssetBrowser({ assetOrigin = '' }: AssetBrowserProps) {
                 page: String(nextPage),
                 pageSize: String(pageSize),
                 assetState: 'APPROVED',
+                // 배포 완료(ASSET_URL LIKE '/deployed/%') 자산만 반환 — totalCount 도 동일 조건 기준
+                deployedOnly: 'true',
             });
 
             if (category) {
@@ -288,14 +280,16 @@ export default function AssetBrowser({ assetOrigin = '' }: AssetBrowserProps) {
     }
 
     return (
-        <div className="flex min-h-screen bg-slate-50">
+        // 루트는 iframe/뷰포트 정확히 맞추기 — 상단 검색 바와 하단 페이지네이션은 고정,
+        // 이미지 그리드만 내부 스크롤되도록 flex column 구조로 고정.
+        <div className="flex h-screen overflow-hidden bg-slate-50">
             {/* ── 좌측 사이드바 — 이미지가 있는 폴더 리스트 ───────────── */}
             <aside
                 className={`shrink-0 overflow-hidden border-r border-slate-200 bg-white transition-[width] duration-300 ease-in-out ${
                     sidebarOpen ? 'w-56' : 'w-0'
                 }`}
             >
-                <div className="w-56 p-4">
+                <div className="h-full w-56 overflow-y-auto p-4">
                     <div className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-500">폴더</div>
                     <ul className="space-y-1">
                         <li>
@@ -343,9 +337,9 @@ export default function AssetBrowser({ assetOrigin = '' }: AssetBrowserProps) {
                 </div>
             </aside>
 
-            <div className="min-w-0 flex-1 px-4 py-6 md:px-8">
+            <div className="flex min-w-0 flex-1 flex-col px-4 py-6 md:px-8">
                 {/* 상단 우측 — 사이드바 토글 햄버거 + 닫기 X */}
-                <div className="mb-3 flex items-center justify-end gap-1">
+                <div className="mb-3 flex shrink-0 items-center justify-end gap-1">
                     <button
                         type="button"
                         onClick={() => setSidebarOpen((prev) => !prev)}
@@ -381,7 +375,7 @@ export default function AssetBrowser({ assetOrigin = '' }: AssetBrowserProps) {
                 </div>
 
                 {/* 검색 조건 카드 — cms-admin/asset-approvals 스타일 */}
-                <div className="mb-3 rounded-md border border-slate-200 bg-white p-2">
+                <div className="mb-3 shrink-0 rounded-md border border-slate-200 bg-white p-2">
                     <div className="flex flex-wrap items-center gap-2">
                         <label className="m-0 text-xs font-medium text-slate-700">카테고리</label>
                         <select
@@ -454,27 +448,28 @@ export default function AssetBrowser({ assetOrigin = '' }: AssetBrowserProps) {
                 </div>
 
                 {/* 건수 */}
-                <div className="mb-3 flex justify-end text-xs text-slate-500">
+                <div className="mb-3 flex shrink-0 justify-end text-xs text-slate-500">
                     <p>
                         총 {totalCount}건, {page} / {totalPages} 페이지
                     </p>
                 </div>
 
-                {loading ? (
-                    <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-12 text-center text-slate-500">
-                        이미지 목록을 불러오는 중입니다.
-                    </div>
-                ) : error ? (
-                    <div className="rounded-2xl border border-red-200 bg-red-50 p-12 text-center text-red-600">
-                        {error}
-                    </div>
-                ) : visibleAssets.length === 0 ? (
-                    <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-12 text-center text-slate-500">
-                        조건에 맞는 이미지가 없습니다.
-                    </div>
-                ) : (
-                    <>
-                        {/* 고정폭 카드 — auto-fill로 가용 폭에 맞춰 열 개수만 바뀌고 개별 카드 크기는 일정 */}
+                {/* 스크롤 영역 — 이미지 그리드(또는 로딩/에러/빈 상태)만 내부 스크롤 */}
+                <div className="flex-1 overflow-y-auto">
+                    {loading ? (
+                        <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-12 text-center text-slate-500">
+                            이미지 목록을 불러오는 중입니다.
+                        </div>
+                    ) : error ? (
+                        <div className="rounded-2xl border border-red-200 bg-red-50 p-12 text-center text-red-600">
+                            {error}
+                        </div>
+                    ) : visibleAssets.length === 0 ? (
+                        <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-12 text-center text-slate-500">
+                            조건에 맞는 이미지가 없습니다.
+                        </div>
+                    ) : (
+                        // 고정폭 카드 — auto-fill로 가용 폭에 맞춰 열 개수만 바뀌고 개별 카드 크기는 일정
                         <div className="grid grid-cols-[repeat(auto-fill,180px)] justify-start gap-4">
                             {visibleAssets.map((asset) => {
                                 const isSelected = asset.url ? selectedUrl === asset.url : false;
@@ -528,53 +523,55 @@ export default function AssetBrowser({ assetOrigin = '' }: AssetBrowserProps) {
                                 );
                             })}
                         </div>
+                    )}
+                </div>
 
-                        {totalPages > 1 ? (
-                            <div className="mt-6 flex justify-center gap-1">
-                                <button
-                                    type="button"
-                                    onClick={() => setPage(Math.max(1, page - 1))}
-                                    disabled={page === 1}
-                                    className={`px-3.5 py-1.5 rounded-md border border-[#e5e7eb] text-[13px] ${
-                                        page === 1
-                                            ? 'bg-[#f9fafb] text-[#d1d5db] cursor-not-allowed'
-                                            : 'bg-white text-[#374151] cursor-pointer'
-                                    }`}
-                                >
-                                    이전
-                                </button>
+                {/* 페이지네이션 — 1페이지 상태에서도 노출 (이전/다음 버튼 자동 disabled)
+                    단, 로딩/에러/빈 목록 상태에서는 숨김 — 시각적 혼선 방지 */}
+                {!loading && !error && visibleAssets.length > 0 ? (
+                    <div className="mt-6 flex shrink-0 justify-center gap-1">
+                        <button
+                            type="button"
+                            onClick={() => setPage(Math.max(1, page - 1))}
+                            disabled={page === 1}
+                            className={`px-3.5 py-1.5 rounded-md border border-[#e5e7eb] text-[13px] ${
+                                page === 1
+                                    ? 'bg-[#f9fafb] text-[#d1d5db] cursor-not-allowed'
+                                    : 'bg-white text-[#374151] cursor-pointer'
+                            }`}
+                        >
+                            이전
+                        </button>
 
-                                {visiblePages.map((visiblePage) => (
-                                    <button
-                                        key={visiblePage}
-                                        type="button"
-                                        onClick={() => setPage(visiblePage)}
-                                        className={`px-3 py-1.5 rounded-md border text-[13px] cursor-pointer ${
-                                            page === visiblePage
-                                                ? 'border-[#0046A4] bg-[#0046A4] text-white font-semibold'
-                                                : 'border-[#e5e7eb] bg-white text-[#374151] font-normal'
-                                        }`}
-                                    >
-                                        {visiblePage}
-                                    </button>
-                                ))}
+                        {visiblePages.map((visiblePage) => (
+                            <button
+                                key={visiblePage}
+                                type="button"
+                                onClick={() => setPage(visiblePage)}
+                                className={`px-3 py-1.5 rounded-md border text-[13px] cursor-pointer ${
+                                    page === visiblePage
+                                        ? 'border-[#0046A4] bg-[#0046A4] text-white font-semibold'
+                                        : 'border-[#e5e7eb] bg-white text-[#374151] font-normal'
+                                }`}
+                            >
+                                {visiblePage}
+                            </button>
+                        ))}
 
-                                <button
-                                    type="button"
-                                    onClick={() => setPage(Math.min(totalPages, page + 1))}
-                                    disabled={page === totalPages}
-                                    className={`px-3.5 py-1.5 rounded-md border border-[#e5e7eb] text-[13px] ${
-                                        page === totalPages
-                                            ? 'bg-[#f9fafb] text-[#d1d5db] cursor-not-allowed'
-                                            : 'bg-white text-[#374151] cursor-pointer'
-                                    }`}
-                                >
-                                    다음
-                                </button>
-                            </div>
-                        ) : null}
-                    </>
-                )}
+                        <button
+                            type="button"
+                            onClick={() => setPage(Math.min(totalPages, page + 1))}
+                            disabled={page === totalPages}
+                            className={`px-3.5 py-1.5 rounded-md border border-[#e5e7eb] text-[13px] ${
+                                page === totalPages
+                                    ? 'bg-[#f9fafb] text-[#d1d5db] cursor-not-allowed'
+                                    : 'bg-white text-[#374151] cursor-pointer'
+                            }`}
+                        >
+                            다음
+                        </button>
+                    </div>
+                ) : null}
             </div>
         </div>
     );

--- a/html-cms/src/components/files/AssetBrowser.tsx
+++ b/html-cms/src/components/files/AssetBrowser.tsx
@@ -239,13 +239,29 @@ export default function AssetBrowser({ assetOrigin = '' }: AssetBrowserProps) {
         setSelectedUrl((prev) => (prev === url ? null : url));
     }
 
-    // 우측 상단 X — 팝업 창 닫기
+    // 우측 상단 X — 팝업 창 또는 iframe 모달 닫기
+    // - 팝업(window.opener 존재) → window.close()
+    // - iframe(window.parent !== window) → 부모에 PICKER_CLOSE postMessage 전송
     // window.history.back()은 사용하지 않음:
     //   Next.js SSR 인증 redirect 등으로 opener가 null이 되는 경우,
     //   history.back()이 에디터 메인 창이 아닌 팝업 창의 히스토리를 이동시켜
     //   에디터 화면으로 돌아오지 못하는 버그가 생긴다.
     function handleClose() {
         if (typeof window === 'undefined') return;
+
+        // 팝업 창 — 브라우저가 opener를 신뢰하는 경우
+        if (window.opener) {
+            window.close();
+            return;
+        }
+
+        // iframe 모달 — 부모(EditClient)에게 닫기 요청
+        if (window.parent && window.parent !== window) {
+            window.parent.postMessage({ type: 'PICKER_CLOSE' }, '*');
+            return;
+        }
+
+        // 단독 창으로 접근 시 fallback — close() 시도
         window.close();
     }
 

--- a/html-cms/src/components/files/AssetBrowser.tsx
+++ b/html-cms/src/components/files/AssetBrowser.tsx
@@ -338,8 +338,8 @@ export default function AssetBrowser({ assetOrigin = '' }: AssetBrowserProps) {
             </aside>
 
             <div className="flex min-w-0 flex-1 flex-col px-4 py-6 md:px-8">
-                {/* 상단 우측 — 사이드바 토글 햄버거 + 닫기 X */}
-                <div className="mb-3 flex shrink-0 items-center justify-end gap-1">
+                {/* 상단 바 — 햄버거(왼쪽, 폴더 사이드바 토글) + 닫기 X (오른쪽) */}
+                <div className="mb-3 flex shrink-0 items-center justify-between gap-1">
                     <button
                         type="button"
                         onClick={() => setSidebarOpen((prev) => !prev)}

--- a/html-cms/src/db/queries/asset.sql.ts
+++ b/html-cms/src/db/queries/asset.sql.ts
@@ -17,6 +17,10 @@ export const ASSET_SELECT_BY_ID = `
 /**
  * 에셋 목록 조회 (카테고리 필터, BLOB 제외, 페이지네이션 — Oracle 11g 호환)
  * USE_YN='Y' 고정: cms-admin 에서 "숨김" 처리된 자산(USE_YN='N')은 /cms/files 에 노출되지 않는다.
+ *
+ * :deployedOnly 가 NULL 이 아니면 ASSET_URL LIKE '/deployed/%' 조건을 추가로 적용한다.
+ * 에디터 이미지 picker는 실제 배포까지 완료된 자산만 노출해야 하므로 이 값으로 제어한다.
+ * (승인만 되고 파일이 아직 uploads/·/static/ 에 남아있는 자산은 운영에서 서빙되지 않아 깨짐)
  */
 export const ASSET_SELECT_LIST = `
   SELECT * FROM (
@@ -31,6 +35,7 @@ export const ASSET_SELECT_LIST = `
         AND (:businessCategory IS NULL OR BUSINESS_CATEGORY = :businessCategory)
         AND (:assetState IS NULL OR ASSET_STATE = :assetState)
         AND (:search IS NULL OR LOWER(ASSET_NAME) LIKE '%' || LOWER(:search) || '%')
+        AND (:deployedOnly IS NULL OR ASSET_URL LIKE '/deployed/%')
       ORDER BY CREATE_DATE DESC
     ) A
     WHERE ROWNUM <= :endRow
@@ -38,7 +43,7 @@ export const ASSET_SELECT_LIST = `
   WHERE RN > :startRow
 `;
 
-/** 에셋 전체 건수 (페이지네이션용) — SELECT_LIST 와 동일한 USE_YN='Y' 필터 유지 */
+/** 에셋 전체 건수 (페이지네이션용) — SELECT_LIST 와 동일 필터 조건 유지 (totalCount 정합성) */
 export const ASSET_COUNT = `
   SELECT COUNT(*) AS TOTAL_COUNT
   FROM SPW_CMS_ASSET
@@ -46,6 +51,7 @@ export const ASSET_COUNT = `
     AND (:businessCategory IS NULL OR BUSINESS_CATEGORY = :businessCategory)
     AND (:assetState IS NULL OR ASSET_STATE = :assetState)
     AND (:search IS NULL OR LOWER(ASSET_NAME) LIKE '%' || LOWER(:search) || '%')
+    AND (:deployedOnly IS NULL OR ASSET_URL LIKE '/deployed/%')
 `;
 
 /** 에셋 등록 */

--- a/html-cms/src/db/repository/asset.repository.ts
+++ b/html-cms/src/db/repository/asset.repository.ts
@@ -38,18 +38,27 @@ export async function getAssetById(assetId: string): Promise<CmsAsset | null> {
     }
 }
 
-/** 에셋 목록 조회 (페이지네이션) */
+/**
+ * 에셋 목록 조회 (페이지네이션)
+ *
+ * deployedOnly=true 를 주면 ASSET_URL LIKE '/deployed/%' 로 추가 필터하여
+ * "배포까지 완료된" 자산만 반환한다. 에디터 이미지 picker(/cms/files)에서 사용.
+ */
 export async function getAssetList(options?: {
     businessCategory?: string;
     assetState?: AssetState;
     search?: string;
     page?: number;
     pageSize?: number;
+    deployedOnly?: boolean;
 }): Promise<{ list: CmsAsset[]; totalCount: number }> {
     const page = options?.page ?? 1;
     const pageSize = options?.pageSize ?? 20;
     const startRow = (page - 1) * pageSize;
     const endRow = page * pageSize;
+    // Oracle에는 BOOLEAN 바인드 타입이 없으므로 'Y' 또는 null로 치환.
+    // SQL 쪽은 `:deployedOnly IS NULL OR ...` 로 분기하므로 값 자체는 무엇이든 상관없음.
+    const deployedOnly = options?.deployedOnly ? 'Y' : null;
 
     const conn = await getConnection();
     try {
@@ -60,6 +69,7 @@ export async function getAssetList(options?: {
                     businessCategory: options?.businessCategory ?? null,
                     assetState: options?.assetState ?? null,
                     search: options?.search?.trim() || null,
+                    deployedOnly,
                     startRow,
                     endRow,
                 },
@@ -71,6 +81,7 @@ export async function getAssetList(options?: {
                     businessCategory: options?.businessCategory ?? null,
                     assetState: options?.assetState ?? null,
                     search: options?.search?.trim() || null,
+                    deployedOnly,
                 },
                 OBJ,
             ),

--- a/html-cms/src/lib/cms-file-picker.ts
+++ b/html-cms/src/lib/cms-file-picker.ts
@@ -56,12 +56,14 @@ export function openCmsFilesPicker(onSelect: (url: string) => void) {
     if (existing) existing.remove();
 
     // 오버레이 — 반투명 배경. 외곽 클릭 시 닫기.
+    // z-index: 편집 패널(EventBanner 등)이 99998/99999, TableEditorModal이 100001을 사용 →
+    // 이들 모두 위에 뜨도록 1,000,000 부여. (picker는 편집 패널에서 호출되므로 반드시 최상위)
     const overlay = document.createElement('div');
     overlay.id = MODAL_ID;
     overlay.style.cssText = [
         'position:fixed',
         'inset:0',
-        'z-index:9999',
+        'z-index:1000000',
         'display:flex',
         'align-items:center',
         'justify-content:center',

--- a/html-cms/src/lib/cms-file-picker.ts
+++ b/html-cms/src/lib/cms-file-picker.ts
@@ -1,5 +1,31 @@
+/**
+ * @file cms-file-picker.ts
+ * @description
+ *   승인된 CMS 이미지 선택기(`/cms/files`)를 에디터 내 iframe 모달로 띄우는 유틸.
+ *
+ *   이전에는 `window.open` 기반 팝업 창을 사용했으나 다음 문제가 있었다:
+ *     - 주소창에 `/cms/files` URL이 그대로 노출
+ *     - 브라우저 팝업 차단에 막힐 수 있음
+ *     - 에디터와 분리된 독립 창이라 수명 관리가 불편
+ *
+ *   현재 구현은 `document.body`에 오버레이 + iframe 을 직접 주입해
+ *   에디터 DOM 내부 모달로 표시한다. iframe 안의 AssetBrowser 가
+ *   선택 완료 시 `window.parent.postMessage({type:'ASSETS_SELECTED',urls})`를,
+ *   닫기(X) 시 `PICKER_CLOSE` 를 부모에 전달한다.
+ *
+ *   호출부 API(`openCmsFilesPicker(onSelect) => cleanup`)는 이전과 동일하므로
+ *   6개 에디터(EventBanner, PopupBanner, AuthCenterIcon, ProductMenuIcon,
+ *   SlideEditor, FlexList)의 기존 호출 코드는 수정 없이 iframe 모달로 전환된다.
+ *
+ * @example
+ *   const cleanup = openCmsFilesPicker((url) => {
+ *     updateSlide(idx, { imageUrl: url });
+ *   });
+ *   // 필요 시 수동 취소: cleanup();
+ */
 import { nextApi } from '@/lib/api-url';
 
+/** 단건 URL만 콜백으로 전달하기 위해 postMessage payload에서 첫 URL을 추출 */
 function extractFirstAssetUrl(data: unknown): string | null {
     if (!data || typeof data !== 'object') return null;
 
@@ -16,27 +42,85 @@ function extractFirstAssetUrl(data: unknown): string | null {
     return null;
 }
 
+/** 이중 오픈 방지를 위한 모달 DOM id — 한 번에 하나만 존재 */
+const MODAL_ID = 'spw-cms-file-picker-modal';
+
+/**
+ * 승인된 이미지 선택 모달을 연다.
+ * @param onSelect 이미지 선택 시 호출되는 콜백 (URL 1건)
+ * @returns cleanup 함수 — 호출 시 모달을 즉시 닫고 리스너 제거
+ */
 export function openCmsFilesPicker(onSelect: (url: string) => void) {
+    // 이미 열려 있는 모달이 있으면 제거 (예: 연타로 열기 시도)
+    const existing = document.getElementById(MODAL_ID);
+    if (existing) existing.remove();
+
+    // 오버레이 — 반투명 배경. 외곽 클릭 시 닫기.
+    const overlay = document.createElement('div');
+    overlay.id = MODAL_ID;
+    overlay.style.cssText = [
+        'position:fixed',
+        'inset:0',
+        'z-index:9999',
+        'display:flex',
+        'align-items:center',
+        'justify-content:center',
+        'background:rgba(0,0,0,0.5)',
+    ].join(';');
+
+    // 모달 컨테이너 — 1280×900 기본, 화면 좁을 때 95vw/95vh 제한
+    const box = document.createElement('div');
+    box.style.cssText = [
+        'position:relative',
+        'width:1280px',
+        'max-width:95vw',
+        'height:900px',
+        'max-height:95vh',
+        'background:#ffffff',
+        'border-radius:8px',
+        'overflow:hidden',
+        'box-shadow:0 20px 25px -5px rgba(0,0,0,0.1),0 10px 10px -5px rgba(0,0,0,0.04)',
+    ].join(';');
+
+    // iframe — AssetBrowser 렌더. src는 basePath 반영된 절대 경로.
+    const iframe = document.createElement('iframe');
+    iframe.src = nextApi('/files');
+    iframe.title = '이미지 선택';
+    iframe.style.cssText = 'width:100%;height:100%;border:0;display:block';
+
+    box.appendChild(iframe);
+    overlay.appendChild(box);
+
+    // 오버레이(iframe 바깥) 클릭 시 닫기 — iframe 내부 클릭은 이벤트가 올라오지 않음
+    overlay.addEventListener('click', (e) => {
+        if (e.target === overlay) cleanup();
+    });
+
     const handleMessage = (event: MessageEvent) => {
+        // iframe 내부 X 버튼 → 선택 없이 닫기
+        if (typeof event.data === 'object' && event.data !== null) {
+            const type = (event.data as { type?: string }).type;
+            if (type === 'PICKER_CLOSE') {
+                cleanup();
+                return;
+            }
+        }
+
         const url = extractFirstAssetUrl(event.data);
         if (!url) return;
 
-        window.removeEventListener('message', handleMessage);
+        cleanup();
         onSelect(url);
         window.focus();
     };
 
-    window.addEventListener('message', handleMessage);
-    const popup = window.open(
-        nextApi('/files'),
-        'spw-image-browser',
-        'width=1280,height=900,scrollbars=yes,resizable=yes',
-    );
-
-    if (!popup) {
+    function cleanup() {
         window.removeEventListener('message', handleMessage);
-        throw new Error('이미지 선택 창을 열 수 없습니다. 팝업 차단을 확인해 주세요.');
+        overlay.remove();
     }
 
-    return () => window.removeEventListener('message', handleMessage);
+    window.addEventListener('message', handleMessage);
+    document.body.appendChild(overlay);
+
+    return cleanup;
 }

--- a/html-cms/src/lib/cms-file-picker.ts
+++ b/html-cms/src/lib/cms-file-picker.ts
@@ -24,6 +24,7 @@
  *   // 필요 시 수동 취소: cleanup();
  */
 import { nextApi } from '@/lib/api-url';
+import { attachResizeHandles, centerInitialBox } from '@/lib/resizable-box';
 
 /** 단건 URL만 콜백으로 전달하기 위해 postMessage payload에서 첫 URL을 추출 */
 function extractFirstAssetUrl(data: unknown): string | null {
@@ -58,26 +59,15 @@ export function openCmsFilesPicker(onSelect: (url: string) => void) {
     // 오버레이 — 반투명 배경. 외곽 클릭 시 닫기.
     // z-index: 편집 패널(EventBanner 등)이 99998/99999, TableEditorModal이 100001을 사용 →
     // 이들 모두 위에 뜨도록 1,000,000 부여. (picker는 편집 패널에서 호출되므로 반드시 최상위)
+    // 박스를 absolute 로 띄우기 위해 flex 중앙배치는 제거 — 중앙 배치는 centerInitialBox 가 담당.
     const overlay = document.createElement('div');
     overlay.id = MODAL_ID;
-    overlay.style.cssText = [
-        'position:fixed',
-        'inset:0',
-        'z-index:1000000',
-        'display:flex',
-        'align-items:center',
-        'justify-content:center',
-        'background:rgba(0,0,0,0.5)',
-    ].join(';');
+    overlay.style.cssText = ['position:fixed', 'inset:0', 'z-index:1000000', 'background:rgba(0,0,0,0.5)'].join(';');
 
-    // 모달 컨테이너 — 1280×900 기본, 화면 좁을 때 95vw/95vh 제한
+    // 모달 컨테이너 — 절대 위치, 크기·좌표는 centerInitialBox 에서 px 단위로 직접 설정
     const box = document.createElement('div');
     box.style.cssText = [
-        'position:relative',
-        'width:1280px',
-        'max-width:95vw',
-        'height:900px',
-        'max-height:95vh',
+        'position:absolute',
         'background:#ffffff',
         'border-radius:8px',
         'overflow:hidden',
@@ -116,13 +106,22 @@ export function openCmsFilesPicker(onSelect: (url: string) => void) {
         window.focus();
     };
 
+    // 드래그 리사이즈 핸들 detach 함수 — cleanup 시 호출하여 핸들 DOM 제거
+    // (overlay 자체를 remove 하면 핸들도 같이 사라지지만, 명시적으로 정리)
+    let detachResize: (() => void) | null = null;
+
     function cleanup() {
         window.removeEventListener('message', handleMessage);
+        detachResize?.();
         overlay.remove();
     }
 
     window.addEventListener('message', handleMessage);
     document.body.appendChild(overlay);
+
+    // DOM에 붙인 뒤 초기 중앙 배치 + 8방향 드래그 리사이즈 활성화
+    centerInitialBox(box, { width: 1280, height: 900 });
+    detachResize = attachResizeHandles(box, { minWidth: 480, minHeight: 360 });
 
     return cleanup;
 }

--- a/html-cms/src/lib/resizable-box.ts
+++ b/html-cms/src/lib/resizable-box.ts
@@ -1,0 +1,191 @@
+/**
+ * @file resizable-box.ts
+ * @description
+ *   임의의 DOM 박스에 8방향(상·하·좌·우 + 4개 코너) 드래그 리사이즈 핸들을 부착하는 유틸.
+ *
+ *   박스는 반드시 `position: fixed | absolute` 이고 `left/top/width/height`가 픽셀 단위로
+ *   설정되어 있어야 한다(호출 쪽에서 초기 배치 필요). 유틸은 8개의 투명 핸들 div 를 박스
+ *   내부에 추가하고, 마우스 드래그로 해당 방향의 변을/모서리를 조절하여 박스 크기를
+ *   재계산하고 적용한다.
+ *
+ *   iframe 위에서 드래그할 때 mousemove 가 부모로 전달되지 않는 문제를 방지하기 위해
+ *   드래그 중엔 박스 내부 모든 iframe 에 `pointer-events: none` 을 일시 적용한다.
+ *
+ * @example
+ *   const detach = attachResizeHandles(boxEl, { minWidth: 400, minHeight: 300 });
+ *   // 필요 시 핸들 제거: detach();
+ */
+
+export interface ResizableOptions {
+    /** 최소 너비(px). 기본 400 */
+    minWidth?: number;
+    /** 최소 높이(px). 기본 300 */
+    minHeight?: number;
+}
+
+/**
+ * 박스 요소에 8방향 리사이즈 핸들을 부착.
+ * @returns 핸들·이벤트를 모두 제거하는 cleanup 함수
+ */
+export function attachResizeHandles(box: HTMLElement, options: ResizableOptions = {}): () => void {
+    const minWidth = options.minWidth ?? 400;
+    const minHeight = options.minHeight ?? 300;
+
+    // 핸들 정의 — dir 문자에 포함된 n/s/e/w 로 어떤 변·모서리를 움직일지 판별
+    const handleDefs: Array<{ dir: 'n' | 's' | 'w' | 'e' | 'nw' | 'ne' | 'sw' | 'se'; cursor: string }> = [
+        { dir: 'n', cursor: 'ns-resize' },
+        { dir: 's', cursor: 'ns-resize' },
+        { dir: 'w', cursor: 'ew-resize' },
+        { dir: 'e', cursor: 'ew-resize' },
+        { dir: 'nw', cursor: 'nwse-resize' },
+        { dir: 'ne', cursor: 'nesw-resize' },
+        { dir: 'sw', cursor: 'nesw-resize' },
+        { dir: 'se', cursor: 'nwse-resize' },
+    ];
+
+    /** 핸들의 위치·크기 인라인 스타일. 변(6px 띠) / 코너(14px 정사각) */
+    function handleStyle(dir: string): string {
+        const edge = 6;
+        const corner = 14;
+        switch (dir) {
+            case 'n':
+                return `top:0;left:0;right:0;height:${edge}px`;
+            case 's':
+                return `bottom:0;left:0;right:0;height:${edge}px`;
+            case 'w':
+                return `left:0;top:0;bottom:0;width:${edge}px`;
+            case 'e':
+                return `right:0;top:0;bottom:0;width:${edge}px`;
+            case 'nw':
+                return `top:0;left:0;width:${corner}px;height:${corner}px`;
+            case 'ne':
+                return `top:0;right:0;width:${corner}px;height:${corner}px`;
+            case 'sw':
+                return `bottom:0;left:0;width:${corner}px;height:${corner}px`;
+            case 'se':
+                return `bottom:0;right:0;width:${corner}px;height:${corner}px`;
+            default:
+                return '';
+        }
+    }
+
+    const createdHandles: HTMLDivElement[] = [];
+
+    function startResize(e: MouseEvent, dir: string) {
+        // 오버레이의 click 등 상위 이벤트와 분리
+        e.preventDefault();
+        e.stopPropagation();
+
+        const startX = e.clientX;
+        const startY = e.clientY;
+        const rect = box.getBoundingClientRect();
+        const startWidth = rect.width;
+        const startHeight = rect.height;
+        const startLeft = rect.left;
+        const startTop = rect.top;
+
+        // 드래그 중 텍스트 선택 깜빡임 방지
+        const prevBodyUserSelect = document.body.style.userSelect;
+        document.body.style.userSelect = 'none';
+
+        // 박스 내부 iframe 은 mouse 이벤트를 가로채므로 드래그 동안만 pointer-events 차단
+        const iframes = Array.from(box.querySelectorAll('iframe'));
+        const prevPointerEvents = iframes.map((ifr) => ifr.style.pointerEvents);
+        iframes.forEach((ifr) => {
+            ifr.style.pointerEvents = 'none';
+        });
+
+        function onMove(ev: MouseEvent) {
+            const dx = ev.clientX - startX;
+            const dy = ev.clientY - startY;
+
+            let newLeft = startLeft;
+            let newTop = startTop;
+            let newWidth = startWidth;
+            let newHeight = startHeight;
+
+            if (dir.includes('e')) {
+                newWidth = Math.max(minWidth, startWidth + dx);
+            }
+            if (dir.includes('w')) {
+                // 왼쪽 변을 움직일 때는 width 가 작아지는 만큼 left 가 커진다
+                const w = Math.max(minWidth, startWidth - dx);
+                newLeft = startLeft + (startWidth - w);
+                newWidth = w;
+            }
+            if (dir.includes('s')) {
+                newHeight = Math.max(minHeight, startHeight + dy);
+            }
+            if (dir.includes('n')) {
+                const h = Math.max(minHeight, startHeight - dy);
+                newTop = startTop + (startHeight - h);
+                newHeight = h;
+            }
+
+            // 뷰포트 경계 안으로 보정 (모달이 밖으로 나가 선택 불가 상태가 되는 사고 방지)
+            newLeft = Math.max(0, Math.min(window.innerWidth - newWidth, newLeft));
+            newTop = Math.max(0, Math.min(window.innerHeight - newHeight, newTop));
+
+            box.style.left = `${newLeft}px`;
+            box.style.top = `${newTop}px`;
+            box.style.width = `${newWidth}px`;
+            box.style.height = `${newHeight}px`;
+        }
+
+        function onUp() {
+            window.removeEventListener('mousemove', onMove);
+            window.removeEventListener('mouseup', onUp);
+            document.body.style.userSelect = prevBodyUserSelect;
+            iframes.forEach((ifr, i) => {
+                ifr.style.pointerEvents = prevPointerEvents[i];
+            });
+        }
+
+        window.addEventListener('mousemove', onMove);
+        window.addEventListener('mouseup', onUp);
+    }
+
+    for (const def of handleDefs) {
+        const h = document.createElement('div');
+        h.dataset.resizeHandle = def.dir;
+        h.style.cssText = [
+            'position:absolute',
+            handleStyle(def.dir),
+            `cursor:${def.cursor}`,
+            // z-index 은 iframe(기본 auto) 보다 위, 모달 내부의 다른 절대 배치 요소는 없다고 가정
+            'z-index:10',
+            // 시각적으로는 투명 — 커서 변화로 존재를 알림
+            'background:transparent',
+            // 터치 환경에서 스크롤과 충돌하지 않도록 pan-y 만 허용
+            'touch-action:none',
+        ].join(';');
+        h.addEventListener('mousedown', (e) => startResize(e, def.dir));
+        box.appendChild(h);
+        createdHandles.push(h);
+    }
+
+    return () => {
+        for (const h of createdHandles) {
+            h.remove();
+        }
+    };
+}
+
+/**
+ * 박스 초기 중앙 배치 계산 헬퍼.
+ * 화면 중앙에 orig 크기로 두되, 화면이 좁으면 95vw/95vh 로 축소.
+ */
+export function centerInitialBox(
+    box: HTMLElement,
+    orig: { width: number; height: number },
+    maxViewportRatio = 0.95,
+): void {
+    const width = Math.min(orig.width, window.innerWidth * maxViewportRatio);
+    const height = Math.min(orig.height, window.innerHeight * maxViewportRatio);
+    const left = Math.max(0, (window.innerWidth - width) / 2);
+    const top = Math.max(0, (window.innerHeight - height) / 2);
+    box.style.left = `${left}px`;
+    box.style.top = `${top}px`;
+    box.style.width = `${width}px`;
+    box.style.height = `${height}px`;
+}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)                                                                                                                 
                                                                                                                                                   
  Closes #179                                                                                                                                      
                                                                                                                                                   
  ## ✨ 변경 사항 (Changes)

  `/cms/edit` 에서 이미지를 선택할 때 `/cms/files` 가 **별도 브라우저 창(window.open 팝업)** 으로 열리며 주소창에 URL이 그대로 노출되던 문제를
  해결하고, 이어 발견된 UX·데이터 정합성 이슈까지 함께 정리한 브랜치입니다.

  ### 1. `window.open` 팝업 → iframe 모달로 전환

  **`#fileEmbedImage` 인터셉트 경로 (ContentBuilder 이미지 블록의 "이미지 변경" 버튼)**
  - 클릭 인터셉트 후 기존 `window.open(...)` 제거
  - `imagePickerOpen` 상태 + 에디터 DOM 내부 iframe 모달 추가
  - 선택된 URL 전달 경로: iframe → `window.parent.postMessage` → EditClient 메시지 리스너 → `imageReplaceTargetRef` 의 `<img>` `src` 교체

  **6개 편집 패널이 공유하는 `openCmsFilesPicker` 유틸**
  `src/lib/cms-file-picker.ts` 를 `document.body` 에 오버레이 + iframe 주입 방식으로 재작성. 공개 API (`openCmsFilesPicker(onSelect) => cleanup`)
  는 동일하게 유지하여 호출부 코드 무수정.

  | 사용 컴포넌트 | 한글 라벨 |
  | --- | --- |
  | `AuthCenterIconEditor.tsx` | 보안·인증센터 아이콘 편집 |
  | `EventBannerEditor.tsx` | 이벤트 배너 슬라이드 편집 |
  | `FlexListEditor.tsx` | 유연 리스트 편집 |
  | `PopupBannerEditor.tsx` | 팝업 배너 편집 |
  | `ProductMenuIconEditor.tsx` | 상품 메뉴 아이콘 편집 |
  | `SlideEditorModal.tsx` | 공통 슬라이드 편집 모달 |

  ### 2. 메시지 이중 처리 방지 가드

  `cms-file-picker` 유틸 모달과 EditClient 의 메시지 리스너가 **같은 `ASSETS_SELECTED` 를 모두 수신**해 슬라이드 업데이트와 동시에 캔버스로
  이미지가 추가 삽입되는 잠재 버그 수정. 유틸 모달 DOM (`#spw-cms-file-picker-modal`) 이 활성이면 EditClient 리스너는 개입하지 않도록 가드 추가.

  ### 3. iframe 환경의 닫기(X) 동작

  `AssetBrowser.handleClose` 에서 `window.opener` 가 없고 부모가 존재하면 `PICKER_CLOSE` postMessage 를 부모에 전송하도록 분기. EditClient /
  cms-file-picker 양쪽에서 이 메시지로 모달 종료.

  ### 4. z-index 상향

  편집 패널(`zIndex: 99998/99999`) 과 `TableEditorModal` (`100001`) 이 iframe 모달(기존 9999)보다 위라서 picker 가 가려지던 문제. 모든 picker
  모달의 `z-index: 1000000` 으로 상향.

  ### 5. 서버/클라이언트 이미지 필터 정합성

  이전에는 서버가 `assetState=APPROVED` 로만 필터하고 클라이언트가 `isDeployedAsset` 으로 경로 재필터 → 서버 `totalCount(8)` 와 실제 표시 건수(4)
  가 어긋나는 불일치. 서버에서 일괄 필터하도록 통일.

  - `ASSET_SELECT_LIST` / `ASSET_COUNT` 에 `:deployedOnly` 파라미터 추가 (값 존재 시 `ASSET_URL LIKE '/deployed/%'` 조건 적용)
  - `getAssetList` 레포지토리에 `deployedOnly?: boolean` 옵션 추가
  - `/api/assets` GET 에서 `?deployedOnly=true` 파싱
  - 클라이언트 `AssetBrowser` 는 fetch URL 에 `deployedOnly=true` 추가, `isDeployedAsset` · `deployedAssets` 재필터 로직 제거

  운영 `/static/` 경로(업로드 직후·배포 전)는 운영 페이지에서 서빙되지 않으므로 picker 에도 노출하지 않음. 배포 완료된 `/deployed/` 경로만 선택
  가능.

  ### 6. 페이지네이션 UI 항상 표시

  - `totalPages > 1` 조건 제거 → 1페이지 상태에서도 페이지네이션 노출 (이전/다음은 조건에 따라 자동 disabled)

  ### 7. 이미지 그리드 내부 스크롤 구조

  iframe 모달에서 검색 바·페이지네이션이 스크롤과 함께 밀려가던 문제 해결.

  - `AssetBrowser` 루트: `min-h-screen` → `h-screen overflow-hidden`
  - 메인 영역 `flex flex-col`, 상단 섹션(헤더·검색 카드·건수) 에 `shrink-0`
  - 이미지 그리드만 `flex-1 overflow-y-auto` 로 감싸 독립 스크롤
  - 페이지네이션을 스크롤 영역 밖 `shrink-0` 으로 최하단 고정
  - 사이드바 내부에도 `h-full overflow-y-auto` 적용

  ### 8. 햄버거 아이콘 좌측 배치

  폴더 사이드바 토글 햄버거가 닫기(X) 와 함께 우측에 몰려 있어 토글 의도와 시각적 연결이 약했던 문제. 상단 바 정렬 `justify-end` →
  `justify-between` 으로 변경, 햄버거(왼쪽, 사이드바 토글) + 닫기(오른쪽) 분리 배치.

  ### 9. 8방향 드래그 리사이즈 지원

  사용자가 콘텐츠 양에 맞게 모달 크기를 자유롭게 조절할 수 있도록 4개 변 + 4개 모서리 총 8방향 드래그 리사이즈 추가.

  **`src/lib/resizable-box.ts` (신규 유틸)**
  - `attachResizeHandles(box, { minWidth, minHeight })` — 투명 핸들 8개 부착, 방향별 커서(`ns-resize`/`ew-resize`/`nwse-resize`/`nesw-resize`) 적용
  - 드래그 중 iframe 에 `pointer-events:none` 을 일시 적용해 mousemove 손실 방지
  - 뷰포트 경계 안으로 좌표 clamp, min/max 크기 제약
  - `centerInitialBox(box, { width, height })` — 초기 1280×900(화면 95%내 축소) + 중앙 배치 헬퍼

  **EditClient.tsx / cms-file-picker.ts**
  - 모달 박스를 flex 중앙배치에서 `position: absolute` 로 전환
  - 박스에 `ref`/참조 부여, 오픈 시 `centerInitialBox` + `attachResizeHandles` 호출
  - cleanup 에서 detach 처리

  ---

  **주요 변경 파일 요약**

  | 파일 | 변경 내용 |
  | --- | --- |
  | `src/components/edit/EditClient.tsx` | 인터셉트 로직 → 모달 상태 토글, iframe 모달 JSX, 메시지 리스너 가드, z-index 1000000, 드래그 리사이즈
  연동 |
  | `src/lib/cms-file-picker.ts` | `window.open` → DOM 오버레이·iframe, PICKER_CLOSE 처리, 절대위치 + 리사이즈 |
  | `src/components/files/AssetBrowser.tsx` | 내부 스크롤 구조, 서버 필터 위임, 페이지네이션 항상 표시, 햄버거 좌측 |
  | `src/lib/resizable-box.ts` | **(신규)** 8방향 리사이즈 유틸 |
  | `src/app/api/assets/route.ts` | `?deployedOnly=true` 파싱 |
  | `src/db/repository/asset.repository.ts` | `deployedOnly` 옵션 추가 |
  | `src/db/queries/asset.sql.ts` | `SELECT_LIST` / `COUNT` 에 `:deployedOnly` 필터 추가 |

  ## 📸 변경 사항 확인 (선택)

  | 변경 전 (Before) | 변경 후 (After) |
  | :--- | :--- |
  | 별도 브라우저 창 팝업 + 주소창에 `localhost:3000/cms/files` 노출 | 에디터 내 iframe 모달, 주소창 유지 |
  | 편집 패널 아래에 picker 가 가려짐 | 편집 패널 위에 picker 표시 |
  | 모달 크기 고정 | 4개 변·4개 모서리로 자유롭게 리사이즈 |
  | 검색 바/페이지네이션이 스크롤과 함께 밀려감 | 상단 바·페이지네이션 고정, 그리드만 내부 스크롤 |
  | "총 8건" 인데 실제 4개만 표시 | 서버/클라 필터 통일로 건수 일치 |
  | 1페이지일 때 페이지네이션 UI 미노출 | 1페이지에서도 페이지네이션 표시 (이전/다음 disabled) |

  ## ⚠️ 고려 및 주의 사항 (선택)

  - **메시지 리스너 가드**는 `document.getElementById('spw-cms-file-picker-modal')` 로 유틸 모달 활성 여부를 판별합니다. 유틸의 모달 DOM id 가
  변경되면 EditClient 쪽도 함께 수정 필요.
  - **iframe 모달 + React 상태 모달** 두 구현이 공존합니다. 향후 EditClient 의 `#fileEmbedImage` 경로도 `openCmsFilesPicker` 유틸로 통일하면
  `imagePickerOpen` 상태와 JSX, `PICKER_CLOSE` 분기를 제거 가능 (별도 리팩터링 과제).
  - **z-index: 1000000** 상향. 이후 더 높은 오버레이가 필요하면 이 값을 초과하도록 설정.
  - **DB `ASSET_URL LIKE '/deployed/%'` 필터** 는 prefix 기반이므로 운영 경로 명명 규칙이 바뀌면 SQL 조건도 같이 조정 필요 (`DEPLOYED_BASE_URL`
  환경변수 변경 시 주의).
  - **이미지 표시는 `object-cover` 180×180 정사각 크롭** 상태. 가로/세로로 긴 이미지는 카드 내에서 잘려 보이므로 실제 비율 확인은 선택 후
  에디터에서 가능 (개선 여지 있음).

  ## 💬 리뷰 포인트 (선택)

  - EditClient 의 `isCmsFilePickerActive()` 가드가 의도대로 동작하는지 — 6개 편집 패널에서 이미지 선택 후 **캔버스에 이미지가 중복 삽입되지
  않는지** 확인.
  - 드래그 리사이즈 동작 — 4 변 / 4 모서리 전부, 특히 iframe 위 드래그 시 마우스 추적이 끊기지 않는지.
  - `?deployedOnly=true` 필터의 totalCount 정합성 — 배포 완료된 자산 개수와 페이지네이션 총합 일치 여부.
  - ContentBuilder 툴바의 이미지 삽입 경로(`filePicker`/`imageSelect` 옵션) 는 이번 변경과 무관하게 그대로 동작해야 합니다 — 해당 경로는
  ContentBuilder 내장 모달을 사용하므로 본 PR 의 가드로 스킵되면 안 됨.

  ## 🔗 참고 사항 (선택)

  - 커밋 히스토리 (7개 + merge 1개)
    - `f09e03d` feat #179: 이미지 교체 picker를 window.open 팝업에서 iframe 모달로 전환
    - `5663bc6` feat #179: prettier 포맷 적용
    - `75b562e` feat #179: cms-file-picker 유틸을 iframe 모달로 전환
    - `4862dad` fix #179: 이미지 picker 모달이 편집 패널 위로 오도록 z-index 상향
    - `27569f8` feat #179: 이미지 picker UX 개선 — 스크롤·필터·페이지네이션
    - `d2f5a67` fix #179: 이미지 picker 햄버거 아이콘 좌측 배치
    - `aa88a97` feat #179: 이미지 picker 모달 8방향 드래그 리사이즈 지원