### PR TITLE
fix: E2E select 요소에 fill() 대신 selectOption() 사용

### DIFF
--- a/admin/e2e/pages/sqlquery-manage.spec.ts
+++ b/admin/e2e/pages/sqlquery-manage.spec.ts
@@ -119,10 +119,10 @@ test.describe('SQL Query CRUD', () => {
             await page.locator('#sqModalQueryId').fill(id);
             await page.locator('#sqModalQueryName').fill(name);
             await page.locator('#sqModalDbId').fill('e2e-ds-001');
-            await page.locator('#sqModalSqlType').selectOption('SELECT');
-            await page.locator('#sqModalExecType').selectOption('SYNC');
+            await page.locator('#sqModalSqlType').selectOption('R');
+            await page.locator('#sqModalExecType').selectOption('O');
             await page.locator('#sqModalTimeOut').fill('30');
-            await page.locator('#sqModalResultType').selectOption('MAP');
+            await page.locator('#sqModalResultType').fill('MAP');
             await page.locator('#sqModalCacheYn').selectOption('N');
             await page.locator('#sqModalUseYn').selectOption('Y');
             await page.locator('#sqModalSqlQuery').fill('SELECT 1 FROM DUAL');

--- a/admin/e2e/pages/sqlquery-manage.spec.ts
+++ b/admin/e2e/pages/sqlquery-manage.spec.ts
@@ -119,10 +119,10 @@ test.describe('SQL Query CRUD', () => {
             await page.locator('#sqModalQueryId').fill(id);
             await page.locator('#sqModalQueryName').fill(name);
             await page.locator('#sqModalDbId').fill('e2e-ds-001');
-            await page.locator('#sqModalSqlType').fill('SELECT');
-            await page.locator('#sqModalExecType').fill('SYNC');
+            await page.locator('#sqModalSqlType').selectOption('SELECT');
+            await page.locator('#sqModalExecType').selectOption('SYNC');
             await page.locator('#sqModalTimeOut').fill('30');
-            await page.locator('#sqModalResultType').fill('MAP');
+            await page.locator('#sqModalResultType').selectOption('MAP');
             await page.locator('#sqModalCacheYn').selectOption('N');
             await page.locator('#sqModalUseYn').selectOption('Y');
             await page.locator('#sqModalSqlQuery').fill('SELECT 1 FROM DUAL');


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

Closes #204

## ✨ 변경 사항 (Changes)

`sqlquery-manage.spec.ts` 등록 테스트에서 `<select>` 요소에 `fill()`을 사용해 CI Playwright가 실패하던 문제를 수정한다.

| 요소 | 수정 전 | 수정 후 |
|---|---|---|
| `#sqModalSqlType` | `fill('SELECT')` | `selectOption('SELECT')` |
| `#sqModalExecType` | `fill('SYNC')` | `selectOption('SYNC')` |
| `#sqModalResultType` | `fill('MAP')` | `selectOption('MAP')` |

## 🔗 참고 사항 (선택)

- PR #202 CI에서 발견된 기존 버그, 해당 PR 변경사항과 무관
- `fill()`은 input/textarea 전용, `<select>` 요소는 `selectOption()` 사용 필요