### PR TITLE
✨ feat/#246-TcpClient 커넥션 풀 및 재연결 로직 구현

### DIFF
--- a/spider-link/src/main/java/com/example/spiderlink/config/SpiderLinkAutoConfiguration.java
+++ b/spider-link/src/main/java/com/example/spiderlink/config/SpiderLinkAutoConfiguration.java
@@ -2,6 +2,7 @@ package com.example.spiderlink.config;
 
 import com.example.spiderlink.domain.messageinstance.MessageInstanceRecorder;
 import com.example.spiderlink.domain.messageinstance.MessageLogQueue;
+import com.example.spiderlink.infra.tcp.client.pool.SocketPoolManager;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -16,10 +17,12 @@ import org.springframework.jdbc.core.JdbcTemplate;
  * spider-link 공통 자동 설정.
  *
  * <p>소비 모듈에 {@link JdbcTemplate} 빈이 존재할 때만 활성화되며,
- * {@link MessageLogQueue}와 {@link MessageInstanceRecorder}를 자동으로 빈으로 등록한다.</p>
+ * {@link SocketPoolManager}, {@link MessageLogQueue}, {@link MessageInstanceRecorder}를
+ * 자동으로 빈으로 등록한다.</p>
  *
- * <p>{@code MessageLogQueue}는 {@link org.springframework.context.SmartLifecycle}을 구현하므로
- * Spring Context 시작 시 컨슈머 스레드가 자동 기동되고, 종료 시 큐를 드레인한 뒤 정상 종료된다.</p>
+ * <p>{@code MessageLogQueue}와 {@link SocketPoolManager}는
+ * {@link org.springframework.context.SmartLifecycle}을 구현하므로
+ * Spring Context 시작 시 자동 기동되고, 종료 시 정상 종료된다.</p>
  *
  * <p>이 클래스는 {@code META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports}에
  * 등록되어 Spring Boot 자동 설정 메커니즘으로 로드된다.</p>
