### PR TITLE
fix: 반려 이미지 삭제 시 CMS API 403 오류 수정

### DIFF
--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
@@ -127,6 +127,7 @@ public class CmsBuilderClient {
             cmsBuilderRestClient
                     .delete()
                     .uri(DELETE_PATH_TEMPLATE, assetId)
+                    .header("x-deploy-token", properties.getDeploySecret())
                     .retrieve()
                     .toBodilessEntity();
 

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
@@ -78,11 +78,10 @@ public class CmsBuilderClient {
         try {
             // cmsBuilderRestClient 사용 — 대용량 업로드를 위해 60초 read-timeout 유지 (#177)
             // deploy 클라이언트(10초)는 파일 이동 전용이므로 업로드에 사용하면 타임아웃 위험이 있다.
-            // x-deploy-token은 header()로 직접 주입하여 서버 간 인증을 통과시킨다.
+            // x-deploy-token은 빈 설정의 defaultHeader로 주입되므로 여기서 별도 지정하지 않는다.
             CmsBuilderUploadApiResponse response = cmsBuilderRestClient
                     .post()
                     .uri(properties.getUploadPath())
-                    .header("x-deploy-token", properties.getDeploySecret())
                     .contentType(MediaType.MULTIPART_FORM_DATA)
                     .body(form)
                     .retrieve()
@@ -124,10 +123,10 @@ public class CmsBuilderClient {
      */
     public void delete(String assetId, String userId) {
         try {
+            // x-deploy-token은 빈 설정의 defaultHeader로 주입되므로 여기서 별도 지정하지 않는다.
             cmsBuilderRestClient
                     .delete()
                     .uri(DELETE_PATH_TEMPLATE, assetId)
-                    .header("x-deploy-token", properties.getDeploySecret())
                     .retrieve()
                     .toBodilessEntity();
 

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/config/CmsBuilderConfig.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/config/CmsBuilderConfig.java
@@ -21,10 +21,16 @@ public class CmsBuilderConfig {
 
     private final CmsBuilderProperties properties;
 
-    /** CMS Builder 전용 RestClient — 업로드·삭제 호출에 사용 (대용량 업로드를 고려한 long read-timeout) */
+    /**
+     * CMS Builder 전용 RestClient — 업로드·삭제 호출에 사용 (대용량 업로드를 고려한 long read-timeout).
+     * CMS 엔드포인트는 x-deploy-token 헤더 인증을 요구하므로 defaultHeader로 고정 주입한다.
+     */
     @Bean
     public RestClient cmsBuilderRestClient() {
-        return buildClient(properties.getConnectTimeoutSeconds(), properties.getReadTimeoutSeconds());
+        return buildClient(properties.getConnectTimeoutSeconds(), properties.getReadTimeoutSeconds())
+                .mutate()
+                .defaultHeader("x-deploy-token", properties.getDeploySecret())
+                .build();
     }
 
     /**

--- a/html-cms/src/app/api/assets/[assetId]/route.ts
+++ b/html-cms/src/app/api/assets/[assetId]/route.ts
@@ -1,7 +1,6 @@
 // src/app/api/assets/[assetId]/route.ts
 // 에셋 단건 삭제 API
 
-import { timingSafeEqual } from 'crypto';
 import { unlink } from 'fs/promises';
 
 import { NextRequest } from 'next/server';
@@ -9,23 +8,7 @@ import { NextRequest } from 'next/server';
 import { deleteAsset, getAssetById, hardDeleteAsset } from '@/db/repository/asset.repository';
 import { errorResponse, getErrorMessage, successResponse } from '@/lib/api-response';
 import { canWriteCms, getCurrentUser } from '@/lib/current-user';
-import { DEPLOY_SECRET } from '@/lib/env';
-
-/**
- * Admin 백엔드 등 서버 간 호출 시 x-deploy-token 헤더로 인증한다.
- * 타이밍 공격 방지를 위해 timingSafeEqual로 비교한다.
- */
-function isValidToken(token: string | null): boolean {
-    if (!DEPLOY_SECRET || !token) return false;
-    try {
-        const expected = Buffer.from(DEPLOY_SECRET, 'utf8');
-        const received = Buffer.from(token, 'utf8');
-        if (expected.length !== received.length) return false;
-        return timingSafeEqual(expected, received);
-    } catch {
-        return false;
-    }
-}
+import { isValidDeployToken } from '@/lib/server-auth';
 
 /**
  * DELETE /api/assets/:assetId — 에셋 삭제
@@ -46,7 +29,7 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ a
         let userId: string;
         let userName: string;
 
-        if (isValidToken(req.headers.get('x-deploy-token'))) {
+        if (isValidDeployToken(req.headers.get('x-deploy-token'))) {
             // 서버 간 호출(Admin 백엔드): 세션 없이 시스템 계정으로 처리
             userId = 'SYSTEM';
             userName = 'SYSTEM';

--- a/html-cms/src/app/api/assets/[assetId]/route.ts
+++ b/html-cms/src/app/api/assets/[assetId]/route.ts
@@ -1,19 +1,38 @@
 // src/app/api/assets/[assetId]/route.ts
 // 에셋 단건 삭제 API
 
+import { timingSafeEqual } from 'crypto';
 import { unlink } from 'fs/promises';
 
 import { NextRequest } from 'next/server';
 
 import { deleteAsset, getAssetById, hardDeleteAsset } from '@/db/repository/asset.repository';
+import { errorResponse, getErrorMessage, successResponse } from '@/lib/api-response';
 import { canWriteCms, getCurrentUser } from '@/lib/current-user';
-import { successResponse, errorResponse, getErrorMessage } from '@/lib/api-response';
+import { DEPLOY_SECRET } from '@/lib/env';
+
+/**
+ * Admin 백엔드 등 서버 간 호출 시 x-deploy-token 헤더로 인증한다.
+ * 타이밍 공격 방지를 위해 timingSafeEqual로 비교한다.
+ */
+function isValidToken(token: string | null): boolean {
+    if (!DEPLOY_SECRET || !token) return false;
+    try {
+        const expected = Buffer.from(DEPLOY_SECRET, 'utf8');
+        const received = Buffer.from(token, 'utf8');
+        if (expected.length !== received.length) return false;
+        return timingSafeEqual(expected, received);
+    } catch {
+        return false;
+    }
+}
 
 /**
  * DELETE /api/assets/:assetId — 에셋 삭제
  * - APPROVED: 논리 삭제 (USE_YN = 'N') — 페이지 참조 보존
  * - WORK/PENDING/REJECTED: 물리 삭제 (DB row 완전 제거)
  * - 모든 상태에서 물리 파일은 제거
+ * - x-deploy-token 헤더 유효 시 세션 없이 서버 간 호출 허용 (Admin 백엔드용)
  */
 export async function DELETE(req: NextRequest, { params }: { params: Promise<{ assetId: string }> }) {
     try {
@@ -24,11 +43,21 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ a
             return errorResponse('에셋을 찾을 수 없습니다.', 404);
         }
 
-        const currentUser = await getCurrentUser();
-        if (!canWriteCms(currentUser)) {
-            return errorResponse('Permission denied.', 403);
+        let userId: string;
+        let userName: string;
+
+        if (isValidToken(req.headers.get('x-deploy-token'))) {
+            // 서버 간 호출(Admin 백엔드): 세션 없이 시스템 계정으로 처리
+            userId = 'SYSTEM';
+            userName = 'SYSTEM';
+        } else {
+            const currentUser = await getCurrentUser();
+            if (!canWriteCms(currentUser)) {
+                return errorResponse('Permission denied.', 403);
+            }
+            userId = currentUser.userId;
+            userName = currentUser.userName;
         }
-        const { userId, userName } = currentUser;
 
         // 상태별 DB 삭제 처리
         if (asset.ASSET_STATE === 'APPROVED') {

--- a/html-cms/src/app/api/builder/upload/route.ts
+++ b/html-cms/src/app/api/builder/upload/route.ts
@@ -1,4 +1,4 @@
-import crypto, { timingSafeEqual } from 'crypto';
+import crypto from 'crypto';
 import { mkdir, unlink, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
 
@@ -8,23 +8,8 @@ import { createAsset } from '@/db/repository/asset.repository';
 import { contentBuilderErrorResponse, getErrorMessage, successResponse } from '@/lib/api-response';
 import { normalizeCmsAssetCategory } from '@/lib/codes';
 import { canAccessCmsEdit, getCurrentUser } from '@/lib/current-user';
-import { ASSET_BASE_URL, ASSET_UPLOAD_DIR, DEPLOY_SECRET, SERVER_MODE } from '@/lib/env';
-
-/**
- * Admin 백엔드 등 서버 간 호출 시 x-deploy-token 헤더로 인증한다.
- * 타이밍 공격 방지를 위해 timingSafeEqual로 비교한다.
- */
-function isValidToken(token: string | null): boolean {
-    if (!DEPLOY_SECRET || !token) return false;
-    try {
-        const expected = Buffer.from(DEPLOY_SECRET, 'utf8');
-        const received = Buffer.from(token, 'utf8');
-        if (expected.length !== received.length) return false;
-        return timingSafeEqual(expected, received);
-    } catch {
-        return false;
-    }
-}
+import { ASSET_BASE_URL, ASSET_UPLOAD_DIR, SERVER_MODE } from '@/lib/env';
+import { isValidDeployToken } from '@/lib/server-auth';
 
 export async function POST(req: NextRequest) {
     if (SERVER_MODE === 'operation') {
@@ -44,7 +29,7 @@ export async function POST(req: NextRequest) {
     const assetDesc = formData.get('assetDesc')?.toString() || null;
 
     try {
-        const deployTokenValid = isValidToken(req.headers.get('x-deploy-token'));
+        const deployTokenValid = isValidDeployToken(req.headers.get('x-deploy-token'));
 
         let userId: string;
         let userName: string;

--- a/html-cms/src/lib/server-auth.ts
+++ b/html-cms/src/lib/server-auth.ts
@@ -1,0 +1,23 @@
+// src/lib/server-auth.ts
+// 서버 간 호출 인증 유틸 — x-deploy-token 헤더 검증
+
+import { timingSafeEqual } from 'crypto';
+
+import { DEPLOY_SECRET } from '@/lib/env';
+
+/**
+ * x-deploy-token 헤더 값이 서버에 설정된 DEPLOY_SECRET과 일치하는지 검증한다.
+ * Admin 백엔드 등 서버 간 호출 시 세션 없이 인증하는 용도로 사용한다.
+ * 타이밍 공격 방지를 위해 timingSafeEqual로 비교한다.
+ */
+export function isValidDeployToken(token: string | null): boolean {
+    if (!DEPLOY_SECRET || !token) return false;
+    try {
+        const expected = Buffer.from(DEPLOY_SECRET, 'utf8');
+        const received = Buffer.from(token, 'utf8');
+        if (expected.length !== received.length) return false;
+        return timingSafeEqual(expected, received);
+    } catch {
+        return false;
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

Closes #201

## ✨ 변경 사항 (Changes)

Admin에서 반려(REJECTED) 이미지 삭제 시 CMS API가 403을 반환하는 문제를 수정한다.

**원인**
Admin(`CmsBuilderClient.delete()`)은 CMS DELETE API 호출 시 `x-deploy-token` 헤더를 누락했고,
CMS(`DELETE /api/assets/:assetId`)는 해당 헤더를 검증하지 않아 세션 없는 서버 간 호출을 차단했다.

**수정 내용**
- `admin/CmsBuilderClient.java`: DELETE 요청에 `x-deploy-token` 헤더 추가 (`upload()`와 동일)
- `html-cms/src/app/api/assets/[assetId]/route.ts`: `x-deploy-token` 유효 시 세션 인증 우회, `SYSTEM` 계정으로 처리 (`upload/route.ts`와 동일한 패턴)

## ⚠️ 고려 및 주의 사항 (선택)

- CMS 서버 재배포 필요 (html-cms 변경 포함)
- `DEPLOY_SECRET` 환경변수가 양쪽 서버에 동일하게 설정되어 있어야 한다

## 💬 리뷰 포인트 (선택)

- `isValidToken()` 함수가 `upload/route.ts`에도 동일하게 존재함 — 공통 유틸로 추출할지 검토 가능 (현재는 누락 수정 범위만 최소화)