### PR TITLE
fix: event-banner 이미지 비율 불일치 시 잘림 현상 수정 (#231)

### DIFF
--- a/html-cms/e2e/components/event-banner.spec.ts
+++ b/html-cms/e2e/components/event-banner.spec.ts
@@ -80,7 +80,7 @@ interface BannerSlide {
 
 const buildSlide = (slide: BannerSlide, idx: number): string => {
     const imgHtml = slide.imageUrl
-        ? `<img src="${slide.imageUrl}" alt="${slide.altText ?? ''}" style="width:100%;aspect-ratio:16/9;object-fit:cover;display:block;">`
+        ? `<img src="${slide.imageUrl}" alt="${slide.altText ?? ''}" style="width:100%;aspect-ratio:16/9;object-fit:contain;display:block;">`
         : `<div style="width:100%;aspect-ratio:16/9;background:#E5E7EB;display:flex;align-items:center;justify-content:center;">` +
           `<span style="color:#9CA3AF;font-size:14px;">이미지를 추가하세요</span></div>`;
 
@@ -327,11 +327,11 @@ test.describe('event-banner — 세로형(portrait) 이미지 비율 처리', ()
         expect(ratio, `16:9 비율(0.5625)을 유지해야 합니다 (실제: ${ratio.toFixed(4)})`).toBeCloseTo(9 / 16, 1);
     });
 
-    test('이미지에 object-fit:cover가 적용됨 (세로 이미지 crop 처리)', async ({ page }) => {
+    test('이미지에 object-fit:contain이 적용됨 (비율 불일치 시 잘림 없이 전체 표시)', async ({ page }) => {
         const objectFit = await page.locator('[data-banner-item] img').first().evaluate(
             (el) => getComputedStyle(el).objectFit,
         );
-        expect(objectFit, 'object-fit:cover로 portrait 이미지가 crop되어야 합니다').toBe('cover');
+        expect(objectFit, 'object-fit:contain으로 이미지 전체가 배너 영역 안에 표시되어야 합니다').toBe('contain');
     });
 
     // eslint-disable-next-line playwright/expect-expect

--- a/html-cms/scripts/migrate-event-banner-to-html.ts
+++ b/html-cms/scripts/migrate-event-banner-to-html.ts
@@ -38,7 +38,7 @@ function escapeHtml(str: string): string {
 function buildSlideHtml(slide: BannerSlide, idx: number): string {
     // 이미지 영역 (없으면 플레이스홀더)
     const imgHtml = slide.imageUrl
-        ? `<img src="${escapeHtml(slide.imageUrl)}" alt="${escapeHtml(slide.altText ?? '')}" style="width:100%;aspect-ratio:16/9;object-fit:cover;display:block;" />`
+        ? `<img src="${escapeHtml(slide.imageUrl)}" alt="${escapeHtml(slide.altText ?? '')}" style="width:100%;aspect-ratio:16/9;object-fit:contain;display:block;" />`
         : `<div style="width:100%;aspect-ratio:16/9;background:#E5E7EB;display:flex;align-items:center;justify-content:center;"><span style="color:#9CA3AF;font-size:14px;">이미지를 추가하세요</span></div>`;
 
     // 오버레이 텍스트 (선택)

--- a/html-cms/src/components/edit/EventBannerEditor.tsx
+++ b/html-cms/src/components/edit/EventBannerEditor.tsx
@@ -40,7 +40,7 @@ function escapeHtml(str: string): string {
 
 function buildSlideHtml(slide: BannerSlide, idx: number): string {
     const imgHtml = slide.imageUrl
-        ? `<img src="${escapeHtml(slide.imageUrl)}" alt="${escapeHtml(slide.altText ?? '')}" style="width:100%;aspect-ratio:16/9;object-fit:cover;display:block;" />`
+        ? `<img src="${escapeHtml(slide.imageUrl)}" alt="${escapeHtml(slide.altText ?? '')}" style="width:100%;aspect-ratio:16/9;object-fit:contain;display:block;" />`
         : `<div style="width:100%;aspect-ratio:16/9;background:#E5E7EB;display:flex;align-items:center;justify-content:center;"><span style="color:#9CA3AF;font-size:14px;">이미지를 추가하세요</span></div>`;
 
     const overlayHtml =

--- a/html-cms/src/components/edit/EventBannerEditor.tsx
+++ b/html-cms/src/components/edit/EventBannerEditor.tsx
@@ -516,7 +516,7 @@ export default function EventBannerEditor({ blockEl, onClose }: Props) {
                                             style={{
                                                 width: '100%',
                                                 aspectRatio: '16/9',
-                                                objectFit: 'cover',
+                                                objectFit: 'contain', // buildSlideHtml과 동일 — 에디터 프리뷰와 실제 렌더링 일치
                                                 borderRadius: 6,
                                                 border: '1px solid #e5e7eb',
                                                 background: '#f9fafb',


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #231

## ✨ 변경 사항 (Changes)

**원인:** `object-fit:cover` + `aspect-ratio:16/9` 조합으로 인해, 16:9가 아닌 비율의 이미지(1:1, 4:3 등)가 배너 영역을 채우기 위해 중앙 기준으로 잘렸음.

**수정:** `object-fit:cover` → `object-fit:contain` (3곳 일괄 적용)

| 파일 | 변경 내용 |
| :--- | :--- |
| `src/components/edit/EventBannerEditor.tsx` | `buildSlideHtml` 이미지 스타일 수정 |
| `scripts/migrate-event-banner-to-html.ts` | DB 시드 스크립트 동기화 |
| `e2e/components/event-banner.spec.ts` | 테스트 HTML 및 `object-fit` 어서션 업데이트 |

**비율별 렌더링 결과:**

| 이미지 비율 | 결과 |
| :--- | :--- |
| 16:9 | 배너 영역을 정확히 채움 (letterbox 없음) |
| 4:3 | 좌우 여백 발생, 이미지 전체 표시 |
| 1:1 | 좌우 여백 발생, 이미지 전체 표시 |
| 9:16 (세로) | 상하 여백 발생, 이미지 전체 표시 |

여백(letterbox)은 배너 루트의 `background:#ffffff`가 자연스럽게 투과되어 처리됨.

## ⚠️ 고려 및 주의 사항 (선택)

- 이미 저장된 페이지 HTML에는 `object-fit:cover`가 남아 있음. 기존 페이지 소급 패치 스크립트는 이번 범위에서 제외.
- 배너에 오버레이 텍스트(`data-banner-overlay`)가 있는 경우 `position:absolute;bottom:0` 고정이므로 레이아웃 영향 없음.