### PR TITLE
✨ feat/#245-MessageInstanceRecorder 비동기 큐 전환

### DIFF
--- a/spider-link/src/main/java/com/example/spiderlink/config/SpiderLinkAutoConfiguration.java
+++ b/spider-link/src/main/java/com/example/spiderlink/config/SpiderLinkAutoConfiguration.java
@@ -1,6 +1,7 @@
 package com.example.spiderlink.config;
 
 import com.example.spiderlink.domain.messageinstance.MessageInstanceRecorder;
+import com.example.spiderlink.domain.messageinstance.MessageLogQueue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -15,7 +16,10 @@ import org.springframework.jdbc.core.JdbcTemplate;
  * spider-link 공통 자동 설정.
  *
  * <p>소비 모듈에 {@link JdbcTemplate} 빈이 존재할 때만 활성화되며,
- * {@link MessageInstanceRecorder}를 자동으로 빈으로 등록한다.</p>
+ * {@link MessageLogQueue}와 {@link MessageInstanceRecorder}를 자동으로 빈으로 등록한다.</p>
+ *
+ * <p>{@code MessageLogQueue}는 {@link org.springframework.context.SmartLifecycle}을 구현하므로
+ * Spring Context 시작 시 컨슈머 스레드가 자동 기동되고, 종료 시 큐를 드레인한 뒤 정상 종료된다.</p>
  *
  * <p>이 클래스는 {@code META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports}에
  * 등록되어 Spring Boot 자동 설정 메커니즘으로 로드된다.</p>
