### PR TITLE
✨ feat/#248-Admin 동적 리로드 API 연동

### DIFF
--- a/admin/docs/sql/oracle/04_alter_tables.sql
+++ b/admin/docs/sql/oracle/04_alter_tables.sql
@@ -683,3 +683,37 @@ INSERT INTO FWK_RELATION_PARAM (SERVICE_ID, SERVICE_SEQ_NO, COMPONENT_ID, PARAM_
 VALUES ('SVC_BIZ_PAYABLE_AMT', 1, 'BIZ_TCP_CORE_PAYABLE_AMT', 2, 'cardId');
 
 COMMIT;
+
+-- =============================================================
+-- #248 Admin 동적 리로드 — WAS 인스턴스 및 관리 포트 등록
+-- =============================================================
+-- ※ 개발자가 DB에서 직접 실행해야 합니다.
+-- Admin 운영정보 → Reload 화면에서 biz-auth / biz-transfer 대상 선택 가능해짐.
+-- 실행 전 중복 확인:
+--   SELECT * FROM FWK_WAS_INSTANCE WHERE INSTANCE_ID IN ('auth', 'trf');
+--   SELECT * FROM FWK_PROPERTY WHERE PROPERTY_GROUP_ID = 'was_config';
+-- =============================================================
+
+-- Step 1: biz-auth WAS 인스턴스 등록
+INSERT INTO FWK_WAS_INSTANCE (INSTANCE_ID, INSTANCE_NAME, INSTANCE_DESC, INSTANCE_TYPE, IP, PORT, OPER_MODE_TYPE)
+VALUES ('auth', 'biz-auth', '인증 AP 서버 (TCP:19100 / HTTP:19180)', 'A', '127.0.0.1', '19100', 'D');
+
+-- Step 2: biz-transfer WAS 인스턴스 등록
+INSERT INTO FWK_WAS_INSTANCE (INSTANCE_ID, INSTANCE_NAME, INSTANCE_DESC, INSTANCE_TYPE, IP, PORT, OPER_MODE_TYPE)
+VALUES ('trf', 'biz-transfer', '이체 AP 서버 (TCP:19200 / HTTP:19280)', 'A', '127.0.0.1', '19200', 'D');
+
+-- Step 3: biz-auth 관리 포트 FWK_PROPERTY 등록
+INSERT INTO FWK_PROPERTY (PROPERTY_GROUP_ID, PROPERTY_ID, PROPERTY_NAME, PROPERTY_DESC, DATA_TYPE, DEFAULT_VALUE, LAST_UPDATE_USER_ID)
+VALUES ('was_config', 'auth.MANAGEMENT_SERVER_IP', 'biz-auth 관리 서버 IP', 'Admin reload API 대상 IP', 'S', '127.0.0.1', 'system');
+
+INSERT INTO FWK_PROPERTY (PROPERTY_GROUP_ID, PROPERTY_ID, PROPERTY_NAME, PROPERTY_DESC, DATA_TYPE, DEFAULT_VALUE, LAST_UPDATE_USER_ID)
+VALUES ('was_config', 'auth.MANAGEMENT_SERVER_PORT', 'biz-auth 관리 서버 포트', 'Admin reload API 대상 포트', 'N', '19180', 'system');
+
+-- Step 4: biz-transfer 관리 포트 FWK_PROPERTY 등록
+INSERT INTO FWK_PROPERTY (PROPERTY_GROUP_ID, PROPERTY_ID, PROPERTY_NAME, PROPERTY_DESC, DATA_TYPE, DEFAULT_VALUE, LAST_UPDATE_USER_ID)
+VALUES ('was_config', 'trf.MANAGEMENT_SERVER_IP', 'biz-transfer 관리 서버 IP', 'Admin reload API 대상 IP', 'S', '127.0.0.1', 'system');
+
+INSERT INTO FWK_PROPERTY (PROPERTY_GROUP_ID, PROPERTY_ID, PROPERTY_NAME, PROPERTY_DESC, DATA_TYPE, DEFAULT_VALUE, LAST_UPDATE_USER_ID)
+VALUES ('was_config', 'trf.MANAGEMENT_SERVER_PORT', 'biz-transfer 관리 서버 포트', 'Admin reload API 대상 포트', 'N', '19280', 'system');
+
+COMMIT;

--- a/admin/src/main/java/com/example/admin_demo/domain/reload/enums/ReloadType.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reload/enums/ReloadType.java
@@ -18,7 +18,7 @@ public enum ReloadType implements BaseEnum {
     SERVICE("service_reload_all", "서비스 정보", "서비스 정보를 Reload한다."),
     ERROR("error", "오류 코드 정보", "오류코드 정보를 Reload한다."),
     XML_PROPERTY("xml_property", "XML Property 정보", "XML Property 정보를 Reload한다.", false),
-    MESSAGE("message", "전문 정보", "전문정보를 Reload한다.", false),
+    MESSAGE("message", "전문 정보", "전문정보를 Reload한다."),
     SQL_QUERY("sql_query", "SQL Query 정보", "SQL Query 정보를 Reload한다.", false);
 
     private final String code;

--- a/demo/bizApp/biz-auth/.env.example
+++ b/demo/bizApp/biz-auth/.env.example
@@ -3,6 +3,9 @@ DB_URL=jdbc:oracle:thin:@localhost:1521:XE
 DB_USERNAME=
 DB_PASSWORD=
 
+# HTTP Management Server (Admin reload API 수신용)
+HTTP_SERVER_PORT=19180
+
 # TCP Server
 TCP_SERVER_PORT=19100
 TCP_SERVER_HANDLER_POOL_SIZE=5

--- a/demo/bizApp/biz-auth/pom.xml
+++ b/demo/bizApp/biz-auth/pom.xml
@@ -24,6 +24,12 @@
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
 
+        <!-- Admin reload API(/api/management/reload) 수신을 위한 내장 웹 서버 -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
         <!-- Jackson — ObjectMapper 빈 자동 구성 (JsonMessageCodec, TcpClient 의존) -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/demo/bizApp/biz-auth/src/main/resources/application.yml
+++ b/demo/bizApp/biz-auth/src/main/resources/application.yml
@@ -4,8 +4,6 @@ spring:
   config:
     import: optional:file:.env[.properties]
   main:
-    # HTTP 서버 없이 순수 TCP 서버로 동작 (spring-boot-starter 전용)
-    web-application-type: none
     keep-alive: true
   datasource:
     url: ${DB_URL}
@@ -19,6 +17,10 @@ spring:
 mybatis:
   # classpath*: 로 spider-link JAR 내부 XML까지 탐색
   mapper-locations: classpath*:mapper/oracle/**/*.xml
+
+server:
+  # Admin reload API 수신용 HTTP 관리 포트 (TCP 포트와 별도)
+  port: ${HTTP_SERVER_PORT:19180}
 
 tcp:
   server:

--- a/demo/bizApp/biz-transfer/.env.example
+++ b/demo/bizApp/biz-transfer/.env.example
@@ -3,6 +3,9 @@ DB_URL=jdbc:oracle:thin:@localhost:1521:XE
 DB_USERNAME=
 DB_PASSWORD=
 
+# HTTP Management Server (Admin reload API 수신용)
+HTTP_SERVER_PORT=19280
+
 # TCP Server
 TCP_SERVER_PORT=19200
 TCP_SERVER_HANDLER_POOL_SIZE=10

--- a/demo/bizApp/biz-transfer/pom.xml
+++ b/demo/bizApp/biz-transfer/pom.xml
@@ -24,6 +24,12 @@
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
 
+        <!-- Admin reload API(/api/management/reload) 수신을 위한 내장 웹 서버 -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
         <!-- Jackson — ObjectMapper 빈 자동 구성 (JsonMessageCodec, TcpClient 의존) -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/demo/bizApp/biz-transfer/src/main/resources/application.yml
+++ b/demo/bizApp/biz-transfer/src/main/resources/application.yml
@@ -4,8 +4,6 @@ spring:
   config:
     import: optional:file:.env[.properties]
   main:
-    # TCP 서버만 사용하므로 내장 웹 서버를 비활성화한다
-    web-application-type: none
     keep-alive: true
   datasource:
     url: ${DB_URL}
@@ -19,6 +17,10 @@ spring:
 mybatis:
   # classpath*: 로 spider-link JAR 내부 XML까지 탐색
   mapper-locations: classpath*:mapper/oracle/**/*.xml
+
+server:
+  # Admin reload API 수신용 HTTP 관리 포트 (TCP 포트와 별도)
+  port: ${HTTP_SERVER_PORT:19280}
 
 tcp:
   server:

--- a/spider-link/src/main/java/com/example/spiderlink/config/WebMvcConfig.java
+++ b/spider-link/src/main/java/com/example/spiderlink/config/WebMvcConfig.java
@@ -17,6 +17,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(internalApiInterceptor)
-                .addPathPatterns("/api/internal/**");
+                .addPathPatterns("/api/internal/**", "/api/management/**");
     }
 }

