### PR TITLE
feat: 이미지 업로드 시 사용자 정의 이미지명 지원 및 한글 인코딩 수정 (#212)

### DIFF
--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
@@ -80,7 +80,6 @@ public class CmsBuilderClient {
             String businessCategory,
             String assetDesc) {
 
-        log.info("[CmsBuilderClient.upload] assetName='{}', userId='{}'", assetName, userId);
         MultiValueMap<String, Object> form =
                 buildFormData(file, assetName, userId, userName, businessCategory, assetDesc);
 

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/client/CmsBuilderClient.java
@@ -4,6 +4,7 @@ import com.example.admin_demo.domain.cmsasset.client.dto.CmsBuilderUploadApiResp
 import com.example.admin_demo.domain.cmsasset.config.CmsBuilderProperties;
 import com.example.admin_demo.global.exception.ErrorType;
 import com.example.admin_demo.global.exception.base.BaseException;
+import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.io.Resource;
@@ -63,6 +64,7 @@ public class CmsBuilderClient {
      * CMS Builder 로 이미지 파일을 업로드한다.
      *
      * @param file             원본 이미지
+     * @param assetName        이미지 표시명 (DB 저장용, 한글 허용)
      * @param userId           업로더 ID
      * @param userName         업로더 이름
      * @param businessCategory 업무 카테고리 (선택)
@@ -71,9 +73,16 @@ public class CmsBuilderClient {
      * @throws BaseException 업로드 실패 또는 CMS 응답 오류 시 (HTTP 502)
      */
     public CmsBuilderUploadApiResponse upload(
-            MultipartFile file, String userId, String userName, String businessCategory, String assetDesc) {
+            MultipartFile file,
+            String assetName,
+            String userId,
+            String userName,
+            String businessCategory,
+            String assetDesc) {
 
-        MultiValueMap<String, Object> form = buildFormData(file, userId, userName, businessCategory, assetDesc);
+        log.info("[CmsBuilderClient.upload] assetName='{}', userId='{}'", assetName, userId);
+        MultiValueMap<String, Object> form =
+                buildFormData(file, assetName, userId, userName, businessCategory, assetDesc);
 
         try {
             // cmsBuilderRestClient 사용 — 대용량 업로드를 위해 60초 read-timeout 유지 (#177)
@@ -190,25 +199,52 @@ public class CmsBuilderClient {
         }
     }
 
-    /** 멀티파트 form-data 구성. file 은 파일명·Content-Type 을 보존하여 전송한다. */
+    /**
+     * 멀티파트 form-data 구성. file 은 파일명·Content-Type 을 보존하여 전송한다.
+     *
+     * <p>String 파트는 반드시 {@code text/plain;charset=UTF-8} HttpEntity 로 감싸야 한다.
+     * 그냥 String 을 넣으면 Spring FormHttpMessageConverter 가 ISO-8859-1 로 인코딩하여
+     * 한글(3바이트 UTF-8)이 깨진다.
+     */
     private MultiValueMap<String, Object> buildFormData(
-            MultipartFile file, String userId, String userName, String businessCategory, String assetDesc) {
+            MultipartFile file,
+            String assetName,
+            String userId,
+            String userName,
+            String businessCategory,
+            String assetDesc) {
 
         MultiValueMap<String, Object> form = new LinkedMultiValueMap<>();
         form.add("file", toFilePart(file));
+        if (assetName != null && !assetName.isBlank()) {
+            form.add("assetName", toTextPart(assetName));
+        }
         if (userId != null) {
-            form.add("userId", userId);
+            form.add("userId", toTextPart(userId));
         }
         if (userName != null) {
-            form.add("userName", userName);
+            form.add("userName", toTextPart(userName));
         }
         if (businessCategory != null && !businessCategory.isBlank()) {
-            form.add("businessCategory", businessCategory);
+            form.add("businessCategory", toTextPart(businessCategory));
         }
         if (assetDesc != null && !assetDesc.isBlank()) {
-            form.add("assetDesc", assetDesc);
+            form.add("assetDesc", toTextPart(assetDesc));
         }
         return form;
+    }
+
+    /**
+     * 문자열을 {@code text/plain;charset=UTF-8} HttpEntity 로 감싸 반환한다.
+     *
+     * <p>Spring RestClient 가 멀티파트 파트로 직렬화할 때 charset 을 명시하지 않으면
+     * FormHttpMessageConverter 기본값(ISO-8859-1)으로 처리되어 한글 등 멀티바이트 문자가 깨진다.
+     * 명시적으로 UTF-8 을 지정함으로써 한글 이미지명·사용자명 등이 CMS 측에 올바르게 전달된다.
+     */
+    private HttpEntity<String> toTextPart(String value) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType(MediaType.TEXT_PLAIN, StandardCharsets.UTF_8));
+        return new HttpEntity<>(value, headers);
     }
 
     /**

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/controller/CmsAssetApprovalController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/controller/CmsAssetApprovalController.java
@@ -128,12 +128,21 @@ public class CmsAssetApprovalController {
     @PreAuthorize("hasAuthority('CMS:W')")
     public ResponseEntity<ApiResponse<CmsAssetUploadResponse>> uploadApproved(
             @RequestParam("file") MultipartFile file,
+            @RequestParam(value = "assetName", required = false) String assetName,
             @RequestParam(value = "businessCategory", required = false) String businessCategory,
             @RequestParam(value = "assetDesc", required = false) String assetDesc,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
+        // assetName이 blank이면 원본 파일명으로 폴백하여 CMS에 항상 non-null 값을 전달
+        String resolvedAssetName = (assetName != null && !assetName.isBlank()) ? assetName : file.getOriginalFilename();
+
         CmsAssetUploadResponse response = cmsAssetService.uploadApprovedAsset(
-                file, businessCategory, assetDesc, userDetails.getUserId(), userDetails.getDisplayName());
+                file,
+                resolvedAssetName,
+                businessCategory,
+                assetDesc,
+                userDetails.getUserId(),
+                userDetails.getDisplayName());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("관리자 이미지 업로드가 완료되었습니다.", response));
     }

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/controller/CmsAssetUploadController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/controller/CmsAssetUploadController.java
@@ -46,11 +46,6 @@ public class CmsAssetUploadController {
 
         // assetName이 blank이면 원본 파일명으로 폴백하여 CMS에 항상 non-null 값을 전달
         String resolvedAssetName = (assetName != null && !assetName.isBlank()) ? assetName : file.getOriginalFilename();
-        log.info(
-                "[upload] received assetName='{}', originalFilename='{}', resolved='{}'",
-                assetName,
-                file.getOriginalFilename(),
-                resolvedAssetName);
 
         CmsAssetUploadResponse response = cmsAssetService.uploadAsset(
                 file,

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/controller/CmsAssetUploadController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/controller/CmsAssetUploadController.java
@@ -39,12 +39,26 @@ public class CmsAssetUploadController {
     @PreAuthorize("hasAuthority('CMS:W')")
     public ResponseEntity<ApiResponse<CmsAssetUploadResponse>> upload(
             @RequestParam("file") MultipartFile file,
+            @RequestParam(value = "assetName", required = false) String assetName,
             @RequestParam(value = "businessCategory", required = false) String businessCategory,
             @RequestParam(value = "assetDesc", required = false) String assetDesc,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
+        // assetName이 blank이면 원본 파일명으로 폴백하여 CMS에 항상 non-null 값을 전달
+        String resolvedAssetName = (assetName != null && !assetName.isBlank()) ? assetName : file.getOriginalFilename();
+        log.info(
+                "[upload] received assetName='{}', originalFilename='{}', resolved='{}'",
+                assetName,
+                file.getOriginalFilename(),
+                resolvedAssetName);
+
         CmsAssetUploadResponse response = cmsAssetService.uploadAsset(
-                file, businessCategory, assetDesc, userDetails.getUserId(), userDetails.getDisplayName());
+                file,
+                resolvedAssetName,
+                businessCategory,
+                assetDesc,
+                userDetails.getUserId(),
+                userDetails.getDisplayName());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("이미지 업로드가 완료되었습니다.", response));
     }

--- a/admin/src/main/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetService.java
@@ -44,6 +44,9 @@ public class CmsAssetService {
     private static final int REJECTED_REASON_MAX_CHARS = 1000;
     private static final int REJECTED_REASON_MAX_BYTES = 1000;
 
+    /** ASSET_NAME VARCHAR2(200) — Oracle UTF-8 기준 한글 1자 = 3바이트이므로 200바이트 제한 */
+    private static final int ASSET_NAME_MAX_BYTES = 200;
+
     private final CmsAssetMapper cmsAssetMapper;
     private final CodeService codeService;
     private final CmsBuilderClient cmsBuilderClient;
@@ -154,12 +157,18 @@ public class CmsAssetService {
     }
 
     public CmsAssetUploadResponse uploadAsset(
-            MultipartFile file, String businessCategory, String assetDesc, String uploaderId, String uploaderName) {
+            MultipartFile file,
+            String assetName,
+            String businessCategory,
+            String assetDesc,
+            String uploaderId,
+            String uploaderName) {
 
+        validateAssetNameBytes(assetName);
         assetUploadValidator.validate(file);
         String normalizedCategory = normalizeBusinessCategory(businessCategory);
         CmsBuilderUploadApiResponse cmsResponse =
-                cmsBuilderClient.upload(file, uploaderId, uploaderName, normalizedCategory, assetDesc);
+                cmsBuilderClient.upload(file, assetName, uploaderId, uploaderName, normalizedCategory, assetDesc);
         return CmsAssetUploadResponse.builder()
                 .assetId(cmsResponse.getAssetId())
                 .url(cmsResponse.getUrl())
@@ -167,9 +176,15 @@ public class CmsAssetService {
     }
 
     public CmsAssetUploadResponse uploadApprovedAsset(
-            MultipartFile file, String businessCategory, String assetDesc, String uploaderId, String uploaderName) {
+            MultipartFile file,
+            String assetName,
+            String businessCategory,
+            String assetDesc,
+            String uploaderId,
+            String uploaderName) {
 
-        CmsAssetUploadResponse response = uploadAsset(file, businessCategory, assetDesc, uploaderId, uploaderName);
+        CmsAssetUploadResponse response =
+                uploadAsset(file, assetName, businessCategory, assetDesc, uploaderId, uploaderName);
 
         transactionTemplate.executeWithoutResult(status -> {
             assertTransition(response.getAssetId(), STATE_WORK, STATE_APPROVED);
@@ -257,6 +272,20 @@ public class CmsAssetService {
     private void ensureAssetExists(String assetId) {
         if (cmsAssetMapper.existsByAssetId(assetId) != 1) {
             throw new NotFoundException("이미지를 찾을 수 없습니다. assetId=" + assetId);
+        }
+    }
+
+    /**
+     * 이미지명의 바이트 길이를 검증한다.
+     *
+     * <p>Oracle VARCHAR2(200)은 바이트 단위 제한이므로, 한글 1자 = 3바이트 기준으로
+     * 200바이트를 초과하면 ORA-12899가 발생한다. 서버에서 사전 차단한다.
+     */
+    private void validateAssetNameBytes(String assetName) {
+        if (assetName == null) return;
+        if (assetName.getBytes(StandardCharsets.UTF_8).length > ASSET_NAME_MAX_BYTES) {
+            throw new InvalidInputException(
+                    "이미지명이 너무 깁니다. UTF-8 기준 " + ASSET_NAME_MAX_BYTES + "바이트 이하로 입력해 주세요. (한글 약 66자)");
         }
     }
 

--- a/admin/src/main/resources/templates/pages/asset/approval-script.html
+++ b/admin/src/main/resources/templates/pages/asset/approval-script.html
@@ -487,6 +487,7 @@
 
         open: function() {
             this._clearFile();
+            $('#assetUploadName').val('');
             $('#assetUploadCategory').val('COMMON');
             $('#assetUploadDesc').val('');
             new bootstrap.Modal('#assetUploadModal').show();
@@ -508,6 +509,9 @@
             $('#assetUploadPreviewSize').text(this._formatSize(file.size));
             $('#assetUploadPreviewType').text(file.type);
 
+            // 파일 선택 시 이미지명 input에 원본 파일명 자동 채우기 (사용자가 직접 수정 가능)
+            $('#assetUploadName').val(file.name);
+
             const reader = new FileReader();
             reader.onload = (ev) => $('#assetUploadPreview').attr('src', ev.target.result);
             reader.readAsDataURL(file);
@@ -520,6 +524,8 @@
             $('#assetUploadFileInput').val('');
             $('#assetUploadPreviewWrap').addClass('d-none');
             $('#assetUploadPreview').attr('src', '');
+            // 파일 초기화 시 이미지명도 함께 초기화
+            $('#assetUploadName').val('');
             $('#btnAssetUploadSubmit').prop('disabled', true);
         },
 
@@ -529,8 +535,18 @@
                 return;
             }
 
+            // 이미지명: 사용자 입력값 우선, 비어 있으면 원본 파일명 사용
+            const inputName = $('#assetUploadName').val().trim();
+            const assetName = inputName || this.selectedFile.name;
+
             const fd = new FormData();
             fd.append('file', this.selectedFile);
+            // 원본 파일의 확장자를 보존하여 확장자 위장 방지
+            const ext = this.selectedFile.name.includes('.')
+                ? '.' + this.selectedFile.name.split('.').pop()
+                : '';
+            const nameWithoutExt = assetName.endsWith(ext) ? assetName : assetName.replace(/\.[^.]+$/, '') + ext;
+            fd.append('assetName', nameWithoutExt || this.selectedFile.name);
             fd.append('businessCategory', (($('#assetUploadCategory').val() || 'COMMON').trim() || 'COMMON'));
 
             const desc = $('#assetUploadDesc').val().trim();

--- a/admin/src/main/resources/templates/pages/asset/request-script.html
+++ b/admin/src/main/resources/templates/pages/asset/request-script.html
@@ -338,6 +338,7 @@
 
         open: function() {
             this._clearFile();
+            $('#assetUploadName').val('');
             $('#assetUploadCategory').val('COMMON');
             $('#assetUploadDesc').val('');
             new bootstrap.Modal('#assetUploadModal').show();
@@ -359,6 +360,9 @@
             $('#assetUploadPreviewSize').text(this._formatSize(file.size));
             $('#assetUploadPreviewType').text(file.type);
 
+            // 파일 선택 시 이미지명 input에 원본 파일명 자동 채우기 (사용자가 직접 수정 가능)
+            $('#assetUploadName').val(file.name);
+
             const reader = new FileReader();
             reader.onload = (ev) => $('#assetUploadPreview').attr('src', ev.target.result);
             reader.readAsDataURL(file);
@@ -371,6 +375,8 @@
             $('#assetUploadFileInput').val('');
             $('#assetUploadPreviewWrap').addClass('d-none');
             $('#assetUploadPreview').attr('src', '');
+            // 파일 초기화 시 이미지명도 함께 초기화
+            $('#assetUploadName').val('');
             $('#btnAssetUploadSubmit').prop('disabled', true);
         },
 
@@ -380,8 +386,18 @@
                 return;
             }
 
+            // 이미지명: 사용자 입력값 우선, 비어 있으면 원본 파일명 사용
+            const inputName = $('#assetUploadName').val().trim();
+            const assetName = inputName || this.selectedFile.name;
+
             const fd = new FormData();
             fd.append('file', this.selectedFile);
+            // 원본 파일의 확장자를 보존하여 확장자 위장 방지
+            const ext = this.selectedFile.name.includes('.')
+                ? '.' + this.selectedFile.name.split('.').pop()
+                : '';
+            const nameWithoutExt = assetName.endsWith(ext) ? assetName : assetName.replace(/\.[^.]+$/, '') + ext;
+            fd.append('assetName', nameWithoutExt || this.selectedFile.name);
             fd.append('businessCategory', (($('#assetUploadCategory').val() || 'COMMON').trim() || 'COMMON'));
 
             const desc = $('#assetUploadDesc').val().trim();

--- a/admin/src/main/resources/templates/pages/asset/request-upload-modal.html
+++ b/admin/src/main/resources/templates/pages/asset/request-upload-modal.html
@@ -71,6 +71,15 @@
                         </div>
 
                         <div class="row g-3">
+                            <div class="col-12">
+                                <label for="assetUploadName" class="form-label">
+                                    이미지명 <span class="text-danger">*</span>
+                                </label>
+                                <input type="text" id="assetUploadName" class="form-control form-control-sm"
+                                       maxlength="100"
+                                       placeholder="이미지명을 입력하세요. (최대 100자, 한글 가능)"/>
+                                <div class="form-text">파일 선택 시 자동으로 채워지며, 직접 수정할 수 있습니다.</div>
+                            </div>
                             <div class="col-md-6">
                                 <label for="assetUploadCategory" class="form-label">
                                     업무 카테고리 <span class="text-danger">*</span>

--- a/admin/src/test/java/com/example/admin_demo/domain/cmsasset/controller/CmsAssetUploadControllerTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/cmsasset/controller/CmsAssetUploadControllerTest.java
@@ -50,7 +50,7 @@ class CmsAssetUploadControllerTest {
     @DisplayName("[업로드] CMS:W 권한 + 정상 파일 → 201")
     void upload_withCmsW_returns201() throws Exception {
         MockMultipartFile file = new MockMultipartFile("file", "a.png", "image/png", new byte[] {1, 2, 3});
-        given(cmsAssetService.uploadAsset(any(), any(), any(), eq("cmsUser01"), any()))
+        given(cmsAssetService.uploadAsset(any(), any(), any(), any(), eq("cmsUser01"), any()))
                 .willReturn(CmsAssetUploadResponse.builder()
                         .assetId("uuid-1")
                         .url("/static/a.png")
@@ -58,6 +58,7 @@ class CmsAssetUploadControllerTest {
 
         mockMvc.perform(multipart(URL)
                         .file(file)
+                        .param("assetName", "배너이미지.png")
                         .param("businessCategory", "마케팅")
                         .with(csrf())
                         .with(user(customUserDetails("cmsUser01", "CMS:W"))))
@@ -65,6 +66,22 @@ class CmsAssetUploadControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.assetId").value("uuid-1"))
                 .andExpect(jsonPath("$.data.url").value("/static/a.png"));
+    }
+
+    @Test
+    @DisplayName("[업로드] assetName 미전달 시 원본 파일명으로 폴백 → 201")
+    void upload_withoutAssetName_fallsBackToOriginalFilename() throws Exception {
+        MockMultipartFile file = new MockMultipartFile("file", "a.png", "image/png", new byte[] {1, 2, 3});
+        // assetName이 없으면 컨트롤러에서 getOriginalFilename()("a.png")로 폴백
+        given(cmsAssetService.uploadAsset(any(), eq("a.png"), any(), any(), eq("cmsUser01"), any()))
+                .willReturn(CmsAssetUploadResponse.builder()
+                        .assetId("uuid-2")
+                        .url("/static/a.png")
+                        .build());
+
+        mockMvc.perform(multipart(URL).file(file).with(csrf()).with(user(customUserDetails("cmsUser01", "CMS:W"))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true));
     }
 
     @Test
@@ -82,7 +99,7 @@ class CmsAssetUploadControllerTest {
         MockMultipartFile file = new MockMultipartFile("file", "a.exe", "application/x-msdownload", new byte[] {1});
         willThrow(new InvalidInputException("허용하지 않는 형식"))
                 .given(cmsAssetService)
-                .uploadAsset(any(), any(), any(), any(), any());
+                .uploadAsset(any(), any(), any(), any(), any(), any());
 
         mockMvc.perform(multipart(URL).file(file).with(csrf()).with(user(customUserDetails("cmsUser01", "CMS:W"))))
                 .andExpect(status().isBadRequest());
@@ -94,7 +111,7 @@ class CmsAssetUploadControllerTest {
         MockMultipartFile file = new MockMultipartFile("file", "a.png", "image/png", new byte[] {1});
         willThrow(new BaseException(ErrorType.EXTERNAL_SERVICE_ERROR, "CMS 통신 오류"))
                 .given(cmsAssetService)
-                .uploadAsset(any(), any(), any(), any(), any());
+                .uploadAsset(any(), any(), any(), any(), any(), any());
 
         mockMvc.perform(multipart(URL).file(file).with(csrf()).with(user(customUserDetails("cmsUser01", "CMS:W"))))
                 .andExpect(status().isBadGateway());

--- a/admin/src/test/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetServiceUploadTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/cmsasset/service/CmsAssetServiceUploadTest.java
@@ -66,15 +66,27 @@ class CmsAssetServiceUploadTest {
     void uploadAsset_happyPath_returnsResponse() {
         givenCategoryExists("카테고리A");
         MockMultipartFile file = new MockMultipartFile("file", "a.png", "image/png", new byte[] {1, 2, 3});
-        given(cmsBuilderClient.upload(eq(file), eq(USER_ID), eq(USER_NAME), eq("카테고리A"), eq("설명")))
+        given(cmsBuilderClient.upload(eq(file), eq("배너.png"), eq(USER_ID), eq(USER_NAME), eq("카테고리A"), eq("설명")))
                 .willReturn(buildCmsResponse("uuid-1", "/static/a.png"));
 
-        CmsAssetUploadResponse result = cmsAssetService.uploadAsset(file, "카테고리A", "설명", USER_ID, USER_NAME);
+        CmsAssetUploadResponse result = cmsAssetService.uploadAsset(file, "배너.png", "카테고리A", "설명", USER_ID, USER_NAME);
 
         assertThat(result.getAssetId()).isEqualTo("uuid-1");
         assertThat(result.getUrl()).isEqualTo("/static/a.png");
         then(assetUploadValidator).should().validate(file);
-        then(cmsBuilderClient).should().upload(file, USER_ID, USER_NAME, "카테고리A", "설명");
+        then(cmsBuilderClient).should().upload(file, "배너.png", USER_ID, USER_NAME, "카테고리A", "설명");
+    }
+
+    @Test
+    @DisplayName("[업로드] 이미지명이 200바이트 초과이면 CMS 호출하지 않고 400 예외 전파")
+    void uploadAsset_assetNameTooLong_throwsInvalidInputException() {
+        // 한글 1자 = 3바이트 → 68자 × 3 = 204바이트 > 200바이트
+        String longName = "가".repeat(68) + ".png";
+        MockMultipartFile file = new MockMultipartFile("file", "a.png", "image/png", new byte[] {1});
+
+        assertThatThrownBy(() -> cmsAssetService.uploadAsset(file, longName, null, null, USER_ID, USER_NAME))
+                .isInstanceOf(InvalidInputException.class);
+        then(cmsBuilderClient).should(never()).upload(any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -85,9 +97,9 @@ class CmsAssetServiceUploadTest {
                 .given(assetUploadValidator)
                 .validate(any(MultipartFile.class));
 
-        assertThatThrownBy(() -> cmsAssetService.uploadAsset(file, null, null, USER_ID, USER_NAME))
+        assertThatThrownBy(() -> cmsAssetService.uploadAsset(file, "a.exe", null, null, USER_ID, USER_NAME))
                 .isInstanceOf(InvalidInputException.class);
-        then(cmsBuilderClient).should(never()).upload(any(), any(), any(), any(), any());
+        then(cmsBuilderClient).should(never()).upload(any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -96,14 +108,16 @@ class CmsAssetServiceUploadTest {
         // 공백 카테고리 → DEFAULT_BUSINESS_CATEGORY("COMMON")로 폴백 → 검증 통과 stub
         givenCategoryExists(CmsAssetService.DEFAULT_BUSINESS_CATEGORY);
         MockMultipartFile file = new MockMultipartFile("file", "a.png", "image/png", new byte[] {1});
-        given(cmsBuilderClient.upload(any(), any(), any(), any(), any()))
+        given(cmsBuilderClient.upload(any(), any(), any(), any(), any(), any()))
                 .willReturn(buildCmsResponse("uuid-2", "/static/b.png"));
 
-        cmsAssetService.uploadAsset(file, "   ", "", USER_ID, USER_NAME);
+        cmsAssetService.uploadAsset(file, "a.png", "   ", "", USER_ID, USER_NAME);
 
         // 공백 businessCategory 는 normalizeBusinessCategory() 에서 COMMON 으로 정규화된다.
         // 빈 문자열 assetDesc 는 null/blank 체크 없이 그대로 CMS 로 전달된다.
-        then(cmsBuilderClient).should().upload(file, USER_ID, USER_NAME, CmsAssetService.DEFAULT_BUSINESS_CATEGORY, "");
+        then(cmsBuilderClient)
+                .should()
+                .upload(file, "a.png", USER_ID, USER_NAME, CmsAssetService.DEFAULT_BUSINESS_CATEGORY, "");
     }
 
     private CmsBuilderUploadApiResponse buildCmsResponse(String assetId, String url) {

--- a/html-cms/src/app/api/builder/upload/route.ts
+++ b/html-cms/src/app/api/builder/upload/route.ts
@@ -72,7 +72,6 @@ export async function POST(req: NextRequest) {
         const buffer = Buffer.from(await file.arrayBuffer());
         const assetId = crypto.randomUUID();
 
-        console.log('[upload route] assetNameInput=%s, file.name=%s', assetNameInput, file.name);
         // 표시명(DB 저장): 사용자 입력명 우선, 없으면 원본 파일명 그대로 사용 (한글 허용)
         const assetName = assetNameInput || file.name;
 

--- a/html-cms/src/app/api/builder/upload/route.ts
+++ b/html-cms/src/app/api/builder/upload/route.ts
@@ -42,6 +42,8 @@ export async function POST(req: NextRequest) {
     const bodyUserName = formData.get('userName')?.toString() || null;
     const businessCategoryInput = formData.get('businessCategory')?.toString() || null;
     const assetDesc = formData.get('assetDesc')?.toString() || null;
+    // 사용자가 직접 입력한 표시명. Admin 서버에서 항상 채워서 전달하므로 없을 경우 원본 파일명 폴백
+    const assetNameInput = formData.get('assetName')?.toString().trim() || null;
 
     try {
         const deployTokenValid = isValidToken(req.headers.get('x-deploy-token'));
@@ -69,9 +71,14 @@ export async function POST(req: NextRequest) {
 
         const buffer = Buffer.from(await file.arrayBuffer());
         const assetId = crypto.randomUUID();
-        const assetName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
 
-        const filename = `${assetId}_${assetName}`;
+        console.log('[upload route] assetNameInput=%s, file.name=%s', assetNameInput, file.name);
+        // 표시명(DB 저장): 사용자 입력명 우선, 없으면 원본 파일명 그대로 사용 (한글 허용)
+        const assetName = assetNameInput || file.name;
+
+        // 파일시스템 저장명: 영문·숫자·점·하이픈만 허용하여 OS 경로 안전성 확보
+        const safeFilename = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
+        const filename = `${assetId}_${safeFilename}`;
         const filepath = join(ASSET_UPLOAD_DIR, filename);
         await mkdir(dirname(filepath), { recursive: true });
         await writeFile(filepath, buffer);


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

Closes #212

## ✨ 변경 사항 (Changes)

### Admin (Spring Boot)
- **이미지명 입력 필드 추가** — 업로드 모달(`request-upload-modal.html`)에 `assetUploadName` 입력 필드 추가. 파일 선택 시 원본 파일명으로 자동 채워지며, 사용자가 직접 수정 가능
- **두 화면 공통 적용** — 이미지 승인요청 화면 / 이미지 승인관리 화면 모두 동일 모달 fragment 공유 → 1개 파일 변경으로 양쪽 반영
- **확장자 위장 방지** — JS에서 사용자 입력명에 원본 파일의 확장자를 강제 보존 (ex. `.jpg` 파일에 `.png` 이름 입력 불가)
- **assetName Controller 파라미터 추가** — `CmsAssetUploadController`, `CmsAssetApprovalController` 업로드 엔드포인트에 `assetName` 파라미터 수신. null/blank 이면 `getOriginalFilename()`으로 폴백
- **바이트 길이 검증** — `CmsAssetService.validateAssetNameBytes()`: Oracle VARCHAR2(200) 바이트 제한 초과 시 400 예외 사전 차단 (한글 약 66자)
- **한글 인코딩 버그 수정** — `CmsBuilderClient.buildFormData()`: 멀티파트 텍스트 파트를 `HttpEntity<String>` + `Content-Type: text/plain; charset=UTF-8`로 감싸 전송. 기존 plain String 방식은 `FormHttpMessageConverter` 기본값(ISO-8859-1)으로 인코딩되어 한글이 깨지는 문제 해결
- **단위 테스트 추가** — 정상 흐름 / 이름 길이 초과 / Validator 실패 / 공백 카테고리 정규화 / 권한 검증 시나리오

### html-cms (Next.js)
- **route.ts assetName 수신** — `formData.get('assetName')`으로 Admin 전달값 수신. 없을 경우 `file.name` 폴백
- **표시명/파일명 분리** — DB에 저장되는 `assetName`(한글 가능)과 파일시스템의 `safeFilename`(영숫자만)을 명시적으로 분리
- **디버그 로그 추가** — 업로드 흐름 추적을 위한 임시 로그 추가 (`assetNameInput`, `file.name`)

## ⚠️ 고려 및 주의 사항

- 기존 업로드된 이미지의 `ASSET_NAME`은 원본 파일명으로 저장된 상태 — 소급 수정 미적용 (의도적 결정)
- 디버그 로그(`log.info`, `console.log`)는 이슈 검증 후 제거 예정

## 💬 리뷰 포인트

- `CmsBuilderClient.toTextPart()`: Spring `RestClient` 멀티파트에서 한글 텍스트 파트 인코딩 방식 검토
- JS 확장자 강제 보존 로직 (`_submit()`의 `ext`, `nameWithoutExt` 계산) — 엣지 케이스 확인