### PR TITLE
fix: info-card-slide mobile 모드 카드 1개일 때 너비 100% 처리 (#239)

### DIFF
--- a/html-cms/e2e/components/info-card-slide-editor.spec.ts
+++ b/html-cms/e2e/components/info-card-slide-editor.spec.ts
@@ -13,13 +13,10 @@ test.describe('InfoCardSlideEditor', () => {
         await page.getByTestId('open-info-card-slide-editor').click();
         await expect(page.getByTestId('info-card-slide-editor')).toBeVisible();
 
-        const widthValue = await page.getByTestId('card-width-0').inputValue();
-        const heightValue = await page.getByTestId('card-height-0').inputValue();
-
         // liveWidth/liveHeight fallback 제거 — 명시적으로 입력하지 않으면 빈 값
         // (렌더링 너비를 자동 저장하면 inner div에 고정 px가 박혀 100% 확장을 막는 부작용 있었음)
-        expect(widthValue).toBe('');
-        expect(heightValue).toBe('');
+        await expect(page.getByTestId('card-width-0')).toHaveValue('');
+        await expect(page.getByTestId('card-height-0')).toHaveValue('');
     });
 
     test('reflects latest canvas text when reopening the editor', async ({ page }) => {

--- a/html-cms/e2e/components/info-card-slide-editor.spec.ts
+++ b/html-cms/e2e/components/info-card-slide-editor.spec.ts
@@ -9,15 +9,17 @@ test.describe('InfoCardSlideEditor', () => {
         await page.waitForLoadState('domcontentloaded');
     });
 
-    test('shows current card width and height as default values', async ({ page }) => {
+    test('shows empty card width and height by default', async ({ page }) => {
         await page.getByTestId('open-info-card-slide-editor').click();
         await expect(page.getByTestId('info-card-slide-editor')).toBeVisible();
 
         const widthValue = await page.getByTestId('card-width-0').inputValue();
         const heightValue = await page.getByTestId('card-height-0').inputValue();
 
-        expect(Number(widthValue)).toBeGreaterThan(0);
-        expect(Number(heightValue)).toBeGreaterThan(0);
+        // liveWidth/liveHeight fallback 제거 — 명시적으로 입력하지 않으면 빈 값
+        // (렌더링 너비를 자동 저장하면 inner div에 고정 px가 박혀 100% 확장을 막는 부작용 있었음)
+        expect(widthValue).toBe('');
+        expect(heightValue).toBe('');
     });
 
     test('reflects latest canvas text when reopening the editor', async ({ page }) => {

--- a/html-cms/e2e/components/info-card-slide-editor.spec.ts
+++ b/html-cms/e2e/components/info-card-slide-editor.spec.ts
@@ -9,14 +9,14 @@ test.describe('InfoCardSlideEditor', () => {
         await page.waitForLoadState('domcontentloaded');
     });
 
-    test('shows empty card width and height by default', async ({ page }) => {
+    test('does not auto-fill card width from live rendered size', async ({ page }) => {
         await page.getByTestId('open-info-card-slide-editor').click();
         await expect(page.getByTestId('info-card-slide-editor')).toBeVisible();
 
-        // liveWidth/liveHeight fallback 제거 — 명시적으로 입력하지 않으면 빈 값
-        // (렌더링 너비를 자동 저장하면 inner div에 고정 px가 박혀 100% 확장을 막는 부작용 있었음)
+        // liveWidth fallback 제거 — 렌더링 너비가 widthPx에 자동 저장되지 않음.
+        // 명시적으로 widthPx를 입력하지 않았으면 빈 값이어야 함.
+        // (자동 저장 시 inner div에 고정 px가 박혀 100% 확장을 막는 부작용이 있었음)
         await expect(page.getByTestId('card-width-0')).toHaveValue('');
-        await expect(page.getByTestId('card-height-0')).toHaveValue('');
     });
 
     test('reflects latest canvas text when reopening the editor', async ({ page }) => {

--- a/html-cms/scripts/migrate-info-card-slide-to-html.ts
+++ b/html-cms/scripts/migrate-info-card-slide-to-html.ts
@@ -250,11 +250,13 @@ const SLIDE_SCRIPT =
     `track.querySelectorAll('[data-card-item] > div').forEach(function(inner){` +
     `inner.style.minHeight=maxH+'px';` +
     `});` +
-    // 카드 너비 92% + snap center + 정중앙 정렬
-    `track.querySelectorAll('[data-card-item]').forEach(function(card){` +
+    // 카드 너비 — 1개이면 100%(화면 꽉 채움), 2개 이상이면 92%(다음 카드 살짝 노출)
+    `var cardItems=track.querySelectorAll('[data-card-item]');` +
+    `var isSingle=cardItems.length===1;` +
+    `cardItems.forEach(function(card){` +
     `if(mode==='web'){card.style.flex='0 0 min(480px,46vw)';card.style.width='min(480px,46vw)';card.style.maxWidth='';card.style.minWidth='0';card.style.scrollSnapAlign='start';}` +
     `else if(mode==='responsive'){card.style.flex='0 0 min(440px,78vw)';card.style.width='min(440px,78vw)';card.style.scrollSnapAlign='start';}` +
-    `else{card.style.flex='0 0 92%';card.style.width='92%';card.style.scrollSnapAlign='center';}` +
+    `else{var w=isSingle?'100%':'92%';card.style.flex='0 0 '+w;card.style.width=w;card.style.scrollSnapAlign='center';}` +
     `});` +
     // 하단 버튼 텍스트 넘침 시 글자 크기 자동 축소
     `track.querySelectorAll('[data-card-item] a').forEach(function(btn){` +

--- a/html-cms/src/components/edit/InfoCardSlideEditor.tsx
+++ b/html-cms/src/components/edit/InfoCardSlideEditor.tsx
@@ -256,10 +256,13 @@ const SLIDE_SCRIPT =
     `track.querySelectorAll('[data-card-item] > div').forEach(function(inner){` +
     `inner.style.minHeight=maxH+'px';` +
     `});` +
-    `track.querySelectorAll('[data-card-item]').forEach(function(card){` +
+    `var cardItems=track.querySelectorAll('[data-card-item]');` +
+    // 카드 1개일 때는 100%로 화면을 꽉 채움 — 2개 이상이면 92%로 다음 카드를 살짝 노출
+    `var isSingle=cardItems.length===1;` +
+    `cardItems.forEach(function(card){` +
     `if(mode==='web'){card.style.flex='0 0 min(480px,46vw)';card.style.width='min(480px,46vw)';card.style.maxWidth='';card.style.minWidth='0';card.style.scrollSnapAlign='start';}` +
     `else if(mode==='responsive'){card.style.flex='0 0 min(440px,78vw)';card.style.width='min(440px,78vw)';card.style.scrollSnapAlign='start';}` +
-    `else{card.style.flex='0 0 92%';card.style.width='92%';card.style.scrollSnapAlign='center';}` +
+    `else{var w=isSingle?'100%':'92%';card.style.flex='0 0 '+w;card.style.width=w;card.style.scrollSnapAlign='center';}` +
     `});` +
     `track.querySelectorAll('[data-card-item] a').forEach(function(btn){` +
     `if(!btn.style.borderRadius)return;` +

--- a/html-cms/src/components/edit/InfoCardSlideEditor.tsx
+++ b/html-cms/src/components/edit/InfoCardSlideEditor.tsx
@@ -337,8 +337,6 @@ function parseSlides(blockEl: HTMLElement): CardSlide[] {
             const innerStyle = innerCard?.getAttribute('style') || '';
             const innerWidthMatch = innerStyle.match(/(?:^|;)width:min\(100%,(\d+)px\)/i);
             const heightMatch = innerStyle.match(/(?:^|;)min-height:(\d+)px/i);
-            const liveWidth = innerCard?.getBoundingClientRect().width || item.getBoundingClientRect().width || 0;
-            const liveHeight = innerCard?.getBoundingClientRect().height || 0;
             const widthPx = Number.parseInt(widthMatch?.[1] || innerWidthMatch?.[1] || '', 10);
             const heightPx = Number.parseInt(heightMatch?.[1] || '', 10);
             const copyable = !!item.querySelector('[data-card-copy]') || !!fallback.copyable;

--- a/html-cms/src/components/edit/InfoCardSlideEditor.tsx
+++ b/html-cms/src/components/edit/InfoCardSlideEditor.tsx
@@ -371,8 +371,11 @@ function parseSlides(blockEl: HTMLElement): CardSlide[] {
                 showMore,
                 moreHref,
                 title: safeTitle,
-                widthPx: Number.isFinite(widthPx) ? widthPx : liveWidth > 0 ? Math.round(liveWidth) : undefined,
-                heightPx: Number.isFinite(heightPx) ? heightPx : liveHeight > 0 ? Math.round(liveHeight) : undefined,
+                // liveWidth/liveHeight 자동 저장 제거 — 렌더링 너비를 고정값으로 박으면
+                // SLIDE_SCRIPT가 너비를 100%로 바꿔도 inner div가 고정 px로 막히는 부작용 발생.
+                // widthPx/heightPx는 사용자가 에디터 입력 필드에 명시적으로 입력한 값만 보존.
+                widthPx: Number.isFinite(widthPx) ? widthPx : undefined,
+                heightPx: Number.isFinite(heightPx) ? heightPx : undefined,
                 copyable,
                 subtitle,
                 infoLines,

--- a/html-cms/src/components/view/ViewClient.tsx
+++ b/html-cms/src/components/view/ViewClient.tsx
@@ -604,7 +604,10 @@ export default function ViewClient({ html, viewMode, bank, embed }: Props) {
             });
 
             // 카드 너비·스냅 정렬 (모드별 다름)
-            track.querySelectorAll<HTMLElement>('[data-card-item]').forEach((card) => {
+            // mobile: 카드 1개이면 여백 없이 100%, 2개 이상이면 92%로 다음 카드 살짝 노출
+            const cardItems = track.querySelectorAll<HTMLElement>('[data-card-item]');
+            const isSingle = cardItems.length === 1;
+            cardItems.forEach((card) => {
                 if (mode === 'web') {
                     card.style.flex = '0 0 min(480px,46vw)';
                     card.style.width = 'min(480px,46vw)';
@@ -616,8 +619,9 @@ export default function ViewClient({ html, viewMode, bank, embed }: Props) {
                     card.style.width = 'min(440px,78vw)';
                     card.style.scrollSnapAlign = 'start';
                 } else {
-                    card.style.flex = '0 0 92%';
-                    card.style.width = '92%';
+                    const w = isSingle ? '100%' : '92%';
+                    card.style.flex = `0 0 ${w}`;
+                    card.style.width = w;
                     card.style.scrollSnapAlign = 'center';
                 }
             });


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #239

## ✨ 변경 사항 (Changes)

`info-card-slide-mobile` 컴포넌트에서 카드가 1개일 때 화면 너비에 맞게 카드 크기가 커지지 않던 문제를 수정합니다.

### 문제 원인

1. **ViewClient 하드코딩** — `ViewClient.tsx`가 `info-card-slide` 레이아웃을 직접 처리하며 mobile 모드 카드 너비를 `92%`로 고정하고 있었음. 카드 수와 무관하게 항상 `92%`가 적용됨.

2. **parseSlides liveWidth 자동 저장** — 편집 모달 오픈 시 `getBoundingClientRect().width`(렌더링 너비)를 `widthPx` fallback으로 저장하여 inner div에 `width:min(100%,Xpx)`가 고정되는 부작용이 있었음.

### 수정 내용

| 파일 | 변경 내용 |
|---|---|
| `src/components/view/ViewClient.tsx` | mobile 모드에서 카드 1개이면 `100%`, 2개 이상이면 `92%` 적용 |
| `src/components/edit/InfoCardSlideEditor.tsx` | `parseSlides`에서 `liveWidth` fallback 제거 — 명시적 입력값만 보존 |
| `src/components/edit/InfoCardSlideEditor.tsx` | SLIDE_SCRIPT에도 동일한 `isSingle` 로직 추가 (동기화) |
| `scripts/migrate-info-card-slide-to-html.ts` | 마이그레이션 스크립트 SLIDE_SCRIPT 동기화 |

### 동작 방식

- 카드 **1개**: `flex: 0 0 100%` — 화면 너비에 맞게 카드가 꽉 채워짐
- 카드 **2개 이상**: `flex: 0 0 92%` — 오른쪽에 다음 카드가 살짝 보이는 기존 동작 유지

## ⚠️ 고려 및 주의 사항 (선택)

- `liveWidth` fallback 제거로 인해, 이전에 에디터에서 저장된 페이지의 카드에 `width:min(100%,Xpx)` inline style이 있을 수 있음. 편집 모달 열고 적용 시 자동 제거됨.
- `widthPx`를 에디터 입력 필드에 직접 입력한 경우에는 기존대로 동작.

## 💬 리뷰 포인트 (선택)

- ViewClient에서 SLIDE_SCRIPT와 별도로 직접 처리하는 구조이므로, SLIDE_SCRIPT 수정만으로는 효과가 없음을 참고.