--- a/spider-link/src/main/java/com/example/spiderlink/infra/http/InternalManagementController.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/http/InternalManagementController.java
@@ -1,0 +1,87 @@
+package com.example.spiderlink.infra.http;
+
+import com.example.spiderlink.infra.tcp.handler.MetaDrivenCommandHandler;
+import com.example.spiderlink.infra.tcp.parser.MessageStructurePool;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Admin → WAS 운영정보 리로드 내부 API.
+ *
+ * <p>Admin의 ReloadService가 {@code POST /api/management/reload} 로 호출하며,
+ * 요청 본문의 {@code gubun} 값에 따라 캐시를 무효화한다.</p>
+ *
+ * <pre>{@code
+ * gubun=request_app_mapping → MetaDrivenCommandHandler 커맨드 캐시 갱신
+ * gubun=message             → MessageStructurePool 전문 구조 캐시 초기화
+ * (기타 gubun)              → 이 WAS에서 처리 불필요 → 성공 응답(no-op)
+ * }</pre>
+ *
+ * <p>보안: {@link com.example.spiderlink.config.WebMvcConfig}의 인터셉터가
+ * {@code /api/management/**} 경로를 허용 IP(기본: localhost)로만 제한한다.</p>
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/management")
+@RequiredArgsConstructor
+@ConditionalOnBean(MetaDrivenCommandHandler.class)
+public class InternalManagementController {
+
+    private final MetaDrivenCommandHandler metaDrivenCommandHandler;
+
+    /** 전문 구조 캐시 풀 — 없으면 고정길이 전문 미사용으로 간주, message 리로드 생략 */
+    @Nullable
+    private final MessageStructurePool messageStructurePool;
+
+    /**
+     * 운영정보 리로드 엔드포인트.
+     *
+     * @param body {@code gubun} 필드를 포함한 요청 본문
+     */
+    @PostMapping("/reload")
+    public ResponseEntity<Map<String, Object>> reload(
+            @RequestBody(required = false) Map<String, String> body) {
+
+        String gubun = body != null ? body.get("gubun") : null;
+        log.info("[InternalManagementController] reload 요청: gubun={}", gubun);
+
+        try {
+            if ("request_app_mapping".equals(gubun)) {
+                // FWK_LISTENER_TRX_MESSAGE 변경 후 커맨드 캐시 갱신
+                metaDrivenCommandHandler.refreshCommands();
+                return ok("request_app_mapping");
+
+            } else if ("message".equals(gubun)) {
+                // FWK_MESSAGE / FWK_MESSAGE_FIELD 변경 후 전문 구조 캐시 초기화
+                if (messageStructurePool != null) {
+                    messageStructurePool.clear();
+                    return ok("message");
+                } else {
+                    log.debug("[InternalManagementController] MessageStructurePool 빈 없음 — message 리로드 생략");
+                    return ok("message(skipped-no-pool)");
+                }
+
+            } else {
+                // 이 WAS에서 처리할 필요 없는 gubun (예: trx, code 등)
+                log.debug("[InternalManagementController] 처리 불필요 gubun: {}", gubun);
+                return ok("no-op");
+            }
+        } catch (Exception e) {
+            log.error("[InternalManagementController] reload 처리 중 오류: gubun={}, error={}", gubun, e.getMessage(), e);
+            return ResponseEntity.internalServerError()
+                    .body(Map.of("success", false, "message", e.getMessage()));
+        }
+    }
+
+    private ResponseEntity<Map<String, Object>> ok(String action) {
+        return ResponseEntity.ok(Map.of("success", true, "action", action));
+    }
+}