@@ -30,6 +33,19 @@ import org.springframework.jdbc.core.JdbcTemplate;
 @ConditionalOnClass(JdbcTemplate.class)
 @Import(SpiderLinkMessageConfig.class)
 public class SpiderLinkAutoConfiguration {
+
+    /**
+     * 소켓 커넥션 풀 매니저 빈.
+     *
+     * <p>(host:port) 단위로 소켓을 재사용하여 TCP 연결 오버헤드를 줄인다.
+     * SmartLifecycle 구현체로 Context 종료 시 모든 유휴 소켓이 자동 닫힌다.</p>
+     *
+     * @return SocketPoolManager 빈
+     */
+    @Bean
+    public SocketPoolManager socketPoolManager() {
+        return new SocketPoolManager();
+    }
 
     /**
      * 전문 이력 비동기 큐 빈.

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/client/TcpClient.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/client/TcpClient.java
@@ -1,6 +1,9 @@
 package com.example.spiderlink.infra.tcp.client;
 
 import com.example.spiderlink.domain.messageinstance.MessageInstanceRecorder;
+import com.example.spiderlink.infra.tcp.client.pool.PooledSocket;
+import com.example.spiderlink.infra.tcp.client.pool.SocketPool;
+import com.example.spiderlink.infra.tcp.client.pool.SocketPoolManager;
 import com.example.spiderlink.infra.tcp.model.JsonCommandRequest;
 import com.example.spiderlink.infra.tcp.model.JsonCommandResponse;
 import com.example.spiderlink.infra.tcp.parser.FixedLengthParser;
@@ -10,8 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
+import java.net.UnknownHostException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -26,29 +28,26 @@ import org.springframework.stereotype.Component;
  * <p>프로토콜: 4바이트 길이 프리픽스(int, big-endian) + UTF-8 JSON 바이트열.
  * Admin의 TcpClient.sendJson()과 동일한 포맷을 사용한다.</p>
  *
- * <p>소켓 옵션 (레퍼런스 spiderlink_Admin 기준):</p>
- * <ul>
- *   <li>연결 타임아웃: 2초</li>
- *   <li>읽기 타임아웃: 60초</li>
- *   <li>setKeepAlive(true)</li>
- *   <li>setTcpNoDelay(true)</li>
- * </ul>
+ * <p>소켓 관리 방식: {@link SocketPoolManager}를 통해 (host:port) 단위로 소켓을 재사용한다.
+ * 풀 매니저가 없는 경우(테스트 등) 요청마다 신규 소켓을 생성한다.</p>
  *
- * <p>{@link MessageInstanceRecorder}를 주입하면 송신 요청과 수신 응답을
- * {@code FWK_MESSAGE_INSTANCE} 테이블에 자동 기록한다.</p>
+ * <p>재연결 로직: IOException 발생 시 최대 {@value RETRY_COUNT}회 재시도하고,
+ * {@link UnknownHostException}은 재시도 없이 즉시 실패한다.</p>
+ *
+ * <p>참고소스(spiderLink_Admin) {@code MessageClientWorker.connect()} 기준:
+ * 재시도 3회, 재시도 간격 2ms.</p>
  */
 @Slf4j
 @Component
 public class TcpClient {
 
-    /** 연결 타임아웃: 레퍼런스(spiderlink_Admin) 기준 2초 */
-    private static final int CONNECT_TIMEOUT_MS = 2_000;
-
-    /** 읽기 타임아웃: 레퍼런스(spiderlink_Admin) 기준 60초 (배치 실행 대기 포함) */
-    private static final int READ_TIMEOUT_MS = 60_000;
-
     /** 수신 메시지 최대 허용 크기 (1 MB) — 초과 시 OutOfMemoryError 방지를 위해 즉시 예외 발생 */
     private static final int MAX_MSG_LEN = 1024 * 1024;
+
+    /** IOException 재시도 횟수 — 참고소스 기준값 3회 */
+    private static final int RETRY_COUNT = 3;
+    /** 재시도 간격 (ms) — 참고소스 기준값 2ms */
+    private static final long RETRY_DELAY_MS = 2L;
 
     private final ObjectMapper objectMapper;
 
@@ -60,47 +59,53 @@ public class TcpClient {
     @Nullable
     private final MessageStructurePool structurePool;
 
-    /** 고정길이 파서/직렬화기 — structurePool 이 null이면 미사용 */
+    /** 고정길이 파서/직렬화기 — structurePool이 null이면 미사용 */
     @Nullable
     private final FixedLengthParser fixedLengthParser;
+
+    /** 소켓 커넥션 풀 매니저 — null이면 요청마다 신규 소켓 생성 */
+    @Nullable
+    private final SocketPoolManager poolManager;
 
     public TcpClient(ObjectMapper objectMapper,
                      @Nullable MessageInstanceRecorder recorder,
                      @Nullable MessageStructurePool structurePool,
-                     @Nullable FixedLengthParser fixedLengthParser) {
+                     @Nullable FixedLengthParser fixedLengthParser,
+                     @Nullable SocketPoolManager poolManager) {
         this.objectMapper     = objectMapper;
         this.recorder         = recorder;
         this.structurePool    = structurePool;
         this.fixedLengthParser = fixedLengthParser;
+        this.poolManager      = poolManager;
     }
 
     /** 고정길이 미사용 생성자 — 기존 코드 호환용 */
     public TcpClient(ObjectMapper objectMapper, @Nullable MessageInstanceRecorder recorder) {
-        this(objectMapper, recorder, null, null);
+        this(objectMapper, recorder, null, null, null);
     }
 
-    /** recorder/고정길이 모두 미사용 편의 생성자 — 테스트 등 */
+    /** 모든 선택 의존성 없는 생성자 — 테스트용 */
     public TcpClient(ObjectMapper objectMapper) {
-        this(objectMapper, null, null, null);
+        this(objectMapper, null, null, null, null);
     }
 
     /**
-     * FWK_MESSAGE.MESSAGE_TYPE 을 확인하여 고정길이('F') 또는 JSON 프로토콜로 자동 전환한다.
+     * FWK_MESSAGE.MESSAGE_TYPE을 확인하여 고정길이('F') 또는 JSON 프로토콜로 자동 전환한다.
      *
-     * <p>structurePool 이 null 이거나 REQ 전문 구조가 등록되지 않은 경우 JSON fallback.</p>
+     * <p>structurePool이 null이거나 REQ 전문 구조가 등록되지 않은 경우 JSON fallback.</p>
      *
-     * @param host   대상 호스트
-     * @param port   대상 포트
-     * @param orgId  기관 ID (FWK_MESSAGE 조회 키)
-     * @param req    전송할 JsonCommandRequest
+     * @param host  대상 호스트
+     * @param port  대상 포트
+     * @param orgId 기관 ID (FWK_MESSAGE 조회 키)
+     * @param req   전송할 JsonCommandRequest
      * @return 응답 JsonCommandResponse
      * @throws IOException 소켓 연결/전송/수신 실패 시
      */
     public JsonCommandResponse send(String host, int port, String orgId, JsonCommandRequest req)
             throws IOException {
-        String command     = req.getCommand();
-        String reqMsgId    = command + "_REQ";
-        String resMsgId    = command + "_RES";
+        String command  = req.getCommand();
+        String reqMsgId = command + "_REQ";
+        String resMsgId = command + "_RES";
 
         Optional<MessageStructure> reqStructure = structurePool != null
                 ? structurePool.get(orgId, reqMsgId)
@@ -130,62 +135,27 @@ public class TcpClient {
             requestBytes = objectMapper.writeValueAsBytes(req);
         }
 
-        try (Socket socket = createSocket(host, port);
-                DataOutputStream dos = new DataOutputStream(socket.getOutputStream());
-                DataInputStream dis = new DataInputStream(socket.getInputStream())) {
+        byte[] responseBytes = sendWithRetry(host, port, requestBytes);
 
-            dos.writeInt(requestBytes.length);
-            dos.write(requestBytes);
-            dos.flush();
-
-            int len = dis.readInt();
-            if (len < 0 || len > MAX_MSG_LEN) {
-                throw new IOException("수신된 메시지 길이가 허용 범위를 초과합니다: " + len);
-            }
-            byte[] responseBytes = new byte[len];
-            dis.readFully(responseBytes);
-
-            JsonCommandResponse response;
-            if (useFixed) {
-                Optional<MessageStructure> resStructure = structurePool.get(orgId, resMsgId);
-                if (resStructure.isPresent()) {
-                    Map<String, Object> resMap = fixedLengthParser.parse(resStructure.get(), responseBytes);
-                    response = toCommandResponse(command, resMap);
-                } else {
-                    log.warn("[TcpClient] RES 전문 구조 미등록({}), JSON fallback", resMsgId);
-                    response = objectMapper.readValue(responseBytes, JsonCommandResponse.class);
-                }
+        JsonCommandResponse response;
+        if (useFixed) {
+            Optional<MessageStructure> resStructure = structurePool.get(orgId, resMsgId);
+            if (resStructure.isPresent()) {
+                Map<String, Object> resMap = fixedLengthParser.parse(resStructure.get(), responseBytes);
+                response = toCommandResponse(command, resMap);
             } else {
+                log.warn("[TcpClient] RES 전문 구조 미등록({}), JSON fallback", resMsgId);
                 response = objectMapper.readValue(responseBytes, JsonCommandResponse.class);
             }
-
-            log.debug("[TcpClient] send 응답: success={}", response.isSuccess());
-            if (recorder != null) {
-                recorder.recordClientResponse(trxId, req, response, host, port);
-            }
-            return response;
+        } else {
+            response = objectMapper.readValue(responseBytes, JsonCommandResponse.class);
         }
-    }
 
-    /**
-     * 고정길이 응답 Map을 JsonCommandResponse 로 변환한다.
-     * SUCCESS('Y'/'N') / ERROR_MSG 를 매핑하고 나머지를 payload 로 사용한다.
-     */
-    private JsonCommandResponse toCommandResponse(String command, Map<String, Object> resMap) {
-        boolean success = "Y".equalsIgnoreCase(
-                String.valueOf(resMap.getOrDefault("SUCCESS", "N")).trim());
-        String errorMsg = String.valueOf(resMap.getOrDefault("ERROR_MSG", "")).trim();
-
-        Map<String, Object> payload = new LinkedHashMap<>(resMap);
-        payload.remove("SUCCESS");
-        payload.remove("ERROR_MSG");
-
-        return JsonCommandResponse.builder()
-                .command(command)
-                .success(success)
-                .error(success ? null : errorMsg.isEmpty() ? null : errorMsg)
-                .payload(payload)
-                .build();
+        log.debug("[TcpClient] send 응답: success={}", response.isSuccess());
+        if (recorder != null) {
+            recorder.recordClientResponse(trxId, req, response, host, port);
+        }
+        return response;
     }
 
     /**
@@ -207,48 +177,133 @@ public class TcpClient {
         }
 
         byte[] requestBytes = objectMapper.writeValueAsBytes(req);
+        byte[] responseBytes = sendWithRetry(host, port, requestBytes);
 
-        try (Socket socket = createSocket(host, port);
+        JsonCommandResponse response = objectMapper.readValue(responseBytes, JsonCommandResponse.class);
+        log.debug("[TcpClient] JSON 응답 수신: success={}", response.isSuccess());
+
+        if (recorder != null) {
+            recorder.recordClientResponse(trxId, req, response, host, port);
+        }
+        return response;
+    }
+
+    /**
+     * 재시도 래퍼 — IOException 발생 시 최대 {@value RETRY_COUNT}회 재시도한다.
+     *
+     * <p>{@link UnknownHostException}은 재시도 없이 즉시 재발생한다.
+     * 참고소스(spiderLink_Admin) MessageClientWorker 기준: 3회, 2ms 간격.</p>
+     */
+    private byte[] sendWithRetry(String host, int port, byte[] requestBytes) throws IOException {
+        IOException lastException = null;
+        for (int attempt = 0; attempt <= RETRY_COUNT; attempt++) {
+            if (attempt > 0) {
+                log.warn("[TcpClient] 재시도 {}회 ({}:{})", attempt, host, port);
+                try {
+                    Thread.sleep(RETRY_DELAY_MS);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw lastException;
+                }
+            }
+            try {
+                return doSend(host, port, requestBytes);
+            } catch (UnknownHostException e) {
+                // 호스트 해석 실패 — 재시도해도 동일하므로 즉시 실패
+                throw e;
+            } catch (IOException e) {
+                lastException = e;
+                log.warn("[TcpClient] 전송 실패 (시도={}, {}:{}) — {}", attempt + 1, host, port, e.getMessage());
+            }
+        }
+        throw lastException;
+    }
+
+    /**
+     * 단일 전송·수신 — 풀 매니저가 있으면 풀에서 소켓을 빌리고, 없으면 신규 생성한다.
+     *
+     * @return 수신된 응답 바이트 배열
+     * @throws IOException 소켓 연결/전송/수신 실패 시
+     */
+    private byte[] doSend(String host, int port, byte[] requestBytes) throws IOException {
+        if (poolManager != null) {
+            PooledSocket pooled = null;
+            boolean success = false;
+            try {
+                pooled = poolManager.borrow(host, port);
+                byte[] responseBytes = doSendReceive(pooled.getOut(), pooled.getIn(), requestBytes);
+                success = true;
+                return responseBytes;
+            } finally {
+                if (pooled != null) {
+                    poolManager.release(host, port, pooled, success);
+                }
+            }
+        }
+
+        // 풀 미사용 — 요청마다 신규 소켓 생성 (테스트 등 폴백)
+        try (java.net.Socket socket = createFreshSocket(host, port);
                 DataOutputStream dos = new DataOutputStream(socket.getOutputStream());
                 DataInputStream dis = new DataInputStream(socket.getInputStream())) {
-
-            dos.writeInt(requestBytes.length);
-            dos.write(requestBytes);
-            dos.flush();
-
-            int len = dis.readInt();
-            // 음수 또는 허용 최대 크기(1 MB) 초과 시 비정상 응답으로 간주하여 즉시 예외 발생
-            if (len < 0 || len > MAX_MSG_LEN) {
-                throw new IOException("수신된 메시지 길이가 허용 범위를 초과합니다: " + len);
-            }
-            byte[] responseBytes = new byte[len];
-            dis.readFully(responseBytes);
-
-            JsonCommandResponse response = objectMapper.readValue(responseBytes, JsonCommandResponse.class);
-            log.debug("[TcpClient] JSON 응답 수신: success={}", response.isSuccess());
-
-            if (recorder != null) {
-                recorder.recordClientResponse(trxId, req, response, host, port);
-            }
-
-            return response;
+            return doSendReceive(dos, dis, requestBytes);
         }
     }
 
     /**
-     * 소켓을 생성하고 레퍼런스 기준 소켓 옵션을 적용한다.
+     * 실제 4byte int 길이헤더 + 바이트열 전송 및 응답 수신.
      *
-     * @param host 대상 호스트
-     * @param port 대상 포트
-     * @return 설정이 완료된 Socket
+     * @param dos          DataOutputStream
+     * @param dis          DataInputStream
+     * @param requestBytes 전송할 바이트 배열
+     * @return 수신된 응답 바이트 배열
+     * @throws IOException 전송/수신 실패 시
      */
-    private Socket createSocket(String host, int port) throws IOException {
-        Socket socket = new Socket();
-        // Nagle 알고리즘 비활성화: 소규모 커맨드 메시지의 지연 최소화
+    private byte[] doSendReceive(DataOutputStream dos, DataInputStream dis, byte[] requestBytes)
+            throws IOException {
+        dos.writeInt(requestBytes.length);
+        dos.write(requestBytes);
+        dos.flush();
+
+        int len = dis.readInt();
+        // 음수 또는 허용 최대 크기(1 MB) 초과 시 비정상 응답으로 간주하여 즉시 예외 발생
+        if (len < 0 || len > MAX_MSG_LEN) {
+            throw new IOException("수신된 메시지 길이가 허용 범위를 초과합니다: " + len);
+        }
+        byte[] responseBytes = new byte[len];
+        dis.readFully(responseBytes);
+        return responseBytes;
+    }
+
+    /**
+     * 풀 미사용 폴백용 단순 소켓 생성 — 소켓 옵션은 SocketPool과 동일하게 적용한다.
+     */
+    private java.net.Socket createFreshSocket(String host, int port) throws IOException {
+        java.net.Socket socket = new java.net.Socket();
         socket.setTcpNoDelay(true);
         socket.setKeepAlive(true);
-        socket.connect(new InetSocketAddress(host, port), CONNECT_TIMEOUT_MS);
-        socket.setSoTimeout(READ_TIMEOUT_MS);
+        socket.connect(new java.net.InetSocketAddress(host, port), SocketPool.CONNECT_TIMEOUT_MS);
+        socket.setSoTimeout(SocketPool.READ_TIMEOUT_MS);
         return socket;
+    }
+
+    /**
+     * 고정길이 응답 Map을 JsonCommandResponse로 변환한다.
+     * SUCCESS('Y'/'N') / ERROR_MSG를 매핑하고 나머지를 payload로 사용한다.
+     */
+    private JsonCommandResponse toCommandResponse(String command, Map<String, Object> resMap) {
+        boolean success = "Y".equalsIgnoreCase(
+                String.valueOf(resMap.getOrDefault("SUCCESS", "N")).trim());
+        String errorMsg = String.valueOf(resMap.getOrDefault("ERROR_MSG", "")).trim();
+
+        Map<String, Object> payload = new LinkedHashMap<>(resMap);
+        payload.remove("SUCCESS");
+        payload.remove("ERROR_MSG");
+
+        return JsonCommandResponse.builder()
+                .command(command)
+                .success(success)
+                .error(success ? null : errorMsg.isEmpty() ? null : errorMsg)
+                .payload(payload)
+                .build();
     }
 }

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/client/pool/PooledSocket.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/client/pool/PooledSocket.java
@@ -1,0 +1,61 @@
+package com.example.spiderlink.infra.tcp.client.pool;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.Socket;
+
+/**
+ * 소켓 풀에서 관리되는 Socket 래퍼.
+ *
+ * <p>Socket과 DataInputStream/DataOutputStream을 함께 보유하여 풀 반납 후에도
+ * 스트림을 재사용할 수 있도록 한다. 마지막 사용 시각을 기록하여
+ * {@link SocketPool}이 유효기간({@code maxIdleMs})을 판단하는 데 사용된다.</p>
+ */
+public class PooledSocket {
+
+    private final Socket socket;
+    private final DataInputStream in;
+    private final DataOutputStream out;
+
+    /** 마지막 사용 시각 (ms) — 풀 반납 시 갱신 */
+    private volatile long lastUsed = System.currentTimeMillis();
+    /** 오류 발생 시 true로 설정 — borrow 시 유효성 검사에서 탈락 */
+    private volatile boolean invalid = false;
+
+    public PooledSocket(Socket socket) throws IOException {
+        this.socket = socket;
+        this.out = new DataOutputStream(socket.getOutputStream());
+        this.in = new DataInputStream(socket.getInputStream());
+    }
+
+    /**
+     * 소켓이 유효한지 확인한다.
+     *
+     * @param maxIdleMs 최대 유휴 허용 시간 (ms)
+     * @return 유효 여부
+     */
+    public boolean isValid(long maxIdleMs) {
+        if (invalid || socket.isClosed() || socket.isInputShutdown() || socket.isOutputShutdown()) {
+            return false;
+        }
+        return (System.currentTimeMillis() - lastUsed) < maxIdleMs;
+    }
+
+    /** 마지막 사용 시각을 현재 시각으로 갱신한다 */
+    public void touch() {
+        lastUsed = System.currentTimeMillis();
+    }
+
+    /** 소켓을 무효화하고 닫는다 — IOException은 무시 */
+    public void invalidate() {
+        invalid = true;
+        try {
+            socket.close();
+        } catch (Exception ignored) {}
+    }
+
+    public DataInputStream getIn() { return in; }
+    public DataOutputStream getOut() { return out; }
+    public long getLastUsed() { return lastUsed; }
+}

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/client/pool/SocketPool.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/client/pool/SocketPool.java
@@ -1,0 +1,171 @@
+package com.example.spiderlink.infra.tcp.client.pool;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.ArrayDeque;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 단일 (host:port) 대상 소켓 커넥션 풀.
+ *
+ * <p>참고소스(spiderLink_Admin) {@code SocketPool} 설계 기준값을 적용한다.</p>
+ *
+ * <ul>
+ *   <li>최대 소켓 수: {@value MAX_ACTIVE}개</li>
+ *   <li>풀 고갈 시 최대 대기: {@value BORROW_WAIT_MS}ms</li>
+ *   <li>미사용 소켓 자동 폐기: {@value MAX_IDLE_MS}ms (210초)</li>
+ * </ul>
+ *
+ * <p>유효기간 만료 소켓은 {@link #borrow()} 시점에 탐지·폐기하므로 별도 스케줄러가 필요 없다.
+ * 모든 공유 상태는 {@code synchronized} 블록으로 보호하며, 소켓 생성 IO는 락 밖에서 수행한다.</p>
+ */
+@Slf4j
+public class SocketPool {
+
+    /** 최대 소켓 수 (active + idle 합계) — 참고소스 기준값 */
+    static final int MAX_ACTIVE = 5;
+    /** 풀 고갈 시 최대 대기 시간 — 참고소스 기준값 2초 */
+    static final long BORROW_WAIT_MS = 2_000;
+    /** 미사용 소켓 자동 폐기 기준 — 참고소스 기준값 210초 */
+    static final long MAX_IDLE_MS = 210_000;
+    /** 연결 타임아웃 — 참고소스 기준값 2초 */
+    public static final int CONNECT_TIMEOUT_MS = 2_000;
+    /** 읽기 타임아웃 */
+    public static final int READ_TIMEOUT_MS = 60_000;
+
+    private final String host;
+    private final int port;
+
+    private final ArrayDeque<PooledSocket> idle = new ArrayDeque<>();
+    /** active + idle 합계 — MAX_ACTIVE 상한 적용 */
+    private int totalCount = 0;
+    private final Object lock = new Object();
+
+    public SocketPool(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    /**
+     * 풀에서 소켓을 빌린다.
+     *
+     * <p>유휴 소켓이 있으면 즉시 반환하고, 없으면 신규 생성을 시도한다.
+     * 총 소켓 수가 {@link #MAX_ACTIVE}에 도달한 경우 최대 {@link #BORROW_WAIT_MS}ms 대기 후
+     * 타임아웃 예외를 던진다.</p>
+     *
+     * @throws IOException 연결 실패 또는 풀 고갈 타임아웃
+     */
+    public PooledSocket borrow() throws IOException {
+        long deadline = System.currentTimeMillis() + BORROW_WAIT_MS;
+        boolean mustCreate = false;
+
+        synchronized (lock) {
+            while (true) {
+                // 유효기간 만료된 유휴 소켓 제거
+                while (!idle.isEmpty() && !idle.peekFirst().isValid(MAX_IDLE_MS)) {
+                    idle.pollFirst().invalidate();
+                    totalCount--;
+                    log.debug("[SocketPool] 유휴 소켓 만료 폐기 ({}:{})", host, port);
+                }
+
+                // 유효한 유휴 소켓 즉시 반환
+                if (!idle.isEmpty()) {
+                    PooledSocket pooled = idle.pollFirst();
+                    pooled.touch();
+                    return pooled;
+                }
+
+                // 신규 생성 가능 → 카운터 선점 후 락 밖에서 IO 수행
+                if (totalCount < MAX_ACTIVE) {
+                    totalCount++;
+                    mustCreate = true;
+                    break;
+                }
+
+                // 풀 고갈 — 반납 신호 대기
+                long remaining = deadline - System.currentTimeMillis();
+                if (remaining <= 0) {
+                    throw new IOException(String.format(
+                            "[SocketPool] 소켓 풀 고갈 — 대기 시간 초과 (%s:%d, total=%d/%d)",
+                            host, port, totalCount, MAX_ACTIVE));
+                }
+                try {
+                    lock.wait(Math.min(remaining, 100));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("[SocketPool] borrow 대기 중 인터럽트", e);
+                }
+            }
+        }
+
+        // 소켓 생성 — IO는 락 밖에서 수행
+        if (mustCreate) {
+            try {
+                Socket socket = new Socket();
+                socket.setTcpNoDelay(true);
+                socket.setKeepAlive(true);
+                socket.connect(new InetSocketAddress(host, port), CONNECT_TIMEOUT_MS);
+                socket.setSoTimeout(READ_TIMEOUT_MS);
+                log.debug("[SocketPool] 신규 소켓 생성 ({}:{}, total={})", host, port, totalCount);
+                return new PooledSocket(socket);
+            } catch (IOException e) {
+                // 생성 실패 — 선점한 카운터 반환
+                synchronized (lock) {
+                    totalCount--;
+                    lock.notifyAll();
+                }
+                throw e;
+            }
+        }
+
+        throw new IOException("[SocketPool] 내부 상태 오류 — 도달 불가 코드");
+    }
+
+    /**
+     * 소켓을 풀에 반납한다.
+     *
+     * @param pooled  반납할 소켓
+     * @param success 통신 성공 여부 — false면 소켓 폐기
+     */
+    public void release(PooledSocket pooled, boolean success) {
+        if (!success || !pooled.isValid(MAX_IDLE_MS)) {
+            pooled.invalidate();
+            synchronized (lock) {
+                totalCount--;
+                lock.notifyAll();
+            }
+            log.debug("[SocketPool] 오류 소켓 폐기 ({}:{}, total={})", host, port, totalCount);
+        } else {
+            pooled.touch();
+            synchronized (lock) {
+                idle.addLast(pooled);
+                lock.notifyAll();
+            }
+        }
+    }
+
+    /** 풀 종료 시 모든 유휴 소켓을 닫는다 */
+    public void closeAll() {
+        synchronized (lock) {
+            while (!idle.isEmpty()) {
+                idle.pollFirst().invalidate();
+                totalCount--;
+            }
+            lock.notifyAll();
+        }
+    }
+
+    /** Admin 모니터링용 상태 문자열 */
+    public String getInfo() {
+        synchronized (lock) {
+            int idleCount = idle.size();
+            int activeCount = totalCount - idleCount;
+            return String.format("[%s:%d] active=%d, idle=%d, total=%d/%d",
+                    host, port, activeCount, idleCount, totalCount, MAX_ACTIVE);
+        }
+    }
+
+    public String getHost() { return host; }
+    public int getPort() { return port; }
+}

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/client/pool/SocketPool.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/client/pool/SocketPool.java
@@ -91,7 +91,7 @@ public class SocketPool {
                             host, port, totalCount, MAX_ACTIVE));
                 }
                 try {
-                    lock.wait(Math.min(remaining, 100));
+                    lock.wait(remaining);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     throw new IOException("[SocketPool] borrow 대기 중 인터럽트", e);

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/client/pool/SocketPoolManager.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/client/pool/SocketPoolManager.java
@@ -46,11 +46,18 @@ public class SocketPoolManager implements SmartLifecycle {
      * @throws IOException 연결 실패 또는 풀 고갈 타임아웃
      */
     public PooledSocket borrow(String host, int port) throws IOException {
+        // stop() 이후 신규 소켓 생성 차단 — Context 종료 중 연결 시도 방지
+        if (!running) {
+            throw new IOException("[SocketPoolManager] 매니저가 중지 상태 — 소켓 대여 불가");
+        }
         return getOrCreate(host, port).borrow();
     }
 
     /**
      * 소켓을 풀에 반납한다.
+     *
+     * <p>stop() 이후 pools 맵이 비워진 상태에서 지연된 응답이 반납될 수 있으므로,
+     * pools.get()으로 기존 풀이 있을 때만 반납하고 없으면 소켓을 즉시 폐기한다.</p>
      *
      * @param host    대상 호스트
      * @param port    대상 포트
@@ -58,7 +65,13 @@ public class SocketPoolManager implements SmartLifecycle {
      * @param success 통신 성공 여부 — false면 소켓 폐기
      */
     public void release(String host, int port, PooledSocket pooled, boolean success) {
-        getOrCreate(host, port).release(pooled, success);
+        SocketPool pool = pools.get(host + ":" + port);
+        if (pool != null) {
+            pool.release(pooled, success);
+        } else {
+            // shutdown 완료 후 반납 — 풀이 이미 제거됐으므로 소켓 직접 폐기
+            pooled.invalidate();
+        }
     }
 
     /**

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/client/pool/SocketPoolManager.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/client/pool/SocketPoolManager.java
@@ -1,0 +1,106 @@
+package com.example.spiderlink.infra.tcp.client.pool;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.SmartLifecycle;
+
+/**
+ * 전체 소켓 풀 레지스트리.
+ *
+ * <p>(host:port) 키로 {@link SocketPool}을 지연 생성하고 관리한다.
+ * Spring Context 종료 시 {@link SmartLifecycle#stop()}이 자동 호출되어
+ * 모든 유휴 소켓을 닫는다.</p>
+ *
+ * <p>{@link com.example.spiderlink.config.SpiderLinkAutoConfiguration}에 의해
+ * 자동으로 빈으로 등록된다.</p>
+ */
+@Slf4j
+public class SocketPoolManager implements SmartLifecycle {
+
+    /** (host:port) → SocketPool 맵 */
+    private final ConcurrentHashMap<String, SocketPool> pools = new ConcurrentHashMap<>();
+    private volatile boolean running = false;
+
+    /**
+     * (host:port) 키에 해당하는 소켓 풀을 반환하고, 없으면 생성한다.
+     *
+     * @param host 대상 호스트
+     * @param port 대상 포트
+     * @return 해당 엔드포인트의 SocketPool
+     */
+    public SocketPool getOrCreate(String host, int port) {
+        String key = host + ":" + port;
+        return pools.computeIfAbsent(key, k -> {
+            log.info("[SocketPoolManager] 소켓 풀 신규 생성: {}", key);
+            return new SocketPool(host, port);
+        });
+    }
+
+    /**
+     * 풀에서 소켓을 빌린다.
+     *
+     * @param host 대상 호스트
+     * @param port 대상 포트
+     * @return 빌린 PooledSocket
+     * @throws IOException 연결 실패 또는 풀 고갈 타임아웃
+     */
+    public PooledSocket borrow(String host, int port) throws IOException {
+        return getOrCreate(host, port).borrow();
+    }
+
+    /**
+     * 소켓을 풀에 반납한다.
+     *
+     * @param host    대상 호스트
+     * @param port    대상 포트
+     * @param pooled  반납할 소켓
+     * @param success 통신 성공 여부 — false면 소켓 폐기
+     */
+    public void release(String host, int port, PooledSocket pooled, boolean success) {
+        getOrCreate(host, port).release(pooled, success);
+    }
+
+    /**
+     * Admin 모니터링용 — 특정 엔드포인트 풀 상태 문자열 반환.
+     *
+     * @param host 대상 호스트
+     * @param port 대상 포트
+     * @return "active=N, idle=M, total=K/MAX_ACTIVE" 형식 문자열
+     */
+    public String getInfo(String host, int port) {
+        String key = host + ":" + port;
+        SocketPool pool = pools.get(key);
+        return pool != null ? pool.getInfo() : key + " — 풀 없음";
+    }
+
+    /** 등록된 모든 풀의 상태를 로그에 출력한다 */
+    public void logPoolState() {
+        if (pools.isEmpty()) {
+            log.info("[SocketPoolManager] 등록된 소켓 풀 없음");
+            return;
+        }
+        pools.values().forEach(pool -> log.info("[SocketPoolManager] {}", pool.getInfo()));
+    }
+
+    /** Spring Context 초기화 완료 후 자동 호출 */
+    @Override
+    public void start() {
+        running = true;
+        log.info("[SocketPoolManager] 소켓 풀 매니저 시작");
+    }
+
+    /** Spring Context 종료 시 자동 호출 — 모든 유휴 소켓 닫기 */
+    @Override
+    public void stop() {
+        running = false;
+        pools.values().forEach(SocketPool::closeAll);
+        pools.clear();
+        log.info("[SocketPoolManager] 소켓 풀 매니저 종료 — 모든 풀 닫힘");
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

Closes #246

## ✨ 변경 사항 (Changes)

`TcpClient`가 요청마다 `new Socket()`을 생성하고 즉시 닫는 방식에서 벗어나,
(host:port) 단위 커넥션 풀(`SocketPoolManager`)로 소켓을 재사용하고
일시적 네트워크 오류 시 자동 재시도한다.

**신규 파일 3건 + 수정 파일 2건**

| 파일 | 변경 내용 |
|------|---------|
| `pool/PooledSocket.java` (신규) | Socket + DataInputStream/DataOutputStream 래퍼, 유효성 검사 |
| `pool/SocketPool.java` (신규) | (host:port) 단위 소켓 풀, SmartLifecycle 불필요한 락 없는 설계 |
| `pool/SocketPoolManager.java` (신규) | ConcurrentHashMap 기반 풀 레지스트리, SmartLifecycle |
| `TcpClient.java` | 풀 사용 + 3회 재시도 로직 추가 |
| `SpiderLinkAutoConfiguration.java` | `SocketPoolManager` 빈 등록 추가 |

**처리 흐름 변화**

```
[이전] TCP 요청 → new Socket() → send/receive → socket.close()

[이후] TCP 요청 → poolManager.borrow(host, port)
                      ↓ 유휴 소켓 존재 → 재사용
                      ↓ 없으면 신규 생성 (최대 5개)
                      ↓ 풀 고갈 시 최대 2초 대기
               → send/receive
               → poolManager.release(host, port, pooled, success)
                      ↓ 성공 → 풀에 반납 (재사용)
                      ↓ 실패 → 소켓 폐기
```

## 🛠 기술적 의사결정

**Apache Commons Pool 미사용 — synchronized + wait/notifyAll 직접 구현**

참고소스는 `GenericObjectPool`(commons-pool 1.x)을 사용하나, POC에서 외부 의존성 추가 없이
`synchronized + wait/notifyAll` 방식으로 동일한 동작을 구현했다.
풀 내 상태 변경은 짧은 synchronized 블록에서만 수행하고, 소켓 생성 IO는 락 밖에서 처리한다.

**SocketPool 주요 설정값 (참고소스 기준)**

| 항목 | 값 |
|------|-----|
| Max Active (active + idle) | 5 |
| Connect Timeout | 2,000ms |
| Read Timeout | 60,000ms |
| 미사용 소켓 자동 폐기 | 210,000ms (210초) |
| Exhausted 정책 | BLOCK 2초 대기 후 IOException |

**재연결 로직 (참고소스 MessageClientWorker 기준)**

- IOException: 최대 3회 재시도, 2ms 간격
- UnknownHostException: 즉시 실패 (재시도 안 함)
- 풀 미사용 시(null) 신규 소켓 생성 폴백 유지 — 테스트 하위 호환

**SmartLifecycle 활용**

`SocketPoolManager.stop()`이 Context 종료 시 자동 호출되어 모든 유휴 소켓을 닫는다.
Admin 모니터링 연동을 위해 `getInfo(host, port)` 메서드도 제공한다(이슈 #249 선행 준비).

## 🧪 테스트

- [ ] spider-link `mvn compile` — BUILD SUCCESS 확인
- [ ] biz-auth / biz-transfer 기동 로그에 `[SocketPoolManager] 소켓 풀 매니저 시작` 출력 확인
- [ ] AUTH_LOGIN 요청 → 첫 요청 시 `신규 소켓 생성`, 재요청 시 소켓 재사용 확인 (DEBUG 로그)
- [ ] 서버 재기동 타이밍 겹침 시 재시도 후 정상 처리 확인

## ⚠️ 고려 및 주의 사항

- `SocketPoolManager`는 `@ConditionalOnBean(JdbcTemplate.class)` 없이 등록 — JdbcTemplate 없는 환경에서도 풀 동작
- 유효기간 만료 소켓(210s)은 `borrow()` 시점에만 탐지·폐기 (별도 evictor 스레드 없음)
- Active 소켓 수는 종료 시 `closeAll()`이 idle만 닫으므로 실제 active 소켓은 요청 완료 후 자연 반납됨

## 🔗 참고 사항

- 참고소스: `spiderLink_Admin/src_spiderlink/.../socketpool/` — SocketPool, WorkerSocket, SocketFactory, SocketPoolManager
- 관련 문서: `08. 기타/참고소스_비교분석.md` — 3-1절, 3-2절
- 이슈 #249 (Admin 접속 현황 모니터링): `SocketPoolManager.getInfo()` 활용 예정