### PR TITLE
feat #227 : 신규 미저장 페이지 접근 차단 제거 및 새 페이지 생성 모달 스크롤 개선

### DIFF
--- a/admin/src/main/resources/templates/pages/cms-dashboard/cms-dashboard.html
+++ b/admin/src/main/resources/templates/pages/cms-dashboard/cms-dashboard.html
@@ -36,7 +36,7 @@
 
     <!-- ==================== 새 페이지 생성 모달 ==================== -->
     <div class="modal fade" id="createPageModal" tabindex="-1">
-        <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">새 페이지 만들기</h5>

--- a/html-cms/src/app/dashboard/page.tsx
+++ b/html-cms/src/app/dashboard/page.tsx
@@ -60,8 +60,9 @@ export default async function DashboardPage({
         expiredDate: p.EXPIRED_DATE ? new Date(p.EXPIRED_DATE).toLocaleDateString('en-CA') : null,
         rejectedReason: p.REJECTED_REASON ?? null,
         hasFile:
-            !!p.PAGE_HTML ||
-            (p.FILE_PATH ? existsSync(join(process.cwd(), 'public', p.FILE_PATH.replace(/^\//, ''))) : false),
+            p.PAGE_HTML != null ||
+            !p.FILE_PATH ||
+            existsSync(join(process.cwd(), 'public', p.FILE_PATH.replace(/^\//, ''))),
         isExpired: isPageExpired(p.IS_PUBLIC, p.EXPIRED_DATE),
         isPublic: p.IS_PUBLIC ?? 'Y',
     }));

--- a/html-cms/src/components/dashboard/DashboardClient.tsx
+++ b/html-cms/src/components/dashboard/DashboardClient.tsx
@@ -397,10 +397,6 @@ export default function DashboardClient({
                                                 alert('만료된 페이지는 수정할 수 없습니다.');
                                                 return;
                                             }
-                                            if (!page.hasFile) {
-                                                alert('페이지 파일이 로컬에 존재하지 않습니다.');
-                                                return;
-                                            }
                                             if (!canWrite) {
                                                 return;
                                             }

--- a/html-cms/src/components/edit/EditClient.tsx
+++ b/html-cms/src/components/edit/EditClient.tsx
@@ -1818,11 +1818,6 @@ export default function EditClient({
             })
             .then(({ json: response, networkMs, jsonMs }) => {
                 if (loadController.signal.aborted) return;
-                if (response.fileNotFound) {
-                    alert(
-                        '페이지 파일이 로컬에 존재하지 않습니다.\ngit pull 후 다시 시도하거나, 에디터에서 새로 저장해 주세요.',
-                    );
-                }
                 if (response.html && builderRef.current) {
                     const loadHtmlStart = performance.now();
                     builderRef.current.loadHtml(response.html);


### PR DESCRIPTION
##  관련 이슈 (Related Issues)
- Closes #227

## ✨ 변경 사항 (Changes)
  > 무엇이 바뀌었는지 핵심 내용을 설명해 주세요.

  - 신규 생성 후 아직 저장하지 않은 페이지에 대해 대시보드/에디터에서 `페이지 파일이 로컬에 존재하지 않습니다`로 접근이 차단되던 문제를 수정했습니다.
  - `Springware-CMS`와 `html-cms` 양쪽에서 동일하게 다음 동작으로 맞췄습니다.
    - 대시보드에서 `hasFile` 기준으로 신규 미저장 페이지 진입을 막지 않도록 수정
    - 에디터 진입 후 `fileNotFound` alert로 다시 차단하지 않도록 수정
    - `FILE_PATH`가 없는 신규 페이지는 정상 접근 가능한 페이지로 판단하도록 보정
  - `PAGE_HTML` 존재 여부 판단을 truthy/falsy에 의존하지 않도록 정리해, 신규 페이지/빈 페이지 처리 일관성을 높였습니다.
  - `admin`의 새 페이지 생성 모달에 내부 스크롤이 가능하도록 `modal-dialog-scrollable`을 적용해, 템플릿 목록이 길어도 모바일/소형 화면에서 사용 가능하도록 개선했습니다.

  ##  변경 사항 확인 (선택)
  > UI 변경이 있거나 결과물을 시각적으로 보여줄 수 있다면 첨부해 주세요.

  | 변경 전 (Before) | 변경 후 (After) |
  | :--- | :--- |
  | 신규 페이지 생성 후 저장 없이 다시 진입하면 대시보드 또는 에디터에서 `페이지 파일이 로컬에 존재하지 않습니다` alert가 뜨며 접근 불가 | 신규 페이지 생성 후 저장 전 상
  태여도 대시보드에서 정상 진입되고, 에디터에서 빈 페이지로 열림 |
  | 새 페이지 생성 모달의 템플릿 목록이 길 경우 모달 전체가 답답하게 보이고 스크롤 사용성이 떨어짐 | 새 페이지 생성 모달 내부에서 스크롤 가능하여 긴 목록도 안정적으로 탐
  색 가능 |

  ## ⚠️ 고려 및 주의 사항 (선택)
  > 배포 시 유의점이나 기술적 부채, 향후 영향도를 적어주세요.

  - 이번 수정은 “신규 미저장 페이지도 접근 가능해야 한다”는 정책으로 대시보드/에디터 동작을 맞춘 것입니다.
  - 실제로 `FILE_PATH`가 존재하지만 배포 파일이 유실된 레거시 페이지 케이스는 별도 정책 검토가 필요할 수 있습니다.
  - `admin`은 테스트/JaCoCo는 정상 확인했지만, 포맷 관련 정리는 현재 워킹트리에 남은 변경 없이 `spotless:check` 통과 상태만 확인했습니다.

  ##  리뷰 포인트 (선택)
  > 특별히 신경 써서 봐주었으면 하는 부분이나 의견이 필요한 곳을 적어주세요.

  - 신규 미저장 페이지를 `FILE_PATH` 유무 기준으로 정상 접근 허용하는 현재 정책이 의도와 맞는지 확인 부탁드립니다.
  - `Springware-CMS`와 `html-cms`에서 동일한 사용자 경험으로 맞춘 방향이 적절한지 확인 부탁드립니다.
  - `admin`의 새 페이지 생성 모달 스크롤 처리 방식이 기존 UI 패턴과 충돌하지 않는지 봐주시면 됩니다.

  ##  참고 사항 (선택)
  > 참고 자료 혹은 추가로 전달할 사항을 적어주세요.

  - 확인한 주요 검증 결과
    - `html-cms`: `npm run build` 통과
    - `html-cms`: `npm run lint`는 기존 경고 다수 존재하지만 신규 에러 없음
    - `admin`: `./mvnw.cmd test` 통과
    - `admin`: `target/site/jacoco/jacoco.xml` 생성 확인
    - `admin`: `./mvnw.cmd spotless:check` 통과