### PR TITLE
feat: ReactPlatform — Swagger UI 접근 복구 및 배포 이력 나의 배포 이력 필터 추가

### DIFF
--- a/reactPlatform/src/main/java/com/example/reactplatform/domain/reactdeploy/controller/ReactDeployController.java
+++ b/reactPlatform/src/main/java/com/example/reactplatform/domain/reactdeploy/controller/ReactDeployController.java
@@ -67,17 +67,20 @@ public class ReactDeployController {
     /**
      * 전체 배포 이력을 조회한다 (하단 이력 테이블용).
      *
-     * @param page   페이지 번호 (기본값 1)
-     * @param size   페이지당 건수 (기본값 20)
-     * @param search 코드 ID 또는 실행자 ID 검색 키워드
+     * @param page     페이지 번호 (기본값 1)
+     * @param size     페이지당 건수 (기본값 20)
+     * @param search   코드 ID 또는 실행자 ID 검색 키워드
+     * @param onlyMine true이면 로그인 사용자의 이력만 조회
      */
     @GetMapping("/history")
     @PreAuthorize("hasAuthority('REACT_DEPLOY:R')")
     public ResponseEntity<ApiResponse<Map<String, Object>>> getAllHistory(
             @RequestParam(defaultValue = "1")  @Min(1) int page,
             @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size,
-            @RequestParam(defaultValue = "") String search) {
-        return ResponseEntity.ok(ApiResponse.success(reactDeployService.findAllHistoryList(page, size, search)));
+            @RequestParam(defaultValue = "") String search,
+            @RequestParam(defaultValue = "false") boolean onlyMine) {
+        String userId = onlyMine ? SecurityUtil.getCurrentUserId() : null;
+        return ResponseEntity.ok(ApiResponse.success(reactDeployService.findAllHistoryList(page, size, search, userId)));
     }
 
     /**

--- a/reactPlatform/src/main/java/com/example/reactplatform/domain/reactdeploy/controller/ReactDeployController.java
+++ b/reactPlatform/src/main/java/com/example/reactplatform/domain/reactdeploy/controller/ReactDeployController.java
@@ -12,6 +12,7 @@ import com.example.reactplatform.global.dto.ApiResponse;
 import com.example.reactplatform.global.util.SecurityUtil;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -80,6 +81,11 @@ public class ReactDeployController {
             @RequestParam(defaultValue = "") String search,
             @RequestParam(defaultValue = "false") boolean onlyMine) {
         String userId = onlyMine ? SecurityUtil.getCurrentUserId() : null;
+        // onlyMine 요청인데 사용자 ID를 확인할 수 없으면 전체 이력 노출을 방지하고 빈 결과를 반환한다
+        if (onlyMine && userId == null) {
+            return ResponseEntity.ok(ApiResponse.success(
+                    Map.of("list", List.of(), "totalCount", 0, "page", page, "size", size)));
+        }
         return ResponseEntity.ok(ApiResponse.success(reactDeployService.findAllHistoryList(page, size, search, userId)));
     }
 

--- a/reactPlatform/src/main/java/com/example/reactplatform/domain/reactdeploy/mapper/ReactDeployMapper.java
+++ b/reactPlatform/src/main/java/com/example/reactplatform/domain/reactdeploy/mapper/ReactDeployMapper.java
@@ -56,15 +56,17 @@ public interface ReactDeployMapper {
      * @param offset  시작 행 오프셋 (0-based)
      * @param endRow  종료 행 번호
      * @param search  코드 ID 또는 실행자 ID 키워드 (null·빈 문자열이면 전체)
+     * @param userId  실행자 ID 일치 필터 (null이면 전체)
      */
     List<ReactDeployHistoryResponse> selectAllHistoryList(
             @Param("offset") int offset,
             @Param("endRow") int endRow,
-            @Param("search") String search
+            @Param("search") String search,
+            @Param("userId") String userId
     );
 
     /** 전체 배포 이력 건수 */
-    int selectAllHistoryCount(@Param("search") String search);
+    int selectAllHistoryCount(@Param("search") String search, @Param("userId") String userId);
 
     /**
      * 특정 코드의 배포 이력 목록을 최근 순으로 반환한다 (모달용).

--- a/reactPlatform/src/main/java/com/example/reactplatform/domain/reactdeploy/service/ReactDeployService.java
+++ b/reactPlatform/src/main/java/com/example/reactplatform/domain/reactdeploy/service/ReactDeployService.java
@@ -132,14 +132,15 @@ public class ReactDeployService {
      * @param page   페이지 번호 (1-based)
      * @param size   페이지당 건수
      * @param search 코드 ID 또는 실행자 ID 검색 키워드
+     * @param userId 실행자 ID 일치 필터 — null이면 전체 조회
      * @return list, totalCount, page, size
      */
-    public Map<String, Object> findAllHistoryList(int page, int size, String search) {
+    public Map<String, Object> findAllHistoryList(int page, int size, String search, String userId) {
         int offset = (page - 1) * size;
         int endRow = offset + size;
         String escaped = SqlUtils.escapeLike(nullIfBlank(search));
-        List<ReactDeployHistoryResponse> list = reactDeployMapper.selectAllHistoryList(offset, endRow, escaped);
-        int totalCount = reactDeployMapper.selectAllHistoryCount(escaped);
+        List<ReactDeployHistoryResponse> list = reactDeployMapper.selectAllHistoryList(offset, endRow, escaped, userId);
+        int totalCount = reactDeployMapper.selectAllHistoryCount(escaped, userId);
         return Map.of("list", list, "totalCount", totalCount, "page", page, "size", size);
     }
 

--- a/reactPlatform/src/main/resources/mapper/oracle/reactdeploy/ReactDeployMapper.xml
+++ b/reactPlatform/src/main/resources/mapper/oracle/reactdeploy/ReactDeployMapper.xml
@@ -97,6 +97,10 @@
                 OR h.LAST_UPDATE_USER_ID LIKE '%' || #{search} || '%' ESCAPE '\'
             )
         </if>
+        <!-- onlyMine 체크박스 선택 시 로그인 사용자의 이력만 조회 -->
+        <if test="userId != null and userId != ''">
+            AND h.LAST_UPDATE_USER_ID = #{userId,jdbcType=VARCHAR}
+        </if>
     </sql>
 
     <select id="selectAllHistoryList"

--- a/reactPlatform/src/main/resources/templates/pages/react-deployment/react-deployment-his-search.html
+++ b/reactPlatform/src/main/resources/templates/pages/react-deployment/react-deployment-his-search.html
@@ -24,6 +24,11 @@
                class="form-control form-control-sm flex-fixed-200"
                placeholder="코드 ID / 실행자 ID">
 
+        <div class="form-check ms-2 mb-0">
+            <input class="form-check-input" type="checkbox" id="hisSearchOnlyMine">
+            <label class="form-check-label small fw-medium" for="hisSearchOnlyMine">나의 배포 이력</label>
+        </div>
+
         <div class="flex-grow-1"></div>
 
         <select id="limitRows" class="form-select form-select-sm sp-limit-select">

--- a/reactPlatform/src/main/resources/templates/pages/react-deployment/react-deployment-script.html
+++ b/reactPlatform/src/main/resources/templates/pages/react-deployment/react-deployment-script.html
@@ -71,7 +71,7 @@ const ReactDeployList = window.ReactDeployList = {
     load: function (page) {
         this.currentPage = page || 1;
         const search = $('#deployListSearch').val().trim();
-        $.get(API_BASE_URL + '/react-admin/deployments', {
+        $.get(API_BASE_URL + '/react-deploy', {
             page: this.currentPage, size: this.pageSize, search
         })
         .done(res => {
@@ -172,7 +172,7 @@ const ReactDeployList = window.ReactDeployList = {
 
     redeploy: function (codeId) {
         if (!confirm('해당 코드를 배포하시겠습니까?')) return;
-        $.ajax({ url: API_BASE_URL + '/react-admin/deployments/' + codeId + '/redeploy', type: 'POST' })
+        $.ajax({ url: API_BASE_URL + '/react-deploy/' + codeId + '/redeploy', type: 'POST' })
             .done(res => {
                 if (res.success) {
                     let msg = '배포가 완료됐습니다.';
@@ -201,7 +201,8 @@ const ReactDeployHis = window.ReactDeployHis = {
 
     search: function () {
         this.appliedSearch = {
-            search: $('#hisSearchKeyword').val().trim(),
+            search:   $('#hisSearchKeyword').val().trim(),
+            onlyMine: $('#hisSearchOnlyMine').is(':checked'),
         };
         this.currentPage = 1;
         this.load();
@@ -213,7 +214,7 @@ const ReactDeployHis = window.ReactDeployHis = {
             size: this.itemsPerPage,
         });
         $.ajax({
-            url: API_BASE_URL + '/react-admin/deployments/history',
+            url: API_BASE_URL + '/react-deploy/history',
             method: 'GET',
             data: params,
             success: (res) => {
@@ -323,7 +324,7 @@ const ReactDeployHisModal = window.ReactDeployHisModal = {
 
     load: function () {
         if (!this.currentCodeId) return;
-        $.get(API_BASE_URL + '/react-admin/deployments/' + this.currentCodeId + '/history', {
+        $.get(API_BASE_URL + '/react-deploy/' + this.currentCodeId + '/history', {
             page: this.currentPage, size: this.pageSize,
         })
         .done(res => {
@@ -433,6 +434,7 @@ $(document).ready(function () {
         $('#hisSearchStatus').val('');
         $('#hisSearchMode').val('');
         $('#hisSearchKeyword').val('');
+        $('#hisSearchOnlyMine').prop('checked', false);
         ReactDeployHis.search();
     });
 


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
> - #154

## ✨ 변경 사항 (Changes)

### 🐛 Swagger UI 접근 불가 수정
- **springdoc-openapi `2.5.0` → `2.7.0` 업그레이드**  
  Spring Boot 3.4.x 호환 버전으로 올려 Swagger UI 리소스 핸들러 등록 실패 문제 해결
- **`WebMvcConfig`** : `RequestTraceInterceptor` excludePathPatterns에 `/swagger-ui/**`, `/v3/api-docs/**` 추가
- **`application.yml`** : `springdoc:` 설정 섹션 명시적으로 추가

### 🐛 배포 관리 API URL 잔재 수정
- 템플릿에 남아있던 `/react-admin/deployments` → `/react-deploy` 로 일괄 변경 (4곳)

### ✨ 배포 이력 — 나의 배포 이력 체크박스 추가
- **검색 UI** : 검색 키워드 옆에 "나의 배포 이력" 체크박스 추가 (초기화 버튼 클릭 시 함께 해제)
- **Controller** : `onlyMine=true` 수신 시 `SecurityUtil`로 로그인 사용자 ID 추출 후 필터 적용
- **Service** : `userId` 파라미터 추가
- **Mapper / XML** : `historySearchCondition`에 `LAST_UPDATE_USER_ID = #{userId}` 조건 추가

## 📸 변경 사항 확인 (선택)

| 변경 전 (Before) | 변경 후 (After) |
| :--- | :--- |
| 배포 이력 검색 조건 없음 | 나의 배포 이력 체크박스 추가 |

## ⚠️ 고려 및 주의 사항 (선택)
- springdoc 버전 업그레이드(`2.5.0 → 2.7.0`)로 인해 서버 재빌드 필요
- `onlyMine` 필터는 세션 기반 인증(`SecurityUtil.getCurrentUserId()`)에 의존하므로 인증된 사용자에게만 동작

## 💬 리뷰 포인트 (선택)
- `historySearchCondition` SQL Fragment에 `userId` 조건이 `search` 조건과 AND로 조합되는 방식 확인