### PR TITLE
fix/#209 - CMS 주석 보강 및 제작자 화면에서 템플릿 노출 안되도록 수정

### DIFF
--- a/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/controller/CmsAbTestController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/controller/CmsAbTestController.java
@@ -24,12 +24,20 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * CMS A/B 테스트 그룹을 조회하고 편집하는 관리 API 컨트롤러.
+ *
+ * <p>승인된 CMS 페이지를 실험군으로 묶어 운영하려면 목록 조회, 그룹 저장, 가중치 조정,
+ * 우승안 승격 같은 작업을 한 흐름으로 제공해야 한다.
+ * 이 컨트롤러는 CMS 운영 화면과 A/B 테스트 도메인 서비스를 연결하는 진입점이다.
+ */
 @RestController
 @RequiredArgsConstructor
 public class CmsAbTestController {
 
     private final CmsAbTestService cmsAbTestService;
 
+    /** A/B 테스트 대시보드에 필요한 페이지 목록과 그룹 현황을 함께 조회한다. */
     @GetMapping("/api/cms-admin/ab-tests")
     @PreAuthorize("hasAuthority('CMS:R')")
     public ResponseEntity<ApiResponse<CmsAbTestDashboardResponse>> findDashboard(
@@ -41,12 +49,14 @@ public class CmsAbTestController {
         return ResponseEntity.ok(ApiResponse.success(cmsAbTestService.findDashboard(req, pageRequest)));
     }
 
+    /** 특정 그룹의 구성 페이지와 가중치를 조회해 편집 화면의 초기값으로 사용한다. */
     @GetMapping("/api/cms-admin/ab-tests/{groupId}")
     @PreAuthorize("hasAuthority('CMS:R')")
     public ResponseEntity<ApiResponse<CmsAbGroupResponse>> findGroup(@PathVariable String groupId) {
         return ResponseEntity.ok(ApiResponse.success(cmsAbTestService.findGroup(groupId)));
     }
 
+    /** 그룹을 신규 생성하거나 기존 그룹 구성을 요청 값으로 덮어쓴다. */
     @PostMapping("/api/cms-admin/ab-tests")
     @PreAuthorize("hasAuthority('CMS:W')")
     public ResponseEntity<ApiResponse<Void>> saveGroup(
@@ -55,6 +65,7 @@ public class CmsAbTestController {
         return ResponseEntity.ok(ApiResponse.success("A/B group saved.", null));
     }
 
+    /** 기존 그룹에 속한 페이지들의 노출 가중치만 수정한다. */
     @PatchMapping("/api/cms-admin/ab-tests/{groupId}/weights")
     @PreAuthorize("hasAuthority('CMS:W')")
     public ResponseEntity<ApiResponse<Void>> updateWeights(
@@ -65,6 +76,7 @@ public class CmsAbTestController {
         return ResponseEntity.ok(ApiResponse.success("A/B weights updated.", null));
     }
 
+    /** 실험 종료 후 우승 페이지를 지정해 최종안으로 승격한다. */
     @PostMapping("/api/cms-admin/ab-tests/{groupId}/promote")
     @PreAuthorize("hasAuthority('CMS:W')")
     public ResponseEntity<ApiResponse<Void>> promote(
@@ -75,6 +87,7 @@ public class CmsAbTestController {
         return ResponseEntity.ok(ApiResponse.success("A/B winner promoted.", null));
     }
 
+    /** 그룹 단위로 A/B 연결을 모두 해제해 실험을 초기화한다. */
     @DeleteMapping(value = "/api/cms-admin/ab-tests", params = "groupId")
     @PreAuthorize("hasAuthority('CMS:W')")
     public ResponseEntity<ApiResponse<Void>> clearGroup(
@@ -83,6 +96,7 @@ public class CmsAbTestController {
         return ResponseEntity.ok(ApiResponse.success("A/B group cleared.", null));
     }
 
+    /** 특정 페이지만 그룹에서 제외해 부분 정리를 수행한다. */
     @DeleteMapping(value = "/api/cms-admin/ab-tests", params = "pageId")
     @PreAuthorize("hasAuthority('CMS:W')")
     public ResponseEntity<ApiResponse<Void>> clearPage(

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/dto/CmsAbGroupPageResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/dto/CmsAbGroupPageResponse.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+/** 그룹 상세 조회 시 각 페이지의 가중치와 성과 지표를 보여주기 위한 응답 DTO. */
 public class CmsAbGroupPageResponse {
 
     private String pageId;

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/dto/CmsAbGroupResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/dto/CmsAbGroupResponse.java
@@ -13,6 +13,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+/** 특정 A/B 그룹의 식별자와 소속 페이지 목록을 반환하는 응답 DTO. */
 public class CmsAbGroupResponse {
 
     private String groupId;

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/dto/CmsAbGroupSaveRequest.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/dto/CmsAbGroupSaveRequest.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+/** 그룹 ID와 구성 페이지 목록을 함께 저장할 때 사용하는 요청 DTO. */
 public class CmsAbGroupSaveRequest {
 
     private String groupId;

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/dto/CmsAbPageResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/dto/CmsAbPageResponse.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+/** A/B 테스트 대상 페이지 목록과 현재 실험 상태를 표현하는 응답 DTO. */
 public class CmsAbPageResponse {
 
     private String pageId;

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/dto/CmsAbPageWeightRequest.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/dto/CmsAbPageWeightRequest.java
@@ -8,6 +8,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+/** 그룹 저장 또는 가중치 수정 시 페이지별 노출 비율을 전달하는 DTO. */
 public class CmsAbPageWeightRequest {
 
     private String pageId;

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/dto/CmsAbPromoteRequest.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/dto/CmsAbPromoteRequest.java
@@ -7,6 +7,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+/** 실험 종료 시 우승 페이지를 지정하기 위한 요청 DTO. */
 public class CmsAbPromoteRequest {
 
     private String winnerPageId;

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/dto/CmsAbTestDashboardResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/dto/CmsAbTestDashboardResponse.java
@@ -13,6 +13,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+/** A/B 테스트 대시보드에 필요한 페이지 목록, 그룹 정보, 선택 후보를 함께 반환하는 응답 DTO. */
 public class CmsAbTestDashboardResponse {
 
     private PageResponse<CmsAbPageResponse> pages;

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/dto/CmsAbTestListRequest.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/dto/CmsAbTestListRequest.java
@@ -7,6 +7,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+/** A/B 테스트 대시보드 조회 조건을 담는 요청 DTO. */
 public class CmsAbTestListRequest {
 
     private String search;

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/dto/CmsAbWeightUpdateRequest.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/dto/CmsAbWeightUpdateRequest.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+/** 기존 A/B 그룹의 페이지 가중치만 수정할 때 사용하는 요청 DTO. */
 public class CmsAbWeightUpdateRequest {
 
     private List<CmsAbPageWeightRequest> pages = new ArrayList<>();

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/mapper/CmsAbTestMapper.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/mapper/CmsAbTestMapper.java
@@ -8,42 +8,62 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+/**
+ * CMS A/B 테스트용 페이지·그룹 데이터를 조회하고 갱신하는 MyBatis 매퍼.
+ *
+ * <p>대시보드 조회, 그룹 편집, 우승안 승격이 모두 CMS 페이지 상태와 연결되므로
+ * 관련 SQL을 한 인터페이스에 모아 서비스 계층이 규칙 검증에 집중할 수 있게 한다.
+ */
 @Mapper
 public interface CmsAbTestMapper {
 
+    /** 승인된 페이지 중 대시보드 표에 노출할 목록을 조회한다. */
     List<CmsAbPageResponse> findApprovedPages(
             @Param("req") CmsAbTestListRequest req, @Param("offset") int offset, @Param("endRow") int endRow);
 
+    /** 승인된 페이지 목록의 전체 건수를 반환한다. */
     long countApprovedPages(@Param("req") CmsAbTestListRequest req);
 
+    /** 현재 A/B 그룹에 묶여 있는 페이지들을 검색 조건으로 조회한다. */
     List<CmsAbPageResponse> findAbGroupPages(@Param("search") String search);
 
+    /** 그룹에 추가 가능한 승인 페이지 후보를 조회한다. */
     List<CmsAbPageResponse> findApprovedPageOptions(@Param("search") String search);
 
+    /** 특정 그룹에 속한 페이지 상세와 가중치를 조회한다. */
     List<CmsAbGroupPageResponse> findGroupPages(@Param("groupId") String groupId);
 
+    /** 그룹에 연결된 페이지 수를 세어 존재 여부를 판단한다. */
     long countGroupPages(@Param("groupId") String groupId);
 
+    /** 전달한 페이지들이 모두 승인된 공개 가능 페이지인지 확인한다. */
     long countApprovedPagesByIds(@Param("pageIds") List<String> pageIds);
 
+    /** 다른 그룹에 이미 속한 충돌 페이지가 있는지 확인한다. */
     long countConflictingPages(@Param("groupId") String groupId, @Param("pageIds") List<String> pageIds);
 
+    /** 특정 페이지가 지정한 그룹의 구성원인지 확인한다. */
     long countPageInGroup(@Param("groupId") String groupId, @Param("pageId") String pageId);
 
+    /** 페이지를 그룹에 연결하거나 기존 연결의 가중치를 갱신한다. */
     int updateAbGroup(
             @Param("pageId") String pageId,
             @Param("groupId") String groupId,
             @Param("weight") BigDecimal weight,
             @Param("modifierId") String modifierId);
 
+    /** 그룹에 속한 모든 페이지의 A/B 연결을 해제한다. */
     int clearAbGroup(@Param("groupId") String groupId, @Param("modifierId") String modifierId);
 
+    /** 특정 페이지 하나만 A/B 그룹에서 제외한다. */
     int clearPageAbGroup(@Param("pageId") String pageId, @Param("modifierId") String modifierId);
 
+    /** 우승안 외 나머지 페이지를 패배안 상태로 정리한다. */
     int promoteLosers(
             @Param("groupId") String groupId,
             @Param("winnerPageId") String winnerPageId,
             @Param("modifierId") String modifierId);
 
+    /** 우승 페이지를 최종안으로 승격한다. */
     int setWinner(@Param("winnerPageId") String winnerPageId, @Param("modifierId") String modifierId);
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/service/CmsAbTestService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsabtest/service/CmsAbTestService.java
@@ -25,6 +25,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * CMS A/B 테스트의 비즈니스 규칙을 검증하고 그룹 상태를 변경하는 서비스.
+ *
+ * <p>A/B 테스트는 승인 상태, 공개 가능 여부, 그룹 중복, 가중치 유효성 같은 제약을 함께 확인해야 하므로
+ * 단순 매퍼 호출로 처리하기 어렵다. 이 서비스는 화면 요청을 실험 가능한 데이터 구조로 조합하고,
+ * 실험군 저장과 승격 시 데이터 일관성을 보장하기 위해 필요하다.
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -34,6 +41,7 @@ public class CmsAbTestService {
 
     private final CmsAbTestMapper cmsAbTestMapper;
 
+    /** 대시보드 화면에 필요한 페이지 목록, 그룹 목록, 선택 후보 목록을 한 번에 조합한다. */
     public CmsAbTestDashboardResponse findDashboard(CmsAbTestListRequest req, PageRequest pageRequest) {
         req.setSearch(normalize(req.getSearch()));
         long total = cmsAbTestMapper.countApprovedPages(req);
@@ -71,6 +79,7 @@ public class CmsAbTestService {
                 .build();
     }
 
+    /** 특정 그룹의 구성 페이지와 현재 가중치를 조회한다. */
     public CmsAbGroupResponse findGroup(String groupId) {
         validateGroupId(groupId);
         return CmsAbGroupResponse.builder()
@@ -79,6 +88,11 @@ public class CmsAbTestService {
                 .build();
     }
 
+    /**
+     * 그룹 전체 구성을 저장한다.
+     *
+     * <p>기존 그룹이 있더라도 먼저 연결을 비운 뒤 다시 채워 요청 시점의 구성을 최종 상태로 맞춘다.
+     */
     @Transactional
     public void saveGroup(CmsAbGroupSaveRequest req, String modifierId) {
         validateGroupId(req.getGroupId());
@@ -97,6 +111,7 @@ public class CmsAbTestService {
         }
     }
 
+    /** 기존 그룹 구성원들의 노출 가중치만 수정한다. */
     @Transactional
     public void updateWeights(String groupId, CmsAbWeightUpdateRequest req, String modifierId) {
         validateGroupExists(groupId);
@@ -108,12 +123,14 @@ public class CmsAbTestService {
         }
     }
 
+    /** 그룹에 속한 모든 페이지의 A/B 연결을 해제한다. */
     @Transactional
     public void clearGroup(String groupId, String modifierId) {
         validateGroupExists(groupId);
         cmsAbTestMapper.clearAbGroup(groupId, modifierId);
     }
 
+    /** 특정 페이지 하나만 A/B 그룹에서 제거한다. */
     @Transactional
     public void clearPage(String pageId, String modifierId) {
         validateText(pageId, "pageId is required.");
@@ -123,6 +140,11 @@ public class CmsAbTestService {
         }
     }
 
+    /**
+     * 지정한 우승 페이지를 최종안으로 승격한다.
+     *
+     * <p>우승 페이지가 실제 그룹 구성원인지 검증한 뒤 나머지 후보를 정리하고 우승안 상태를 반영한다.
+     */
     @Transactional
     public void promote(String groupId, String winnerPageId, String modifierId) {
         validateGroupExists(groupId);

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/controller/CmsAssetApprovalController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/controller/CmsAssetApprovalController.java
@@ -51,6 +51,7 @@ public class CmsAssetApprovalController {
     private final CmsAssetService cmsAssetService;
     private final CmsBuilderClient cmsBuilderClient;
 
+    /** 승인 담당자가 검토할 자산 목록을 상태·검색 조건과 함께 조회한다. */
     @GetMapping("/api/cms-admin/asset-approvals")
     @PreAuthorize("hasAuthority('CMS:R')")
     public ResponseEntity<ApiResponse<PageResponse<CmsAssetListResponse>>> findApprovalList(
@@ -92,6 +93,7 @@ public class CmsAssetApprovalController {
         return ResponseEntity.ok(ApiResponse.success(cmsAssetService.findById(assetId)));
     }
 
+    /** 승인 대기 자산을 승인하고 CMS Builder 배포까지 연계한다. */
     @PostMapping("/api/cms-admin/asset-approvals/{assetId}/approve")
     @PreAuthorize("hasAuthority('CMS:W')")
     public ResponseEntity<ApiResponse<Void>> approve(
@@ -101,6 +103,7 @@ public class CmsAssetApprovalController {
         return ResponseEntity.ok(ApiResponse.success("승인이 완료되었습니다.", null));
     }
 
+    /** 승인 대기 자산을 반려하고 검토 사유를 남긴다. */
     @PostMapping("/api/cms-admin/asset-approvals/{assetId}/reject")
     @PreAuthorize("hasAuthority('CMS:W')")
     public ResponseEntity<ApiResponse<Void>> reject(
@@ -112,6 +115,7 @@ public class CmsAssetApprovalController {
         return ResponseEntity.ok(ApiResponse.success("반려가 완료되었습니다.", null));
     }
 
+    /** 자산의 실제 노출 가능 여부를 켜거나 끈다. */
     @PostMapping("/api/cms-admin/asset-approvals/{assetId}/visibility")
     @PreAuthorize("hasAuthority('CMS:W')")
     public ResponseEntity<ApiResponse<Void>> updateVisibility(
@@ -124,6 +128,11 @@ public class CmsAssetApprovalController {
         return ResponseEntity.ok(ApiResponse.success("노출 여부가 변경되었습니다.", null));
     }
 
+    /**
+     * 관리자가 즉시 사용 가능한 자산을 업로드한다.
+     *
+     * <p>일반 사용자 업로드와 달리 승인 대기 없이 바로 승인 및 배포 흐름으로 연결된다.
+     */
     @PostMapping(value = "/api/cms-admin/asset-approvals/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasAuthority('CMS:W')")
     public ResponseEntity<ApiResponse<CmsAssetUploadResponse>> uploadApproved(

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/controller/CmsAssetCategoryController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/controller/CmsAssetCategoryController.java
@@ -10,12 +10,19 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * CMS 자산 업로드 화면에서 사용하는 카테고리 코드를 제공하는 컨트롤러.
+ *
+ * <p>카테고리 정의를 별도 하드코딩하지 않고 공통 코드 체계에서 조회해
+ * 업로드 화면과 운영 정책이 동일한 기준을 사용하도록 하기 위해 필요하다.
+ */
 @RestController
 @RequiredArgsConstructor
 public class CmsAssetCategoryController {
 
     private final CmsAssetService cmsAssetService;
 
+    /** 활성화된 CMS 자산 카테고리 목록을 조회한다. */
     @GetMapping("/api/cms-admin/asset-categories")
     @PreAuthorize("hasAuthority('CMS:R')")
     public ResponseEntity<ApiResponse<List<CodeResponse>>> getAssetCategories() {

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetService.java
@@ -27,6 +27,13 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
+/**
+ * CMS 자산 업로드, 승인, 공개 여부 변경을 담당하는 서비스.
+ *
+ * <p>이미지 자산은 단순 파일 저장으로 끝나지 않고 승인 상태 전이, CMS Builder 연동,
+ * 업로더 권한 검증, 배포 실패 보상 처리까지 함께 다뤄야 한다.
+ * 이 서비스는 Admin의 자산 운영 규칙과 외부 CMS 연동을 한곳에 모아 상태 일관성을 유지하기 위해 필요하다.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -50,6 +57,7 @@ public class CmsAssetService {
     private final AssetUploadValidator assetUploadValidator;
     private final TransactionTemplate transactionTemplate;
 
+    /** 현재 사용자가 등록한 자산 요청 목록을 조회한다. */
     @Transactional(readOnly = true)
     public PageResponse<CmsAssetListResponse> findMyRequestList(
             String currentUserId, CmsAssetRequestListRequest req, PageRequest pageRequest) {
@@ -63,6 +71,7 @@ public class CmsAssetService {
         return PageResponse.of(list, total, pageRequest.getPage(), pageRequest.getSize());
     }
 
+    /** 승인 담당자가 검토할 자산 승인 목록을 조회한다. */
     @Transactional(readOnly = true)
     public PageResponse<CmsAssetListResponse> findApprovalList(
             CmsAssetApprovalListRequest req, PageRequest pageRequest) {
@@ -74,6 +83,7 @@ public class CmsAssetService {
         return PageResponse.of(list, total, pageRequest.getPage(), pageRequest.getSize());
     }
 
+    /** 업로드 화면에서 사용할 활성 자산 카테고리 코드만 반환한다. */
     @Transactional(readOnly = true)
     public List<CodeResponse> getAssetCategoryCodes() {
         // 코드그룹의 USE_YN='Y' 항목을 그대로 노출. 카테고리 추가·폐기는 코드그룹 관리로 일원화한다.
@@ -82,6 +92,7 @@ public class CmsAssetService {
                 .toList();
     }
 
+    /** 자산 상세 모달에 필요한 메타데이터를 조회한다. */
     @Transactional(readOnly = true)
     public CmsAssetDetailResponse findById(String assetId) {
         CmsAssetDetailResponse detail = cmsAssetMapper.findDetailById(assetId);
@@ -91,6 +102,7 @@ public class CmsAssetService {
         return detail;
     }
 
+    /** 작업 중인 자산을 승인 대기 상태로 전환한다. */
     @Transactional
     public void requestApproval(String assetId, String modifierId, String modifierName) {
         assertTransition(assetId, STATE_WORK, STATE_PENDING);
@@ -153,6 +165,11 @@ public class CmsAssetService {
         }
     }
 
+    /**
+     * 일반 자산 업로드를 수행하고 CMS Builder가 발급한 자산 ID와 URL을 반환한다.
+     *
+     * <p>상태 전이는 하지 않고 파일 검증, 카테고리 정규화, 외부 업로드 연동만 담당한다.
+     */
     public CmsAssetUploadResponse uploadAsset(
             MultipartFile file, String businessCategory, String assetDesc, String uploaderId, String uploaderName) {
 
@@ -166,6 +183,11 @@ public class CmsAssetService {
                 .build();
     }
 
+    /**
+     * 관리자가 업로드 즉시 승인까지 끝내는 자산 등록 흐름을 처리한다.
+     *
+     * <p>운영자가 별도 승인 단계를 생략해야 할 때 업로드 후 바로 APPROVED 전이와 배포까지 연속 수행한다.
+     */
     public CmsAssetUploadResponse uploadApprovedAsset(
             MultipartFile file, String businessCategory, String assetDesc, String uploaderId, String uploaderName) {
 
@@ -200,6 +222,11 @@ public class CmsAssetService {
         }
     }
 
+    /**
+     * 본인이 업로드한 자산만 삭제한다.
+     *
+     * <p>승인 흐름에 들어간 자산이 임의로 제거되지 않도록 WORK 또는 REJECTED 상태만 삭제를 허용한다.
+     */
     public void deleteMyAsset(String assetId, String userId) {
         String createUserId = cmsAssetMapper.findCreateUserIdByAssetId(assetId);
         if (createUserId == null) {
@@ -220,6 +247,7 @@ public class CmsAssetService {
         log.info("CMS 이미지 삭제 요청 완료: assetId={}, prevState={}, userId={}", assetId, currentState, userId);
     }
 
+    /** 승인 대기 자산을 반려하고 사유를 함께 기록한다. */
     @Transactional
     public void reject(String assetId, String rejectedReason, String modifierId, String modifierName) {
         assertTransition(assetId, STATE_PENDING, STATE_REJECTED);
@@ -232,6 +260,7 @@ public class CmsAssetService {
         log.info("CMS 이미지 반려 완료: assetId={}, modifierId={}", assetId, modifierId);
     }
 
+    /** 자산의 실제 노출 가능 여부를 변경한다. */
     @Transactional
     public void updateVisibility(String assetId, String useYn, String modifierId, String modifierName) {
         ensureAssetExists(assetId);

--- a/admin/src/main/java/com/example/admin_demo/global/page/controller/CmsRedirectController.java
+++ b/admin/src/main/java/com/example/admin_demo/global/page/controller/CmsRedirectController.java
@@ -8,6 +8,13 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
+/**
+ * CMS 사용자 진입 URL을 역할과 요청 방식에 따라 분기하는 컨트롤러.
+ *
+ * <p>같은 메뉴에서 접속하더라도 CMS 관리자 권한 사용자는 Admin 내부 승인 화면으로,
+ * 일반 CMS 사용자는 실제 CMS 화면으로 보내야 하므로 별도 분기 지점이 필요하다.
+ * 또한 탭 기반 UI의 AJAX 요청과 일반 브라우저 직접 접근을 함께 처리한다.
+ */
 @Controller
 public class CmsRedirectController {
 
@@ -27,6 +34,12 @@ public class CmsRedirectController {
     @Value("${cms.user-url:}")
     private String cmsUserUrl;
 
+    /**
+     * 공통 CMS 진입 요청을 현재 사용자에게 맞는 최종 화면으로 보낸다.
+     *
+     * <p>관리자 계열 역할은 승인 관리 화면으로 redirect 하고, 일반 사용자는 CMS 사용자 URL로 이동시킨다.
+     * 탭 AJAX 요청인 경우에는 HTTP redirect 대신 중간 뷰를 반환해 상위 브라우저 창을 안전하게 이동시킨다.
+     */
     @GetMapping("/cms/user-dashboard")
     public String redirectCmsRoot(
             @AuthenticationPrincipal CustomUserDetails userDetails, HttpServletRequest request, Model model) {

--- a/admin/src/main/resources/mapper/oracle/cmsdashboard/CmsDashboardMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/cmsdashboard/CmsDashboardMapper.xml
@@ -32,6 +32,8 @@
         <where>
             p.USE_YN = 'Y'
             AND p.CREATE_USER_ID = #{userId}
+            <!-- 타 프로젝트의 TEMPLATE / REACT 등 다른 PAGE_TYPE 제외 — 제작자 dashboard는 일반 페이지(PAGE)만 노출 -->
+            AND p.PAGE_TYPE = 'PAGE'
             <if test="req.approveState != null and req.approveState != ''">
                 AND p.APPROVE_STATE = #{req.approveState}
             </if>

--- a/admin/src/main/resources/static/css/app.css
+++ b/admin/src/main/resources/static/css/app.css
@@ -1226,6 +1226,7 @@ span.readonly-select {
 .col-w-200 { width: 200px; }
 .col-w-250 { width: 250px; }
 .col-w-300 { width: 300px; }
+.col-w-350 { width: 350px; }
 
 /* Width utilities */
 .w-70  { width: 70px !important; }

--- a/admin/src/main/resources/templates/pages/cms-approval/cms-approval-table.html
+++ b/admin/src/main/resources/templates/pages/cms-approval/cms-approval-table.html
@@ -6,7 +6,7 @@
     <table class="table table-sm table-hover sp-data-grid" id="approvalTable">
         <thead class="table-light">
             <tr>
-                <th class="sortable" data-sort="pageName">페이지명</th>
+                <th class="col-w-350 sortable" data-sort="pageName">페이지명</th>
                 <th class="col-w-80 sortable" data-sort="viewMode">뷰모드</th>
                 <th class="col-w-90 sortable" data-sort="createUserName">작성자</th>
                 <th class="col-w-100 sortable" data-sort="approveState">승인상태</th>

--- a/admin/src/main/resources/templates/pages/cms-dashboard/cms-dashboard-script.html
+++ b/admin/src/main/resources/templates/pages/cms-dashboard/cms-dashboard-script.html
@@ -327,7 +327,18 @@
             $('#approveRequestPageId').val(pageId);
             $('#approveRequestPageName').text(row.pageName || '-');
             $('#approveRequestApproverId').html('<option value="">승인자 선택</option>');
-            $('#approveRequestBeginningDate').val(row.beginningDate || '');
+
+            // 노출 시작일 최소값 = 오늘 (과거 노출은 의미 없으므로 date picker에서 선택 불가)
+            // YYYY-MM-DD 로컬 시각 기준 — toISOString()은 UTC라 한국 시간 자정 부근에 하루 어긋날 수 있어 사용 금지
+            const now = new Date();
+            const todayStr = now.getFullYear() + '-'
+                           + String(now.getMonth() + 1).padStart(2, '0') + '-'
+                           + String(now.getDate()).padStart(2, '0');
+            $('#approveRequestBeginningDate').attr('min', todayStr);
+
+            // 재승인 케이스에서 row.beginningDate가 과거이면 빈 값으로 초기화 (min 위배 값 잔존 방지)
+            const prefBegin = row.beginningDate || '';
+            $('#approveRequestBeginningDate').val(prefBegin && prefBegin >= todayStr ? prefBegin : '');
             $('#approveRequestExpiredDate').val(row.expiredDate || '');
 
             // 승인자 목록 로드


### PR DESCRIPTION
  ## 🔗 관련 이슈 (Related Issues)
  > 머지 시 자동으로 닫을 이슈는 `Closes #이슈번호` 형식으로 적어주세요.
  > 참조만 할 경우 `- #이슈번호` 형식을 사용하세요.

  - Closes #209

  ## ✨ 변경 사항 (Changes)
  > 무엇이 바뀌었는지 핵심 내용을 설명해 주세요.

  CMS 도메인 전반의 코드 가독성을 높이고, 대시보드/승인 관리 화면의 UX·데이터 정합성을 보완했습니다.

  ### 1. CMS 도메인 주석 보강 (`feat #209 : CMS 주석 보강`)
  - `cmsabtest`(controller/service/mapper/dto 12개) · `cmsasset`(2 controller + service) · `page/CmsRedirectController` JavaDoc/인라인 주석 보강
  - 클래스 역할·메서드 동작·DTO 필드 의미를 명확히 기술하여 신규 합류자가 빠르게 컨텍스트를 잡을 수 있게 함

  ### 2. 제작자 대시보드 목록 PAGE_TYPE 가드 추가
  - 파일: `admin/src/main/resources/mapper/oracle/cmsdashboard/CmsDashboardMapper.xml`
  - `searchConditions`에 `AND p.PAGE_TYPE = 'PAGE'` 추가
  - `findMyPageList` / `countMyPageList`에 동시 적용 → 타 프로젝트가 `SPW_CMS_PAGE`에 추가한 `TEMPLATE` / `REACT` 페이지가 제작자 대시보드에 섞여 노출되지 않도록 차단
  - 기존 `cmsapproval` / `cmsabtest` / `cmsdeployment` 매퍼와 동일 패턴

  ### 3. 승인 요청 모달 노출 시작일 가드
  - 파일: `admin/src/main/resources/templates/pages/cms-dashboard/cms-dashboard-script.html`
  - `openApproveRequestModal`에서 `<input type="date">`의 `min` 속성을 오늘(YYYY-MM-DD)로 동적 설정
  - `toISOString()`(UTC) 대신 `getFullYear/getMonth/getDate`(로컬)로 자정 부근 하루 어긋남 방지
  - 재승인 케이스에서 사전 채워진 `row.beginningDate`가 과거이면 빈 값으로 초기화 (브라우저별 invalid 잔존 방지)

  ### 4. 승인 관리 화면 페이지명 컬럼 폭 축소
  - 파일:
    - `admin/src/main/resources/static/css/app.css` — `.col-w-350 { width: 350px; }` 유틸리티 추가
    - `admin/src/main/resources/templates/pages/cms-approval/cms-approval-table.html` — 페이지명 `<th>`에 `col-w-350` 적용
  - 다른 컬럼 합계(750px) + `table-layout: fixed` 환경에서 자동 폭이 약 530px → 약 2/3인 350px로 축소

  ## 📸 변경 사항 확인 (선택)
  > UI 변경이 있거나 결과물을 시각적으로 보여줄 수 있다면 첨부해 주세요.

  | 변경 전 (Before) | 변경 후 (After) |
  | :--- | :--- |
  | (대시보드 목록에 TEMPLATE/REACT 행 혼입) | (PAGE 타입만 노출) |
  | (승인 요청 모달에서 과거 날짜 선택 가능) | (오늘 이전 비활성화 + 과거 사전값 초기화) |
  | (승인 관리 페이지명 컬럼이 화면 절반 점유) | (페이지명 컬럼 350px로 축소) |

  ## ⚠️ 고려 및 주의 사항 (선택)
  > 배포 시 유의점이나 기술적 부채, 향후 영향도를 적어주세요.

  - **DDL 변경 없음** — `admin/docs/sql/oracle/` 파일 추가 불필요. SQL 변경은 매퍼 XML 동적 조건만 수정.
  - **노출 시작일 가드는 클라이언트 한정** — `<input min>` UI 가드만 적용했고 서버(`CmsDashboardService.requestApproval`) 검증은 추가하지 않았습니다. 위·변조 방지가 필요하면 서버에서 `beginningDate >= 오늘`을 추가 검증해야 합니다.
  - **`existsByPageIdAndUserId`에는 PAGE_TYPE 가드 미적용** — 본 PR은 "조회 조건"에 한정. 승인 요청·삭제 흐름의 소유권 검증에도 가드를 적용할지는 후속 판단 필요.
  - **`col-w-350` 신규 유틸리티 추가** — `app.css`의 col-w 패턴을 따라 표준 위치에 1줄 추가. 다른 화면 영향 없음.
  - **운영 환경 픽셀 폭** — `sp-data-grid`는 `table-layout: fixed` + `width: 100%`라 col-w-350은 비례 폭으로 작동. 화면 폭에 따라 실제 렌더 px가 비례 확대됩니다.

  ## 💬 리뷰 포인트 (선택)
  > 특별히 신경 써서 봐주었으면 하는 부분이나 의견이 필요한 곳을 적어주세요.

  - 대시보드 목록 외에 `existsByPageIdAndUserId` 등 다른 쿼리에도 `PAGE_TYPE='PAGE'` 가드를 일괄 적용할지 의견 부탁드립니다.
  - 승인 요청 모달의 "노출 종료일"에도 `min = 시작일` 가드를 추가할지 (시작일 ≤ 종료일 강제) 정책 확정이 필요합니다.
  - 페이지명 컬럼 폭(`col-w-350`)이 운영 화면에서 시각적으로 적절한지 확인 부탁드립니다. 더 줄이면 `col-w-300`, 더 늘리면 `col-w-400` 신규 추가로 조정 가능합니다.

  ## 🔗 참고 사항 (선택)
  > 참고 자료 혹은 추가로 전달할 사항을 적어주세요.

  - 관련 문서: `admin/docs/cms-overview.md`, `admin/docs/cms-role-policy.md`
  - `PAGE_TYPE` CHECK 제약: `('PAGE', 'TEMPLATE', 'REACT')` (`admin/docs/sql/oracle/04_alter_tables.sql`)
  - 동일 패턴 매퍼: `cmsapproval` / `cmsabtest` / `cmsdeployment`