### PR TITLE
🐛 feature/#225-이미지팝업배너편집적용수정

### DIFF
--- a/html-cms/public/assets/plugins/popup-banner/index.js
+++ b/html-cms/public/assets/plugins/popup-banner/index.js
@@ -79,8 +79,11 @@ export default {
     editor: {
         openContentEditor(element, builder, onChange) {
             // 설정 버튼 클릭 → CustomEvent dispatch → EditClient.tsx에서 PopupBannerEditor 모달 오픈
+            // onChange: ContentBuilder에 변경 사실을 알려 내부 HTML 스냅샷을 갱신하는 콜백
+            //   PopupBannerEditor가 setAttribute 후 onChange()를 호출해야
+            //   applyBehavior() 시 ContentBuilder가 구 스냅샷으로 DOM을 복원하지 않는다.
             document.dispatchEvent(
-                new CustomEvent('spw:popup-banner:edit', { detail: { element } })
+                new CustomEvent('spw:popup-banner:edit', { detail: { element, onChange } })
             );
             // ContentBuilder가 appendChild할 수 있도록 빈 container 반환 (숨김)
             const container = document.createElement('div');

--- a/html-cms/public/assets/plugins/popup-banner/index.js
+++ b/html-cms/public/assets/plugins/popup-banner/index.js
@@ -101,8 +101,10 @@ export default {
         if (existingSheet) existingSheet.remove();
 
         // 뷰어 모드: 동일 페이지 첫 번째 팝업만 활성화
+        // ContentBuilderRuntime은 data-cb-type 속성으로 플러그인을 식별하며 data-component-id를 부여하지 않으므로
+        // data-cb-type 선택자를 사용해야 팝업 배너 요소를 올바르게 찾을 수 있다.
         if (!isEditor) {
-            const allBanners = document.querySelectorAll('[data-component-id^="popup-banner"]');
+            const allBanners = document.querySelectorAll('[data-cb-type="popup-banner"]');
             if (allBanners[0] !== element) return {};
             // "N일간 보지 않기" 기간 내이면 미표시 (미리보기 모드에서는 항상 표시)
             if (!isPreviewMode() && isHiddenUntil(pageId)) return {};

--- a/html-cms/public/assets/plugins/popup-banner/style.css
+++ b/html-cms/public/assets/plugins/popup-banner/style.css
@@ -45,7 +45,8 @@ body[data-view-mode="responsive"] .pb-sheet {
 }
 
 /* ── 에디터 모드: inline 고정 표시 ── */
-[data-component-id^="popup-banner"] .pb-sheet--editor {
+/* data-cb-type: ContentBuilderRuntime이 플러그인 식별에 사용하는 실제 속성 */
+[data-cb-type="popup-banner"] .pb-sheet--editor {
     position: relative;
     transform: none;
     border-radius: 20px 20px 0 0;

--- a/html-cms/scripts/migrate-popup-banner.ts
+++ b/html-cms/scripts/migrate-popup-banner.ts
@@ -8,11 +8,8 @@ import { closePool } from '../src/db/connection';
 
 const THUMBNAIL = '/assets/minimalist-blocks/preview/ibk-popup-banner.svg';
 
-/** 기본 샘플 이미지 데이터 */
-const DEFAULT_IMAGES = JSON.stringify([
-    { url: '/uploads/sample-banner-1.jpg', link: '#', alt: '이벤트 배너 1' },
-    { url: '/uploads/sample-banner-2.jpg', link: '#', alt: '이벤트 배너 2' },
-]);
+/** 기본 이미지 데이터 — 빈 배열로 시작하여 편집 모달에서 이미지를 직접 추가하도록 유도 */
+const DEFAULT_IMAGES = JSON.stringify([]);
 
 /** 뷰 모드별 초기 HTML — data-component-id 루트 + data-cb-type(ContentBuilder 플러그인 식별용) */
 function buildHtml(viewMode: string): string {

--- a/html-cms/src/components/edit/EditClient.tsx
+++ b/html-cms/src/components/edit/EditClient.tsx
@@ -328,6 +328,8 @@ export default function EditClient({
     const [infoCardBlock, setInfoCardBlock] = useState<HTMLElement | null>(null);
     // popup-banner 이미지 팝업 배너 편집 패널
     const [popupBannerBlock, setPopupBannerBlock] = useState<HTMLElement | null>(null);
+    // popup-banner onChange: ContentBuilder 스냅샷 갱신 콜백 (openContentEditor 세 번째 인자)
+    const [popupBannerOnChange, setPopupBannerOnChange] = useState<(() => void) | null>(null);
     // status-card 현황 카드 편집 모달
     const [statusCardBlock, setStatusCardBlock] = useState<HTMLElement | null>(null);
     const [myDataAssetBlock, setMyDataAssetBlock] = useState<HTMLElement | null>(null);
@@ -901,13 +903,14 @@ export default function EditClient({
                 btn.addEventListener('click', (e) => {
                     e.stopPropagation();
                     e.preventDefault();
+                    // popup-banner는 data-component-id 없이 data-cb-type만 사용
                     const block =
                         document
                             .querySelector<HTMLElement>('.icon-active')
-                            ?.closest<HTMLElement>('[data-component-id^="popup-banner"]') ??
+                            ?.closest<HTMLElement>('[data-cb-type="popup-banner"]') ??
                         document
                             .querySelector<HTMLElement>('.elm-active')
-                            ?.closest<HTMLElement>('[data-component-id^="popup-banner"]');
+                            ?.closest<HTMLElement>('[data-cb-type="popup-banner"]');
                     if (block) setPopupBannerBlock(block);
                 });
                 linkTool.appendChild(btn);
@@ -949,9 +952,10 @@ export default function EditClient({
             }
             const pbBtn = document.querySelector<HTMLElement>(`#divLinkTool .${SPW_PB_BTN_CLASS}`);
             if (pbBtn) {
+                // popup-banner는 data-component-id 없이 data-cb-type만 사용
                 const isInPb =
-                    !!iconActive?.closest('[data-component-id^="popup-banner"]') ||
-                    !!elmActive?.closest('[data-component-id^="popup-banner"]');
+                    !!iconActive?.closest('[data-cb-type="popup-banner"]') ||
+                    !!elmActive?.closest('[data-cb-type="popup-banner"]');
                 pbBtn.style.display = isInPb ? 'flex' : 'none';
             }
         };
@@ -2014,8 +2018,13 @@ export default function EditClient({
     // popup-banner 편집 버튼 클릭 이벤트 수신 (index.js → CustomEvent → 패널 오픈)
     useEffect(() => {
         const handleEditEvent = (e: Event) => {
-            const block = (e as CustomEvent<{ element: HTMLElement }>).detail?.element;
-            if (block) setPopupBannerBlock(block);
+            const detail = (e as CustomEvent<{ element: HTMLElement; onChange?: () => void }>).detail;
+            if (detail?.element) {
+                setPopupBannerBlock(detail.element);
+                // useState setter에 함수를 직접 넘기면 React가 state updater로 해석하므로
+                // () => fn 형태로 래핑하여 함수 자체를 state 값으로 저장
+                setPopupBannerOnChange(() => detail.onChange ?? null);
+            }
         };
         document.addEventListener('spw:popup-banner:edit', handleEditEvent);
         return () => document.removeEventListener('spw:popup-banner:edit', handleEditEvent);
@@ -2867,7 +2876,14 @@ export default function EditClient({
 
             {/* ── popup-banner 이미지 팝업 편집 패널 ── */}
             {popupBannerBlock && (
-                <PopupBannerEditor blockEl={popupBannerBlock} onClose={() => setPopupBannerBlock(null)} />
+                <PopupBannerEditor
+                    blockEl={popupBannerBlock}
+                    cbOnChange={popupBannerOnChange}
+                    onClose={() => {
+                        setPopupBannerBlock(null);
+                        setPopupBannerOnChange(null);
+                    }}
+                />
             )}
 
             {/* ── site-footer 드롭다운 편집 패널 ── */}

--- a/html-cms/src/components/edit/PopupBannerEditor.tsx
+++ b/html-cms/src/components/edit/PopupBannerEditor.tsx
@@ -18,6 +18,8 @@ interface BannerImage {
 
 interface Props {
     blockEl: HTMLElement;
+    /** ContentBuilder openContentEditor 세 번째 인자 — 호출 시 ContentBuilder가 현재 DOM을 스냅샷하여 내부 HTML 갱신 */
+    cbOnChange?: (() => void) | null;
     onClose: () => void;
 }
 
@@ -51,11 +53,8 @@ function parseHideDays(el: HTMLElement): number {
 
 const FONT = "-apple-system,BlinkMacSystemFont,'Malgun Gothic','Apple SD Gothic Neo',sans-serif";
 
-export default function PopupBannerEditor({ blockEl, onClose }: Props) {
-    const [images, setImages] = useState<BannerImage[]>(() => {
-        const parsed = parseImages(blockEl);
-        return parsed.length > 0 ? parsed : [{ url: '', link: '#', alt: '' }];
-    });
+export default function PopupBannerEditor({ blockEl, cbOnChange, onClose }: Props) {
+    const [images, setImages] = useState<BannerImage[]>(() => parseImages(blockEl));
     const [hideDays, setHideDays] = useState<number>(() => parseHideDays(blockEl));
 
     // ── 이미지 필드 변경 ─────────────────────────────────────────────────
@@ -100,26 +99,17 @@ export default function PopupBannerEditor({ blockEl, onClose }: Props) {
             alt: img.alt.trim(),
         }));
 
-        // blockEl의 기존 속성(data-cb-type, class 등 ContentBuilder 메타 속성 포함)을 모두 복사하되
-        // data-images / data-hide-days만 갱신한 새 요소를 생성하여 교체한다.
-        //
-        // setAttribute + builderReinit 방식은 ContentBuilder의 MutationObserver / HTML 스냅샷 복원과
-        // 충돌하여 이미지 갱신이 누락되는 문제가 있다. (EventBannerEditor와 동일한 replaceWith 방식 적용)
-        //
-        // replaceWith 후 ContentBuilder가 MutationObserver로 교체를 감지 →
-        // onChange → debouncedReinit → reinitialize() → mount(newEl) 자동 실행되며,
-        // mount()가 data-images를 읽어 pb-sheet--editor를 새로 생성한다.
-        const newEl = document.createElement(blockEl.tagName.toLowerCase());
-        Array.from(blockEl.attributes).forEach((attr) => {
-            // data-images / data-hide-days는 아래에서 갱신된 값으로 설정
-            if (attr.name !== 'data-images' && attr.name !== 'data-hide-days') {
-                newEl.setAttribute(attr.name, attr.value);
-            }
-        });
-        newEl.setAttribute('data-images', JSON.stringify(validated));
-        newEl.setAttribute('data-hide-days', String(hideDays));
-
-        blockEl.replaceWith(newEl);
+        // popup-banner 요소는 data-cb-type만 있고 data-component-id가 없으므로
+        // replaceWith 방식은 ContentBuilder 내부 참조를 갱신하지 못한다.
+        // 올바른 방식:
+        //   1) 속성 갱신 (DOM에 즉시 반영)
+        //   2) cbOnChange() — ContentBuilder에 변경을 알려 내부 HTML 스냅샷 갱신
+        //      → debouncedReinit의 applyBehavior() 가 구 스냅샷으로 DOM을 복원하는 것을 방지
+        //   3) reinitialize() — Runtime이 즉시 unmount → mount 실행 (300ms debounce 없음)
+        blockEl.setAttribute('data-images', JSON.stringify(validated));
+        blockEl.setAttribute('data-hide-days', String(hideDays));
+        cbOnChange?.();
+        void window.builderRuntime?.reinitialize();
         onClose();
     }
 

--- a/html-cms/src/components/edit/PopupBannerEditor.tsx
+++ b/html-cms/src/components/edit/PopupBannerEditor.tsx
@@ -100,11 +100,26 @@ export default function PopupBannerEditor({ blockEl, onClose }: Props) {
             alt: img.alt.trim(),
         }));
 
-        // data 속성 업데이트 후 런타임 reinit — 플러그인 mount()를 다시 실행해 미리보기 갱신
-        blockEl.setAttribute('data-images', JSON.stringify(validated));
-        blockEl.setAttribute('data-hide-days', String(hideDays));
-        window.builderReinit?.();
+        // blockEl의 기존 속성(data-cb-type, class 등 ContentBuilder 메타 속성 포함)을 모두 복사하되
+        // data-images / data-hide-days만 갱신한 새 요소를 생성하여 교체한다.
+        //
+        // setAttribute + builderReinit 방식은 ContentBuilder의 MutationObserver / HTML 스냅샷 복원과
+        // 충돌하여 이미지 갱신이 누락되는 문제가 있다. (EventBannerEditor와 동일한 replaceWith 방식 적용)
+        //
+        // replaceWith 후 ContentBuilder가 MutationObserver로 교체를 감지 →
+        // onChange → debouncedReinit → reinitialize() → mount(newEl) 자동 실행되며,
+        // mount()가 data-images를 읽어 pb-sheet--editor를 새로 생성한다.
+        const newEl = document.createElement(blockEl.tagName.toLowerCase());
+        Array.from(blockEl.attributes).forEach((attr) => {
+            // data-images / data-hide-days는 아래에서 갱신된 값으로 설정
+            if (attr.name !== 'data-images' && attr.name !== 'data-hide-days') {
+                newEl.setAttribute(attr.name, attr.value);
+            }
+        });
+        newEl.setAttribute('data-images', JSON.stringify(validated));
+        newEl.setAttribute('data-hide-days', String(hideDays));
 
+        blockEl.replaceWith(newEl);
         onClose();
     }
 

--- a/html-cms/src/types/contentbuilder-runtime.d.ts
+++ b/html-cms/src/types/contentbuilder-runtime.d.ts
@@ -7,7 +7,7 @@ declare global {
         __spwEditor?: boolean;
         builderReinit?: () => void;
         /** ContentBuilderRuntime 인스턴스 — EditClient.tsx에서 전역 노출 */
-        builderRuntime?: { reinitialize: (container?: Document | HTMLElement) => Promise<number> };
+        builderRuntime?: { reinitialize: (element?: HTMLElement) => void };
     }
 }
 

--- a/html-cms/src/types/contentbuilder-runtime.d.ts
+++ b/html-cms/src/types/contentbuilder-runtime.d.ts
@@ -6,6 +6,8 @@ declare global {
     interface Window {
         __spwEditor?: boolean;
         builderReinit?: () => void;
+        /** ContentBuilderRuntime 인스턴스 — EditClient.tsx에서 전역 노출 */
+        builderRuntime?: { reinitialize: (container?: Document | HTMLElement) => Promise<number> };
     }
 }
 


### PR DESCRIPTION
## 관련 이슈
closes #225

## 변경 사항
- **편집 적용 미반영 수정** (`PopupBannerEditor.tsx`)
  - `replaceWith(newEl)` 방식 제거 → `setAttribute` + `cbOnChange()` + `reinitialize()` 순서로 교체
  - `cbOnChange()` 호출로 ContentBuilder 내부 HTML 스냅샷 갱신 → `applyBehavior()` 시 구 스냅샷으로 DOM 복원되는 문제 해결
- **ContentBuilder onChange 콜백 전달** (`index.js`)
  - `openContentEditor`에서 `onChange`를 `CustomEvent` detail에 포함하여 `PopupBannerEditor`로 전달
- **EditClient 상태 관리** (`EditClient.tsx`)
  - `popupBannerOnChange` 상태 추가
  - `useState`에 함수 저장 시 `() => fn` 래핑 적용 (React state updater 오해 방지)
  - 툴바 버튼 선택자 `data-component-id^="popup-banner"` → `data-cb-type="popup-banner"` 수정
- **타입 선언 추가** (`contentbuilder-runtime.d.ts`)
  - `Window` 인터페이스에 `builderRuntime` 타입 추가
- **초기값 이미지 제거** (`migrate-popup-banner.ts`, `PopupBannerEditor.tsx`)
  - 컴포넌트 HTML 템플릿의 `DEFAULT_IMAGES` 빈 배열로 변경
  - 편집 모달 초기 이미지 목록 빈 배열로 변경

## 🛠 기술적 의사결정
**왜 `replaceWith` 대신 `setAttribute` + `cbOnChange()`인가?**
- `popup-banner`는 `data-component-id` 없이 `data-cb-type`만 사용 → `replaceWith` 후 ContentBuilder가 구 element 참조를 유지하여 재진입 시 이전 값이 표시됨
- `setAttribute` 후 ContentBuilder MutationObserver 감지 → `debouncedReinit` → `applyBehavior()` 가 ContentBuilder 내부 저장 HTML(구 값)로 DOM 복원하는 문제 발생
- `cbOnChange()` 호출로 ContentBuilder가 현재 DOM을 스냅샷 → 이후 `applyBehavior()` 가 새 값을 기준으로 동작

## ⚠️ 고려 및 주의 사항
- `migrate-popup-banner.ts` 재실행 시 기존 DB 컴포넌트 템플릿의 샘플 이미지가 빈 배열로 업데이트됨
- 이미 페이지에 삽입된 팝업 배너의 `data-images`는 페이지 HTML에 저장되어 있으므로 영향 없음

## 📸 변경 사항 확인
- 편집 모달에서 이미지 추가 후 적용 → 에디터 화면 즉시 반영
- 모달 재진입 시 이전에 적용한 값 유지
- 새 팝업 배너 추가 시 편집 모달 이미지 목록 빈 상태로 시작

🤖 Generated with [Claude Code](https://claude.com/claude-code)