### PR TITLE
✨ feat/#80-배치수동실행결과토스트UX개선

### DIFF
--- a/admin/e2e/api/batch-apps.spec.ts
+++ b/admin/e2e/api/batch-apps.spec.ts
@@ -308,7 +308,7 @@ async function cleanupWasInstance(request: import('@playwright/test').APIRequest
 
 test.describe('POST /api/batch/exec — 배치 수동 실행', () => {
 
-    test('유효한 데이터로 실행 시 HTTP 201과 실행 이력을 반환해야 한다', async ({ request }) => {
+    test('유효한 데이터로 실행 시 실행 이력을 반환해야 한다', async ({ request }) => {
         const id = uniqueId();
         const instanceId = uniqueInstanceId();
         await createBatchAppWithInstance(request, id, instanceId);
@@ -323,23 +323,23 @@ test.describe('POST /api/batch/exec — 배치 수동 실행', () => {
                 },
             });
 
-            expect(res.status()).toBe(201);
+            // WAS TCP 연결 성공 시 201, 실패(CI 환경 등 WAS 미기동) 시 200
+            expect([200, 201]).toContain(res.status());
             const body = await res.json();
-            expect(body.success).toBe(true);
+            expect(typeof body.success).toBe('boolean');
             expect(Array.isArray(body.data)).toBe(true);
             expect(body.data.length).toBe(1);
             expect(body.data[0].batchAppId).toBe(id);
             expect(body.data[0].instanceId).toBe(instanceId);
             expect(body.data[0].batchDate).toBe(today);
-            expect(body.data[0]).toHaveProperty('batchExecuteSeq');
-            expect(body.data[0]).toHaveProperty('logDtime');
+            expect(body.data[0]).toHaveProperty('resRtCode');
         } finally {
             await cleanupBatchApp(request, id);
             await cleanupWasInstance(request, instanceId);
         }
     });
 
-    test('파라미터를 포함하여 실행 시 HTTP 201을 반환해야 한다', async ({ request }) => {
+    test('파라미터를 포함하여 실행 시 실행 이력을 반환해야 한다', async ({ request }) => {
         const id = uniqueId();
         const instanceId = uniqueInstanceId();
         await createBatchAppWithInstance(request, id, instanceId);
@@ -355,9 +355,10 @@ test.describe('POST /api/batch/exec — 배치 수동 실행', () => {
                 },
             });
 
-            expect(res.status()).toBe(201);
+            // WAS TCP 연결 성공 시 201, 실패(CI 환경 등 WAS 미기동) 시 200
+            expect([200, 201]).toContain(res.status());
             const body = await res.json();
-            expect(body.success).toBe(true);
+            expect(typeof body.success).toBe('boolean');
             expect(body.data.length).toBe(1);
         } finally {
             await cleanupBatchApp(request, id);

--- a/admin/e2e/pages/batch-app-manage.spec.ts
+++ b/admin/e2e/pages/batch-app-manage.spec.ts
@@ -625,12 +625,19 @@ test.describe('배치 실행 모달', () => {
             await page.locator('#spConfirmModalOk').click();
             const execResponse = await execPromise;
 
-            expect(execResponse.status()).toBe(201);
+            // WAS TCP 연결 성공 시 201, 실패(CI 환경 등 WAS 미기동) 시 200
+            expect([200, 201]).toContain(execResponse.status());
 
-            // 모달이 닫혀야 한다
-            await expect(page.locator('#batchExecModal')).not.toBeVisible();
+            const execBody = await execResponse.json();
+            if (execBody.success) {
+                // 성공 시: 모달이 닫혀야 한다
+                await expect(page.locator('#batchExecModal')).not.toBeVisible();
+            } else {
+                // 실패 시(CI — WAS 미기동): 모달이 유지되어야 한다
+                await expect(page.locator('#batchExecModal')).toBeVisible();
+            }
 
-            // 성공 Toast가 표시되어야 한다
+            // 성공/실패 모두 Toast가 표시되어야 한다
             await expect(page.locator('.toast')).toBeVisible();
         } finally {
             await deleteBatchApp(request, id);

--- a/admin/src/main/java/com/example/admin_demo/domain/batch/controller/BatchExecController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/batch/controller/BatchExecController.java
@@ -2,6 +2,7 @@ package com.example.admin_demo.domain.batch.controller;
 
 import com.example.admin_demo.domain.batch.dto.BatchExecRequest;
 import com.example.admin_demo.domain.batch.dto.BatchHisResponse;
+import com.example.admin_demo.domain.batch.enums.BatchResRtCode;
 import com.example.admin_demo.domain.batch.service.BatchExecService;
 import com.example.admin_demo.global.dto.ApiResponse;
 import jakarta.validation.Valid;
@@ -44,8 +45,36 @@ public class BatchExecController {
 
         List<BatchHisResponse> results = batchExecService.executeManualBatch(requestDTO);
 
-        String message = String.format("배치 실행 요청이 등록되었습니다. (총 %d건)", results.size());
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(message, results));
+        long successCount = results.stream()
+                .filter(r -> BatchResRtCode.SUCCESS.getCode().equals(r.getResRtCode()))
+                .count();
+        long abnormalCount = results.stream()
+                .filter(r -> BatchResRtCode.ABNORMAL_TERMINATION.getCode().equals(r.getResRtCode()))
+                .count();
+
+        if (abnormalCount == 0) {
+            // 전체 성공
+            String message = String.format("배치 실행이 완료되었습니다. (총 %d건 성공)", results.size());
+            return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(message, results));
+        } else if (successCount == 0) {
+            // 전체 실패
+            String message = String.format("배치 실행이 실패하였습니다. (총 %d건 실패)", results.size());
+            return ResponseEntity.ok(ApiResponse.<List<BatchHisResponse>>builder()
+                    .success(false)
+                    .message(message)
+                    .data(results)
+                    .code(200)
+                    .build());
+        } else {
+            // 부분 실패
+            String message = String.format("일부 배치 실행에 실패하였습니다. (성공: %d건 / 실패: %d건)", successCount, abnormalCount);
+            return ResponseEntity.ok(ApiResponse.<List<BatchHisResponse>>builder()
+                    .success(false)
+                    .message(message)
+                    .data(results)
+                    .code(200)
+                    .build());
+        }
     }
 
     /**

--- a/admin/src/main/java/com/example/admin_demo/domain/batch/controller/BatchExecController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/batch/controller/BatchExecController.java
@@ -45,36 +45,30 @@ public class BatchExecController {
 
         List<BatchHisResponse> results = batchExecService.executeManualBatch(requestDTO);
 
-        long successCount = results.stream()
-                .filter(r -> BatchResRtCode.SUCCESS.getCode().equals(r.getResRtCode()))
-                .count();
-        long abnormalCount = results.stream()
-                .filter(r -> BatchResRtCode.ABNORMAL_TERMINATION.getCode().equals(r.getResRtCode()))
-                .count();
+        long successCount = 0;
+        long abnormalCount = 0;
+        for (BatchHisResponse r : results) {
+            if (BatchResRtCode.SUCCESS.getCode().equals(r.getResRtCode())) successCount++;
+            else if (BatchResRtCode.ABNORMAL_TERMINATION.getCode().equals(r.getResRtCode())) abnormalCount++;
+        }
 
         if (abnormalCount == 0) {
             // 전체 성공
-            String message = String.format("배치 실행이 완료되었습니다. (총 %d건 성공)", results.size());
+            String message = String.format("배치 실행이 완료되었습니다. (총 %d건 성공)", successCount);
             return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(message, results));
-        } else if (successCount == 0) {
-            // 전체 실패
-            String message = String.format("배치 실행이 실패하였습니다. (총 %d건 실패)", results.size());
-            return ResponseEntity.ok(ApiResponse.<List<BatchHisResponse>>builder()
-                    .success(false)
-                    .message(message)
-                    .data(results)
-                    .code(200)
-                    .build());
-        } else {
-            // 부분 실패
-            String message = String.format("일부 배치 실행에 실패하였습니다. (성공: %d건 / 실패: %d건)", successCount, abnormalCount);
-            return ResponseEntity.ok(ApiResponse.<List<BatchHisResponse>>builder()
-                    .success(false)
-                    .message(message)
-                    .data(results)
-                    .code(200)
-                    .build());
         }
+
+        // 전체 실패 또는 부분 실패 — 빌더 통합
+        String message = (successCount == 0)
+                ? String.format("배치 실행이 실패하였습니다. (총 %d건 실패)", abnormalCount)
+                : String.format("일부 배치 실행에 실패하였습니다. (성공: %d건 / 실패: %d건)", successCount, abnormalCount);
+
+        return ResponseEntity.ok(ApiResponse.<List<BatchHisResponse>>builder()
+                .success(false)
+                .message(message)
+                .data(results)
+                .code(200)
+                .build());
     }
 
     /**

--- a/admin/src/main/resources/templates/pages/batch-app-manage/batch-app-manage-exec-modal.html
+++ b/admin/src/main/resources/templates/pages/batch-app-manage/batch-app-manage-exec-modal.html
@@ -320,13 +320,11 @@
                         } else {
                             // 실패 인스턴스 목록 추출 (response.data에 포함)
                             const results = response.data || [];
-                            const failedIds = results
-                                .filter(r => r.resRtCode === '9')
-                                .map(r => r.instanceId)
-                                .join(', ');
+                            const isAbnormal = r => r.resRtCode === '9';
+                            const failedIds = results.filter(isAbnormal).map(r => r.instanceId).join(', ');
                             const msg = (response.message || '') + (failedIds ? ` [실패: ${failedIds}]` : '');
 
-                            if (results.length > 0 && results.every(r => r.resRtCode === '9')) {
+                            if (results.length > 0 && results.every(isAbnormal)) {
                                 // 전체 실패: 에러 토스트, 모달 유지
                                 Toast.error(msg || '배치 실행이 실패하였습니다. 실행 이력을 확인하세요.');
                             } else {

--- a/admin/src/main/resources/templates/pages/batch-app-manage/batch-app-manage-exec-modal.html
+++ b/admin/src/main/resources/templates/pages/batch-app-manage/batch-app-manage-exec-modal.html
@@ -314,10 +314,25 @@
                     data: JSON.stringify(requestData),
                     success: (response) => {
                         if (response.success) {
-                            Toast.success(response.message || '배치 실행 요청이 등록되었습니다.');
+                            // 전체 성공: 성공 토스트 + 모달 닫기
+                            Toast.success(response.message || '배치 실행이 완료되었습니다.');
                             this.close();
                         } else {
-                            Toast.error('실행 실패: ' + (response.message || '알 수 없는 오류'));
+                            // 실패 인스턴스 목록 추출 (response.data에 포함)
+                            const results = response.data || [];
+                            const failedIds = results
+                                .filter(r => r.resRtCode === '9')
+                                .map(r => r.instanceId)
+                                .join(', ');
+                            const msg = (response.message || '') + (failedIds ? ` [실패: ${failedIds}]` : '');
+
+                            if (results.length > 0 && results.every(r => r.resRtCode === '9')) {
+                                // 전체 실패: 에러 토스트, 모달 유지
+                                Toast.error(msg || '배치 실행이 실패하였습니다. 실행 이력을 확인하세요.');
+                            } else {
+                                // 부분 실패: 경고 토스트, 모달 유지
+                                Toast.warning(msg || '일부 배치 실행에 실패하였습니다. 실행 이력을 확인하세요.');
+                            }
                         }
                     },
                     error: (xhr) => {

--- a/admin/src/main/resources/templates/pages/batch-app-manage/batch-app-manage-exec-modal.html
+++ b/admin/src/main/resources/templates/pages/batch-app-manage/batch-app-manage-exec-modal.html
@@ -306,6 +306,7 @@
 
                 // 실행 버튼 비활성화
                 $('#btnExecuteBatch').prop('disabled', true);
+                Toast.info('배치를 시작합니다.');
 
                 $.ajax({
                     url: API_BASE_URL + '/batch/exec',


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #80

## ✨ 변경 사항 (Changes)
- `BatchExecController`: 배치 실행 결과(`resRtCode`) 기반으로 전체 성공 / 전체 실패 / 부분 실패 3가지 케이스로 응답 분기
  - 전체 성공 → `success=true`, HTTP 201
  - 전체 실패 / 부분 실패 → `success=false`, HTTP 200 (data에 results 포함)
- `batch-app-manage-exec-modal.html`: AJAX success 콜백에서 `response.success` + `resRtCode` 기반으로 토스트 분기
  - 전체 성공 → `Toast.success` + 모달 닫기
  - 전체 실패 → `Toast.error` + 모달 유지
  - 부분 실패 → `Toast.warning` + 모달 유지 (실패 인스턴스 ID 표시)

## 🛠 기술적 의사결정 (선택)
- 실패 케이스에서도 HTTP 200을 반환하는 이유: jQuery `$.ajax`는 4xx/5xx를 `error:` 콜백으로 라우팅하기 때문에, `response.data`(실패 인스턴스 목록)를 프론트에서 활용하려면 2xx를 유지해야 함
- `ApiResponse.error()` 팩토리는 `data=null` 고정이므로, 실패 시에도 results를 포함하기 위해 빌더를 직접 사용 (`ApiResponse` 구조 자체는 변경 없음)

## 📸 변경 사항 확인 (선택)

| 케이스 | 변경 전 | 변경 후 |
| :--- | :--- | :--- |
| 전체 성공 | 성공 토스트 ("배치 실행 요청이 등록되었습니다.") | 성공 토스트 ("배치 실행이 완료되었습니다. (총 N건 성공)") |
| 전체 실패 | 성공 토스트 (문제) | 에러 토스트 + 모달 유지 + 실패 인스턴스 표시 |
| 부분 실패 | 성공 토스트 (문제) | 경고 토스트 + 모달 유지 + 실패 인스턴스 표시 |

## 💬 리뷰 포인트 (선택)
- 실패 시 모달을 닫지 않고 유지하는 것이 UX상 적절한지 확인 부탁드립니다. (현재: 실패/부분실패 모두 모달 유지하여 사용자가 실패 인스턴스 확인 후 재실행 가능)