--- a/spider-link/src/main/java/com/example/spiderlink/infra/http/InternalManagementController.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/http/InternalManagementController.java
@@ -76,8 +76,9 @@ public class InternalManagementController {
             }
         } catch (Exception e) {
             log.error("[InternalManagementController] reload 처리 중 오류: gubun={}, error={}", gubun, e.getMessage(), e);
+            // e.getMessage()가 null일 수 있으므로(NPE 등) 고정 메시지 반환 — 상세는 서버 로그로만 확인
             return ResponseEntity.internalServerError()
-                    .body(Map.of("success", false, "message", e.getMessage()));
+                    .body(Map.of("success", false, "message", "Internal Server Error"));
         }
     }
 

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/handler/MetaDrivenCommandHandler.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/handler/MetaDrivenCommandHandler.java
@@ -69,6 +69,17 @@ public class MetaDrivenCommandHandler implements CommandHandler<JsonCommandReque
         log.info("[MetaDrivenCommandHandler] 등록된 커맨드 {}개 로드: {}", supportedCommands.size(), supportedCommands);
     }
 
+    /**
+     * 지원 커맨드 캐시를 DB에서 다시 로드한다.
+     *
+     * <p>Admin에서 FWK_LISTENER_TRX_MESSAGE 변경 후 재기동 없이 반영할 때
+     * {@code POST /api/management/reload} (gubun=request_app_mapping) 호출 시 실행된다.</p>
+     */
+    public void refreshCommands() {
+        supportedCommands = new HashSet<>(metaRoutingMapper.selectRegisteredCommands(GW_ID));
+        log.info("[MetaDrivenCommandHandler] 커맨드 캐시 갱신 완료: {}개 — {}", supportedCommands.size(), supportedCommands);
+    }
+
     @Override
     public boolean supports(String command) {
         return supportedCommands.contains(command);

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/handler/MetaDrivenCommandHandler.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/handler/MetaDrivenCommandHandler.java
@@ -60,8 +60,11 @@ public class MetaDrivenCommandHandler implements CommandHandler<JsonCommandReque
     /** Biz 타입 컴포넌트 리플렉션 호출 시 스프링 빈 조회용 */
     private final ApplicationContext applicationContext;
 
-    /** 시작 시 FWK_LISTENER_TRX_MESSAGE에서 등록된 커맨드 목록 캐싱 — DB 조회 최소화 */
-    private Set<String> supportedCommands = new HashSet<>();
+    /**
+     * 시작 시 FWK_LISTENER_TRX_MESSAGE에서 등록된 커맨드 목록 캐싱 — DB 조회 최소화.
+     * volatile: refreshCommands()가 TCP 워커 스레드와 다른 스레드에서 참조를 교체하므로 가시성 보장 필요
+     */
+    private volatile Set<String> supportedCommands = new HashSet<>();
 
     @PostConstruct
     void init() {


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #248

## ✨ 변경 사항 (Changes)
- **spider-link**: `InternalManagementController` 신규 추가 — `POST /api/management/reload`
  - `gubun=request_app_mapping` → `MetaDrivenCommandHandler.refreshCommands()` 호출 (커맨드 캐시 DB 재로드)
  - `gubun=message` → `MessageStructurePool.clear()` 호출 (전문 구조 캐시 초기화)
  - 그 외 gubun → no-op 성공 응답 (이 WAS에서 처리 불필요한 항목)
- **spider-link**: `MetaDrivenCommandHandler.refreshCommands()` 추가 — DB에서 커맨드 목록 재조회
- **spider-link**: `WebMvcConfig` — `/api/management/**` 경로를 `InternalApiInterceptor`(허용 IP) 보호 추가
- **biz-auth**: `spring-boot-starter-web` 의존성 추가, `web-application-type: none` 제거, HTTP 관리 포트 19180 활성화
- **biz-transfer**: 동일 변경, HTTP 관리 포트 19280 활성화
- **admin**: `ReloadType.MESSAGE` `visible=false` → `visible=true` 변경 (리로드 화면에 전문 정보 항목 노출)
- **admin SQL**: `04_alter_tables.sql` (#248) — `FWK_WAS_INSTANCE`, `FWK_PROPERTY` 등록 쿼리 추가

## 🛠 기술적 의사결정 (선택)

**biz-auth/biz-transfer에 Tomcat 내장 서버 추가**  
Admin의 `ReloadService`가 HTTP로 `POST /api/management/reload`를 호출하는 구조인데, 기존 biz-auth/biz-transfer는 `web-application-type: none`으로 TCP only였음. 별도 관리 포트(19180/19280)로 HTTP 서버를 활성화하여 TCP 서버 포트(19100/19200)와 분리 운영.

**InternalManagementController를 spider-link에 구현**  
컨트롤러를 각 biz-app에 두면 앱마다 중복 구현 필요. spider-link JAR에 포함시켜 `MetaDrivenCommandHandler` 빈이 있을 때(`@ConditionalOnBean`) 자동 등록되도록 설계. biz-app 코드 수정 없이 spider-link 업그레이드만으로 연동 가능.

## ⚠️ 고려 및 주의 사항 (선택)
- **DB 실행 필요**: `admin/docs/sql/oracle/04_alter_tables.sql` — `#248` 섹션 Step 1~4 순서대로 실행
  - `FWK_WAS_INSTANCE`: auth(biz-auth), trf(biz-transfer) 인스턴스 등록
  - `FWK_PROPERTY`: `was_config` 그룹에 관리 IP/포트 4건 등록
- biz-auth/biz-transfer **재기동 필요** (Tomcat 내장 서버 추가로 HTTP 포트 바인딩)