@@ -28,12 +32,28 @@ import org.springframework.jdbc.core.JdbcTemplate;
 public class SpiderLinkAutoConfiguration {
 
     /**
+     * 전문 이력 비동기 큐 빈.
+     *
+     * <p>JdbcTemplate 빈이 존재하는 경우에만 생성된다.
+     * SmartLifecycle 구현체로 Context 시작·종료 시 컨슈머 스레드가 자동 관리된다.</p>
+     *
+     * @param jdbcTemplate DB 연결 (소비 모듈의 datasource 사용)
+     * @return MessageLogQueue 빈
+     */
+    @Bean
+    @ConditionalOnBean(JdbcTemplate.class)
+    public MessageLogQueue messageLogQueue(JdbcTemplate jdbcTemplate) {
+        return new MessageLogQueue(jdbcTemplate);
+    }
+
+    /**
      * 전문 거래 이력 기록기 빈.
      *
      * <p>JdbcTemplate 빈이 존재하는 경우에만 생성된다.
+     * {@link MessageLogQueue}에 이력을 적재하고 실제 INSERT는 큐 컨슈머가 비동기로 처리한다.
      * {@code spring.application.name}을 ORG_ID·INSTANCE_ID에 활용한다.</p>
      *
-     * @param jdbcTemplate DB 연결 (소비 모듈의 datasource 사용)
+     * @param queue        비동기 기록 큐
      * @param objectMapper JSON 직렬화용 ObjectMapper
      * @param appName      spring.application.name
      * @return MessageInstanceRecorder 빈
@@ -41,9 +61,9 @@ public class SpiderLinkAutoConfiguration {
     @Bean
     @ConditionalOnBean(JdbcTemplate.class)
     public MessageInstanceRecorder messageInstanceRecorder(
-            JdbcTemplate jdbcTemplate,
+            MessageLogQueue queue,
             ObjectMapper objectMapper,
             @Value("${spring.application.name:unknown}") String appName) {
-        return new MessageInstanceRecorder(jdbcTemplate, objectMapper, appName);
+        return new MessageInstanceRecorder(queue, objectMapper, appName);
     }
 }

--- a/spider-link/src/main/java/com/example/spiderlink/domain/messageinstance/MessageInstanceRecorder.java
+++ b/spider-link/src/main/java/com/example/spiderlink/domain/messageinstance/MessageInstanceRecorder.java
@@ -1,5 +1,6 @@
 package com.example.spiderlink.domain.messageinstance;
 
+import com.example.spiderlink.domain.messageinstance.dto.MessageInstanceInsertRequest;
 import com.example.spiderlink.infra.tcp.model.CommandRequest;
 import com.example.spiderlink.infra.tcp.model.HasCommand;
 import com.example.spiderlink.infra.tcp.model.JsonCommandRequest;
@@ -9,13 +10,13 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
  * spider-link 전문 거래 이력 기록기.
  *
  * <p>SpiderTcpServer(서버 수신·응답)와 TcpClient(클라이언트 송신·수신) 양방향에서
- * {@code FWK_MESSAGE_INSTANCE} 테이블에 전문 이력을 기록한다.</p>
+ * {@link MessageInstanceInsertRequest}를 생성하여 {@link MessageLogQueue}에 적재한다.
+ * 실제 DB INSERT는 큐 컨슈머 스레드가 비동기로 처리하므로 TCP 처리 스레드가 블로킹되지 않는다.</p>
  *
  * <p>DB 기록 실패 시 경고 로그만 출력하고 비즈니스 로직에 영향을 주지 않는다.</p>
  *
@@ -28,7 +29,7 @@ public class MessageInstanceRecorder {
 
     private static final DateTimeFormatter DTIME_FMT = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
 
-    private final JdbcTemplate jdbcTemplate;
+    private final MessageLogQueue queue;
     private final ObjectMapper objectMapper;
     /** spring.application.name — ORG_ID 및 INSTANCE_ID 구성에 사용 */
     private final String appName;
@@ -43,7 +44,7 @@ public class MessageInstanceRecorder {
     public void recordServerRequest(String trxId, Object request, int port) {
         String command = command(request);
         String trackingNo = trackingNo(request, trxId);
-        insert(trxId, "I", "REQ", command, trackingNo, userId(request), toJson(request), true, port);
+        enqueue(trxId, "I", "REQ", command, trackingNo, userId(request), toJson(request), true, appName, port);
     }
 
     /**
@@ -58,7 +59,7 @@ public class MessageInstanceRecorder {
         String command = command(request);
         String trackingNo = trackingNo(request, trxId);
         boolean success = response instanceof JsonCommandResponse r ? r.isSuccess() : true;
-        insert(trxId, "O", "RES", command, trackingNo, userId(request), toJson(response), success, port);
+        enqueue(trxId, "O", "RES", command, trackingNo, userId(request), toJson(response), success, appName, port);
     }
 
     /**
@@ -75,7 +76,7 @@ public class MessageInstanceRecorder {
      * @param userId    요청 사용자 ID (JWT 미인증 구간은 "GUEST")
      */
     public void recordHttpRequest(String requestId, String uri, String data, int port, String userId) {
-        insertHttp(requestId, "I", "REQ", uri, data, true, port, userId);
+        enqueueHttp(requestId, "I", "REQ", uri, data, true, port, userId);
     }
 
     /**
@@ -88,36 +89,10 @@ public class MessageInstanceRecorder {
      * @param data       응답 바디 JSON 문자열
      * @param success    HTTP 응답 성공 여부 (2xx → true)
      * @param port       서버 포트
-     * @param userId     요청 사용자 ID (JWT 미인증 구간은 "GUEST", 로그인 성공 시 실제 userId)
+     * @param userId     요청 사용자 ID
      */
     public void recordHttpResponse(String requestId, String uri, String data, boolean success, int port, String userId) {
-        insertHttp(requestId, "O", "RES", uri, data, success, port, userId);
-    }
-
-    /** HTTP 로그 전용 insert — CHANNEL_TYPE=HTTP, MESSAGE_ID=URI */
-    private void insertHttp(String requestId, String ioType, String reqResType,
-                            String uri, String data, boolean success, int port, String userId) {
-        try {
-            String dtime = LocalDateTime.now().format(DTIME_FMT);
-            String instanceId = appName + ":" + port;
-            jdbcTemplate.update(
-                    "INSERT INTO FWK_MESSAGE_INSTANCE (" +
-                    "  MESSAGE_SNO, TRX_ID, ORG_ID, IO_TYPE, REQ_RES_TYPE, MESSAGE_ID," +
-                    "  TRX_TRACKING_NO, LOG_DTIME, LAST_LOG_DTIME, LAST_RT_CODE," +
-                    "  INSTANCE_ID, RETRY_TRX_YN, MESSAGE_DATA, TRX_DTIME, CHANNEL_TYPE, URI, SUCCESS_YN, USER_ID" +
-                    ") VALUES (" +
-                    "  FWK_MESSAGE_INSTANCE_SEQ.NEXTVAL,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?" +
-                    ")",
-                    requestId, appName, ioType, reqResType, uri,
-                    requestId, dtime, dtime,
-                    success ? "SUCCESS" : "FAIL",
-                    instanceId, "N",
-                    data, dtime, "HTTP", uri,
-                    success ? "Y" : "N", userId
-            );
-        } catch (Exception e) {
-            log.warn("[MessageInstanceRecorder] HTTP 로그 기록 실패 — uri={}: {}", uri, e.getMessage());
-        }
+        enqueueHttp(requestId, "O", "RES", uri, data, success, port, userId);
     }
 
     /**
@@ -129,7 +104,7 @@ public class MessageInstanceRecorder {
      * @param port    대상 포트
      */
     public void recordClientRequest(String trxId, JsonCommandRequest request, String host, int port) {
-        insert(trxId, "O", "REQ", request.getCommand(), request.getRequestId(),
+        enqueue(trxId, "O", "REQ", request.getCommand(), request.getRequestId(),
                 userId(request), toJson(request), true, host, port);
     }
 
@@ -144,41 +119,59 @@ public class MessageInstanceRecorder {
      */
     public void recordClientResponse(String trxId, JsonCommandRequest request,
                                      JsonCommandResponse response, String host, int port) {
-        insert(trxId, "I", "RES", request.getCommand(), request.getRequestId(),
+        enqueue(trxId, "I", "RES", request.getCommand(), request.getRequestId(),
                 userId(request), toJson(response), response.isSuccess(), host, port);
     }
 
-    /** 서버 포트 기준 INSTANCE_ID 생성 후 insert 위임 */
-    private void insert(String trxId, String ioType, String reqResType,
-                        String command, String trackingNo, String userId, String data,
-                        boolean success, int port) {
-        insert(trxId, ioType, reqResType, command, trackingNo, userId, data, success, appName, port);
+    /** TCP 전문 이력 DTO 생성 후 큐에 적재 */
+    private void enqueue(String trxId, String ioType, String reqResType,
+                         String command, String trackingNo, String userId, String data,
+                         boolean success, String host, int port) {
+        String dtime = LocalDateTime.now().format(DTIME_FMT);
+        queue.put(MessageInstanceInsertRequest.builder()
+                .trxId(trxId)
+                .orgId(appName)
+                .ioType(ioType)
+                .reqResType(reqResType)
+                .messageId(command)
+                .trxTrackingNo(trackingNo)
+                .userId(userId)
+                .logDtime(dtime)
+                .lastLogDtime(dtime)
+                .lastRtCode(success ? "SUCCESS" : "FAIL")
+                .instanceId(host + ":" + port)
+                .retryTrxYn("N")
+                .messageData(data)
+                .trxDtime(dtime)
+                .channelType("TCP")
+                .uri(command)
+                .successYn(success ? "Y" : "N")
+                .build());
     }
 
-    private void insert(String trxId, String ioType, String reqResType,
-                        String command, String trackingNo, String userId, String data,
-                        boolean success, String host, int port) {
-        try {
-            String dtime = LocalDateTime.now().format(DTIME_FMT);
-            String instanceId = host + ":" + port;
-            jdbcTemplate.update(
-                    "INSERT INTO FWK_MESSAGE_INSTANCE (" +
-                    "  MESSAGE_SNO, TRX_ID, ORG_ID, IO_TYPE, REQ_RES_TYPE, MESSAGE_ID," +
-                    "  TRX_TRACKING_NO, USER_ID, LOG_DTIME, LAST_LOG_DTIME, LAST_RT_CODE," +
-                    "  INSTANCE_ID, RETRY_TRX_YN, MESSAGE_DATA, TRX_DTIME, CHANNEL_TYPE, URI, SUCCESS_YN" +
-                    ") VALUES (" +
-                    "  FWK_MESSAGE_INSTANCE_SEQ.NEXTVAL,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?" +
-                    ")",
-                    trxId, appName, ioType, reqResType, command,
-                    trackingNo, userId, dtime, dtime,
-                    success ? "SUCCESS" : "FAIL",
-                    instanceId, "N",
-                    data, dtime, "TCP", command,
-                    success ? "Y" : "N"
-            );
-        } catch (Exception e) {
-            log.warn("[MessageInstanceRecorder] DB 기록 실패 — command={}: {}", command, e.getMessage());
-        }
+    /** HTTP 전문 이력 DTO 생성 후 큐에 적재 */
+    private void enqueueHttp(String requestId, String ioType, String reqResType,
+                             String uri, String data, boolean success, int port, String userId) {
+        String dtime = LocalDateTime.now().format(DTIME_FMT);
+        queue.put(MessageInstanceInsertRequest.builder()
+                .trxId(requestId)
+                .orgId(appName)
+                .ioType(ioType)
+                .reqResType(reqResType)
+                .messageId(uri)
+                .trxTrackingNo(requestId)
+                .userId(userId)
+                .logDtime(dtime)
+                .lastLogDtime(dtime)
+                .lastRtCode(success ? "SUCCESS" : "FAIL")
+                .instanceId(appName + ":" + port)
+                .retryTrxYn("N")
+                .messageData(data)
+                .trxDtime(dtime)
+                .channelType("HTTP")
+                .uri(uri)
+                .successYn(success ? "Y" : "N")
+                .build());
     }
 
     private String command(Object request) {

--- a/spider-link/src/main/java/com/example/spiderlink/domain/messageinstance/MessageLogQueue.java
+++ b/spider-link/src/main/java/com/example/spiderlink/domain/messageinstance/MessageLogQueue.java
@@ -75,6 +75,12 @@ public class MessageLogQueue implements SmartLifecycle {
         running = false;
         if (consumerThread != null) {
             consumerThread.interrupt();
+            try {
+                // insertOne() 진행 중인 경우 완료 후 drainRemaining()이 실행되도록 대기
+                consumerThread.join(1000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
         drainRemaining();
         log.info("[MessageLogQueue] 전문 이력 비동기 큐 종료");

--- a/spider-link/src/main/java/com/example/spiderlink/domain/messageinstance/MessageLogQueue.java
+++ b/spider-link/src/main/java/com/example/spiderlink/domain/messageinstance/MessageLogQueue.java
@@ -1,0 +1,131 @@
+package com.example.spiderlink.domain.messageinstance;
+
+import com.example.spiderlink.domain.messageinstance.dto.MessageInstanceInsertRequest;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * 전문 이력 비동기 기록 큐.
+ *
+ * <p>TCP·HTTP 처리 스레드가 DB INSERT를 기다리지 않도록 {@link MessageInstanceInsertRequest}를
+ * 큐에 적재하고, 별도 컨슈머 스레드가 {@code FWK_MESSAGE_INSTANCE}에 INSERT한다.</p>
+ *
+ * <p>큐 용량({@value CAPACITY}건) 초과 시 경고 로그만 출력하고 드랍한다 — 비즈니스 영향 없음.</p>
+ *
+ * <p>Spring Context 종료 시 {@link SmartLifecycle#stop()}이 호출되어 큐에 남은 항목을 모두
+ * 처리한 뒤 컨슈머 스레드를 종료한다.</p>
+ */
+@Slf4j
+public class MessageLogQueue implements SmartLifecycle {
+
+    /** 참고소스(spiderLink_Admin) AsyncQueueManager 권장값 */
+    static final int CAPACITY = 256;
+
+    private static final String INSERT_SQL =
+            "INSERT INTO FWK_MESSAGE_INSTANCE (" +
+            "  MESSAGE_SNO, TRX_ID, ORG_ID, IO_TYPE, REQ_RES_TYPE, MESSAGE_ID," +
+            "  TRX_TRACKING_NO, USER_ID, LOG_DTIME, LAST_LOG_DTIME, LAST_RT_CODE," +
+            "  INSTANCE_ID, RETRY_TRX_YN, MESSAGE_DATA, TRX_DTIME, CHANNEL_TYPE, URI, SUCCESS_YN" +
+            ") VALUES (" +
+            "  FWK_MESSAGE_INSTANCE_SEQ.NEXTVAL,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?" +
+            ")";
+
+    private final LinkedBlockingQueue<MessageInstanceInsertRequest> queue =
+            new LinkedBlockingQueue<>(CAPACITY);
+    private final JdbcTemplate jdbcTemplate;
+
+    private Thread consumerThread;
+    private volatile boolean running = false;
+
+    public MessageLogQueue(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    /**
+     * 전문 이력 INSERT 요청을 큐에 적재한다.
+     *
+     * <p>비블로킹 — 큐가 가득 찬 경우 경고 로그만 출력하고 즉시 반환한다.</p>
+     */
+    public void put(MessageInstanceInsertRequest req) {
+        if (!queue.offer(req)) {
+            log.warn("[MessageLogQueue] 큐 용량 초과 — 전문 이력 드랍 (messageId={})", req.getMessageId());
+        }
+    }
+
+    /** 컨슈머 스레드 시작 — Spring Context 초기화 완료 후 자동 호출 */
+    @Override
+    public void start() {
+        running = true;
+        consumerThread = new Thread(this::consume, "msg-log-consumer");
+        consumerThread.setDaemon(true);
+        consumerThread.start();
+        log.info("[MessageLogQueue] 전문 이력 비동기 큐 시작 (capacity={})", CAPACITY);
+    }
+
+    /**
+     * 컨슈머 스레드 종료 — Spring Context 종료 시 자동 호출.
+     *
+     * <p>큐에 남은 항목을 모두 처리한 뒤 종료한다.</p>
+     */
+    @Override
+    public void stop() {
+        running = false;
+        if (consumerThread != null) {
+            consumerThread.interrupt();
+        }
+        drainRemaining();
+        log.info("[MessageLogQueue] 전문 이력 비동기 큐 종료");
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
+
+    private void consume() {
+        while (running) {
+            try {
+                // 100ms 대기 후 재확인 — running 플래그 변경 감지 가능
+                MessageInstanceInsertRequest req = queue.poll(100, TimeUnit.MILLISECONDS);
+                if (req != null) {
+                    insertOne(req);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (Exception e) {
+                log.warn("[MessageLogQueue] 전문 이력 처리 중 오류: {}", e.getMessage());
+            }
+        }
+    }
+
+    /** Context 종료 시 큐에 남은 항목을 동기로 모두 처리 */
+    private void drainRemaining() {
+        int drained = 0;
+        MessageInstanceInsertRequest req;
+        while ((req = queue.poll()) != null) {
+            insertOne(req);
+            drained++;
+        }
+        if (drained > 0) {
+            log.info("[MessageLogQueue] 종료 시 잔여 {}건 처리 완료", drained);
+        }
+    }
+
+    private void insertOne(MessageInstanceInsertRequest r) {
+        try {
+            jdbcTemplate.update(INSERT_SQL,
+                    r.getTrxId(), r.getOrgId(), r.getIoType(), r.getReqResType(), r.getMessageId(),
+                    r.getTrxTrackingNo(), r.getUserId(), r.getLogDtime(), r.getLastLogDtime(),
+                    r.getLastRtCode(), r.getInstanceId(), r.getRetryTrxYn(),
+                    r.getMessageData(), r.getTrxDtime(), r.getChannelType(), r.getUri(),
+                    r.getSuccessYn()
+            );
+        } catch (Exception e) {
+            log.warn("[MessageLogQueue] DB INSERT 실패 — messageId={}: {}", r.getMessageId(), e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

Closes #245

## ✨ 변경 사항 (Changes)

TCP·HTTP 처리 스레드가 `FWK_MESSAGE_INSTANCE` DB INSERT를 기다리지 않도록 `MessageLogQueue` 비동기 큐를 도입하고, `MessageInstanceRecorder`를 큐 적재 방식으로 전환한다.

**변경 파일 3건**

| 파일 | 변경 내용 |
|------|---------|
| `MessageLogQueue.java` (신규) | `LinkedBlockingQueue(256)` + 컨슈머 스레드, `SmartLifecycle` 구현 |
| `MessageInstanceRecorder.java` | `JdbcTemplate` 직접 호출 제거 → `MessageLogQueue.put()` 위임 |
| `SpiderLinkAutoConfiguration.java` | `MessageLogQueue` 빈 등록 추가, `MessageInstanceRecorder`에 큐 주입 |

**처리 흐름 변화**

```
[이전] TCP 처리 스레드 → jdbcTemplate.update() → DB (블로킹)

[이후] TCP 처리 스레드 → queue.put() → 즉시 반환
                              ↓ (msg-log-consumer 스레드)
                         jdbcTemplate.update() → DB
```

## 🛠 기술적 의사결정

**LinkedBlockingQueue + blocking take() 채택 (참고소스의 ConcurrentLinkedQueue + polling sleep 대비)**

참고소스(spiderLink_Admin)의 `AsyncQueue`는 `ConcurrentLinkedQueue` + `Thread.sleep(10ms)` polling 방식을 사용한다.
주석에 "JDK의 OutOfMemory 버그 때문에 sleep하도록 수정"이라고 명시되어 있으나, 현재 JDK 환경에서는 해소된 이슈다.
`LinkedBlockingQueue.poll(100ms timeout)` 방식은 polling sleep 없이 CPU를 낭비하지 않으며, `InterruptedException`으로 종료 신호를 받을 수 있어 더 명확한 생명주기 관리가 가능하다.

**SmartLifecycle 구현 — Spring Context 종료 시 자동 drain**

`stop()` 호출 시 큐에 남은 항목을 동기로 모두 처리한 뒤 스레드를 종료하므로 애플리케이션 종료 시 전문 이력 유실이 없다.

**큐 용량 초과 시 드랍 (참고소스 동일 정책)**

`queue.offer()` 실패 시 경고 로그만 출력하고 비즈니스 처리는 계속 진행한다. 이력 기록 실패가 서비스 중단으로 이어지지 않도록 설계 의도를 유지한다.

## 🧪 테스트

- [ ] spider-link `mvn compile` — BUILD SUCCESS 확인
- [ ] biz-auth / biz-transfer 기동 후 AUTH_LOGIN 요청 → FWK_MESSAGE_INSTANCE 정상 적재 확인
- [ ] 기동 로그에 `[MessageLogQueue] 전문 이력 비동기 큐 시작 (capacity=256)` 출력 확인

## ⚠️ 고려 및 주의 사항

- `MessageLogQueue`는 `SmartLifecycle` 빈으로 등록되어 JdbcTemplate 빈이 있는 모듈(biz-auth, biz-transfer, mock-core, biz-channel)에서만 활성화됨
- 큐 capacity(256)와 컨슈머 스레드 수(1)는 POC 범위 기준값 — 운영 전환 시 부하 테스트 후 조정 필요

## 🔗 참고 사항

- 참고소스: `spiderLink_Admin/src_common/.../AsyncQueue.java`, `MsgDbLogConsumer.java`
- 관련 문서: `08. 기타/참고소스_비교분석.md` — 3-3절