### PR TITLE
🐛 bug/#243-홍보배너-슬라이드편집-이미지선택·적용-버그수정

### DIFF
--- a/html-cms/src/components/edit/EditClient.tsx
+++ b/html-cms/src/components/edit/EditClient.tsx
@@ -339,6 +339,17 @@ export default function EditClient({
 
     // 슬라이드 편집 모달 (promo-banner / product-gallery)
     const [slideEditorBlock, setSlideEditorBlock] = useState<HTMLElement | null>(null);
+    // slideEditorBlock의 ref 버전 — message 핸들러(클로저) 내부에서 최신 상태를 동기적으로 읽기 위해 사용
+    const slideEditorBlockRef = useRef<HTMLElement | null>(null);
+    // slideEditorBlock 변경 시 ref를 최신 상태로 동기화.
+    // ASSET_SELECTED 핸들러에서 최신 slideEditorBlock을 동기적으로 읽기 위해 ref 사용.
+    useEffect(() => {
+        slideEditorBlockRef.current = slideEditorBlock;
+        // close 후 applyBehavior()를 즉시 호출하지 않는다.
+        // 즉시 호출 시 ContentBuilder가 row에 캐시된 스냅샷으로
+        // replaceWith(clone) 결과를 덮어쓴다.
+        // debouncedReinit이 ContentBuilder onChange 트리거에 의해 자연스럽게 실행된다.
+    }, [slideEditorBlock]);
 
     // 이미지 교체 picker 모달 — #fileEmbedImage 인터셉트 시 /cms/files를 iframe으로 띄움
     // 별도 브라우저 창(window.open) 대신 에디터 DOM 내부 모달로 표시해
@@ -378,6 +389,8 @@ export default function EditClient({
         const debouncedReinit = () => {
             if (reinitTimer) clearTimeout(reinitTimer);
             reinitTimer = setTimeout(async () => {
+                // DOM을 편집 중에 건드리지 않으므로 모달이 열려 있어도 reinit을 허용한다.
+
                 // reinitialize()가 비동기(플러그인 JS/CSS lazy-load)이므로 완료 후 applyBehavior() 호출
                 await runtimeRef.current?.reinitialize();
                 builderRef.current?.applyBehavior();
@@ -1971,6 +1984,13 @@ export default function EditClient({
 
             switch (event.data.type) {
                 case 'ASSET_SELECTED':
+                    // SlideEditorModal이 열려 있으면 openCmsFilesPicker 유틸이 자체 처리하므로 건너뜀.
+                    // DOM 제거 타이밍에 의존하는 getElementById 가드 대신 ref로 판단해 레이스를 제거한다.
+                    if (slideEditorBlockRef.current != null) {
+                        if (isOwnPicker) setImagePickerOpen(false);
+                        window.focus();
+                        break;
+                    }
                     builderRef.current?.selectAsset(event.data.url);
                     if (isOwnPicker) setImagePickerOpen(false);
                     window.focus();
@@ -1980,14 +2000,16 @@ export default function EditClient({
                     const replaceTarget = imageReplaceTargetRef.current;
 
                     if (replaceTarget && urls[0]) {
-                        // 이미지 교체 모드 — #fileEmbedImage 인터셉트로 연 EditClient 모달 경로
+                        // 이미지 교체 모드 — #fileEmbedImage 인터셉트로 연 EditClient 모달 경로.
+                        // SlideEditorModal 열림 여부와 무관하게 항상 처리한다.
                         replaceTarget.setAttribute('src', urls[0]);
                         imageReplaceTargetRef.current = null;
                         // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ContentBuilder 내부 onChange
                         const onChange = (builderRef.current as any)?.opts?.onChange;
                         if (typeof onChange === 'function') onChange();
-                    } else {
-                        // 일반 삽입 모드 — ContentBuilder 내장 filePicker/imageSelect 경유 또는 activeImg 부재 케이스
+                    } else if (slideEditorBlockRef.current == null) {
+                        // SlideEditorModal이 닫혀 있을 때만 ContentBuilder에 이미지를 삽입한다.
+                        // 열려 있으면 openCmsFilesPicker 유틸이 자체 처리하므로 건너뜀.
                         urls.forEach((url) => builderRef.current?.selectAsset(url));
                     }
                     if (isOwnPicker) setImagePickerOpen(false);

--- a/html-cms/src/components/edit/SlideEditorModal.tsx
+++ b/html-cms/src/components/edit/SlideEditorModal.tsx
@@ -23,6 +23,7 @@ interface PromoBannerSlide {
 }
 
 interface ProductGalleryCard {
+    itemId: string; // React key 및 DOM data-item-id — crypto.randomUUID()로 생성
     type: 'savings' | 'deposit' | 'loan';
     badge: string;
     productName: string;
@@ -78,6 +79,8 @@ function parseCard(inner: HTMLElement | null): ProductGalleryCard {
           })()
         : undefined;
     return {
+        // DOM에서 data-item-id를 읽거나 없으면 UUID 생성 (React key 안정성 보장)
+        itemId: inner?.getAttribute('data-item-id') ?? `pg-${crypto.randomUUID()}`,
         type: (inner?.getAttribute('data-type') ?? 'savings') as ProductGalleryCard['type'],
         badge: inner?.querySelector('[data-pg-field="badge"]')?.textContent ?? '',
         productName: inner?.querySelector('[data-pg-field="productName"]')?.textContent ?? '',
@@ -202,7 +205,7 @@ const DEFAULT_SLIDE: PromoBannerSlide = {
     ctaHref: '#',
 };
 
-const DEFAULT_CARD: ProductGalleryCard = {
+const DEFAULT_CARD: Omit<ProductGalleryCard, 'itemId'> = {
     type: 'savings',
     badge: '적금',
     productName: '새 상품명',
@@ -457,7 +460,7 @@ function PromoSlidesEditor({
     const update = (idx: number, patch: Partial<PromoBannerSlide>) =>
         onChange((prev) => prev.map((s, i) => (i === idx ? { ...s, ...patch } : s)));
 
-    const add = () => onChange((prev) => [...prev, { ...DEFAULT_SLIDE, itemId: `pb-${Date.now()}` }]);
+    const add = () => onChange((prev) => [...prev, { ...DEFAULT_SLIDE, itemId: `pb-${crypto.randomUUID()}` }]);
 
     const remove = (idx: number) => onChange((prev) => prev.filter((_, i) => i !== idx));
 
@@ -699,7 +702,7 @@ function ProductCardsEditor({
     const update = (idx: number, patch: Partial<ProductGalleryCard>) =>
         onChange((prev) => prev.map((c, i) => (i === idx ? { ...c, ...patch } : c)));
 
-    const add = () => onChange((prev) => [...prev, { ...DEFAULT_CARD }]);
+    const add = () => onChange((prev) => [...prev, { ...DEFAULT_CARD, itemId: `pg-${crypto.randomUUID()}` }]);
 
     const remove = (idx: number) => onChange((prev) => prev.filter((_, i) => i !== idx));
 
@@ -707,7 +710,7 @@ function ProductCardsEditor({
         <>
             {cards.map((card, idx) => (
                 <div
-                    key={idx}
+                    key={card.itemId}
                     style={{
                         border: '1px solid #e5e7eb',
                         borderRadius: '8px',

--- a/html-cms/src/components/edit/SlideEditorModal.tsx
+++ b/html-cms/src/components/edit/SlideEditorModal.tsx
@@ -39,15 +39,20 @@ interface ProductGalleryCard {
 function parsePromoBannerSlides(root: HTMLElement): PromoBannerSlide[] {
     return Array.from(root.querySelectorAll('[data-pb-slide]')).map((wrapper, i) => {
         const inner = wrapper.querySelector<HTMLElement>('.pb-slide');
+        // 실제 저장된 HTML은 배경색/배경이미지를 .pb-slide-bg 자식 요소에 둠.
+        // .pb-slide-bg가 없는 구버전 HTML은 .pb-slide로 폴백한다.
+        const bgEl = inner?.querySelector<HTMLElement>('.pb-slide-bg') ?? inner;
         const ctaEl = inner?.querySelector('.pb-slide-cta') as HTMLAnchorElement | null;
-        const bgImageMatch = (inner?.style.backgroundImage ?? '').match(/url\(['"]?([^'"]+)['"]?\)/);
+        const bgImageMatch = (bgEl?.style.backgroundImage ?? '').match(/url\(['"]?([^'"]+)['"]?\)/);
         const rawBgImage = bgImageMatch?.[1];
         const bgImage = rawBgImage ? rawBgImage.replace(/\\/g, '/').replace(/^(?!\/)/, '/') : undefined;
+        // backgroundColor가 있으면 hex로 변환, 없으면 background shorthand에서 url() 제거 후 사용
+        const rawBgColor = bgEl?.style.backgroundColor
+            ? rgbToHex(bgEl.style.backgroundColor)
+            : (bgEl?.style.background ?? '').replace(/url\(.*?\)\s*/g, '').trim();
         return {
             itemId: inner?.getAttribute('data-item-id') ?? `pb-${i + 1}`,
-            bgColor: inner?.style.backgroundColor
-                ? rgbToHex(inner.style.backgroundColor)
-                : (inner?.style.background ?? '').replace(/url\(.*?\)\s*/g, '').trim(),
+            bgColor: rawBgColor || '#0046A4', // 파싱 실패 시 기본값
             bgImage,
             badge: inner?.querySelector('.pb-badge')?.textContent ?? '',
             title: inner?.querySelector('.pb-slide-title')?.textContent ?? '',
@@ -100,11 +105,15 @@ function parseProductGalleryCards(root: HTMLElement, componentId: string): Produ
 // ── HTML 재생성 ───────────────────────────────────────────────────────────
 
 function buildSlideHtml(slide: PromoBannerSlide): string {
-    const bgImageStyle = slide.bgImage
-        ? `background-image:url("${slide.bgImage}");background-size:cover;background-position:center;`
-        : '';
+    // 배경색/배경이미지는 .pb-slide-bg에 분리하여 overflow:hidden 클리핑이 올바르게 동작하도록 함
+    const bgStyle =
+        `position:absolute;top:0;right:0;bottom:0;left:0;background:${slide.bgColor};` +
+        (slide.bgImage
+            ? `background-image:url("${slide.bgImage}");background-size:cover;background-position:center;`
+            : '');
     return (
-        `<div class="pb-slide" data-item-id="${slide.itemId}" style="position:relative;height:200px;border-radius:16px;background:${slide.bgColor};${bgImageStyle}">` +
+        `<div class="pb-slide" data-item-id="${slide.itemId}" style="position:relative;height:200px;overflow:hidden;border-radius:16px;">` +
+        `<div class="pb-slide-bg" style="${bgStyle}"></div>` +
         `<div class="pb-slide-content" style="position:relative;z-index:1;padding:24px 20px;display:flex;flex-direction:column;gap:6px;height:100%;box-sizing:border-box;justify-content:center;">` +
         `<span class="pb-badge" style="display:inline-block;background:rgba(255,255,255,0.25);color:#fff;font-size:11px;font-weight:700;padding:3px 10px;border-radius:20px;letter-spacing:0.5px;width:fit-content;border:1px solid rgba(255,255,255,0.4);">${slide.badge}</span>` +
         `<h3 class="pb-slide-title" style="font-size:22px;font-weight:800;color:#fff;margin:0;line-height:1.2;letter-spacing:-0.5px;">${slide.title}</h3>` +
@@ -245,12 +254,7 @@ export default function SlideEditorModal({ blockEl, onClose }: Props) {
     const componentId = blockEl.getAttribute('data-component-id') ?? '';
     const isPromoBanner = componentId.startsWith('promo-banner-');
 
-    // 모달 열릴 때 DOM 스냅샷 저장 (취소 시 복원용)
-    const snapshot = useRef('');
-    const [promoSlides, setPromoSlides] = useState<PromoBannerSlide[]>(() => {
-        snapshot.current = blockEl.innerHTML;
-        return parsePromoBannerSlides(blockEl);
-    });
+    const [promoSlides, setPromoSlides] = useState<PromoBannerSlide[]>(() => parsePromoBannerSlides(blockEl));
     const [productCards, setProductCards] = useState<ProductGalleryCard[]>(() =>
         parseProductGalleryCards(blockEl, componentId),
     );
@@ -299,23 +303,23 @@ export default function SlideEditorModal({ blockEl, onClose }: Props) {
         };
     }, []);
 
-    // 상태 변경 시 DOM 즉시 반영 (실시간 미리보기)
-    useEffect(() => {
-        if (isPromoBanner) applyPromoBannerSlides(blockEl, promoSlides);
-    }, [blockEl, isPromoBanner, promoSlides]);
-
-    useEffect(() => {
-        if (!isPromoBanner) applyProductGalleryCards(blockEl, productCards, componentId);
-    }, [blockEl, componentId, isPromoBanner, productCards]);
-
-    // 확인: DOM이 이미 반영된 상태이므로 그냥 닫기
+    // 확인: blockEl을 클론하여 변경 사항을 적용한 뒤 replaceWith로 교체.
+    // ContentBuilder는 DOM 노드 레퍼런스로 HTML 스냅샷을 캐싱하므로,
+    // 기존 노드에 innerHTML을 직접 수정하면 applyBehavior() 호출 시 캐시된 구버전으로 덮어쓰인다.
+    // replaceWith로 새 노드를 삽입하면 ContentBuilder가 새 노드를 기준으로 재스냅샷하므로 변경이 유지된다.
     function handleConfirm() {
+        const clone = blockEl.cloneNode(true) as HTMLElement;
+        if (isPromoBanner) {
+            applyPromoBannerSlides(clone, promoSlides);
+        } else {
+            applyProductGalleryCards(clone, productCards, componentId);
+        }
+        blockEl.replaceWith(clone);
         onClose();
     }
 
-    // 취소: 스냅샷으로 DOM 복원 후 닫기
+    // 취소: 편집 중 DOM을 건드리지 않으므로 그냥 닫기 (복원 불필요)
     function handleCancel() {
-        blockEl.innerHTML = snapshot.current;
         onClose();
     }
 
@@ -446,14 +450,16 @@ function PromoSlidesEditor({
     onChange,
 }: {
     slides: PromoBannerSlide[];
-    onChange: (v: PromoBannerSlide[]) => void;
+    onChange: React.Dispatch<React.SetStateAction<PromoBannerSlide[]>>;
 }) {
+    // functional update 패턴으로 작성해 openCmsFilesPicker 콜백이
+    // 캡처 시점의 stale slides를 참조하는 문제를 방지한다.
     const update = (idx: number, patch: Partial<PromoBannerSlide>) =>
-        onChange(slides.map((s, i) => (i === idx ? { ...s, ...patch } : s)));
+        onChange((prev) => prev.map((s, i) => (i === idx ? { ...s, ...patch } : s)));
 
-    const add = () => onChange([...slides, { ...DEFAULT_SLIDE, itemId: `pb-${Date.now()}` }]);
+    const add = () => onChange((prev) => [...prev, { ...DEFAULT_SLIDE, itemId: `pb-${Date.now()}` }]);
 
-    const remove = (idx: number) => onChange(slides.filter((_, i) => i !== idx));
+    const remove = (idx: number) => onChange((prev) => prev.filter((_, i) => i !== idx));
 
     return (
         <>
@@ -636,7 +642,7 @@ function PromoSlidesEditor({
                                         }
                                     }}
                                 >
-                                    + cms/files에서 이미지 선택
+                                    + 이미지 선택
                                 </button>
                             )}
                         </div>
@@ -686,14 +692,16 @@ function ProductCardsEditor({
     onChange,
 }: {
     cards: ProductGalleryCard[];
-    onChange: (v: ProductGalleryCard[]) => void;
+    onChange: React.Dispatch<React.SetStateAction<ProductGalleryCard[]>>;
 }) {
+    // functional update 패턴으로 작성해 openCmsFilesPicker 콜백이
+    // 캡처 시점의 stale cards를 참조하는 문제를 방지한다.
     const update = (idx: number, patch: Partial<ProductGalleryCard>) =>
-        onChange(cards.map((c, i) => (i === idx ? { ...c, ...patch } : c)));
+        onChange((prev) => prev.map((c, i) => (i === idx ? { ...c, ...patch } : c)));
 
-    const add = () => onChange([...cards, { ...DEFAULT_CARD }]);
+    const add = () => onChange((prev) => [...prev, { ...DEFAULT_CARD }]);
 
-    const remove = (idx: number) => onChange(cards.filter((_, i) => i !== idx));
+    const remove = (idx: number) => onChange((prev) => prev.filter((_, i) => i !== idx));
 
     return (
         <>
@@ -919,7 +927,7 @@ function ProductCardsEditor({
                                         }
                                     }}
                                 >
-                                    + cms/files에서 이미지 선택
+                                    + 이미지 선택
                                 </button>
                             )}
                         </div>


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
- #243

## ✨ 변경 사항 (Changes)

### 1. `SlideEditorModal.tsx` — 확인 시 `replaceWith` 패턴으로 DOM 교체

- **실시간 DOM 업데이트 제거**: 편집 중 `useEffect`로 DOM을 즉시 반영하던 방식 제거
- **확인 시 cloneNode → replaceWith**: `handleConfirm`에서 `blockEl.cloneNode(true)` 후 변경 사항을 클론에 적용하고 `blockEl.replaceWith(clone)`으로 교체
  - ContentBuilder는 DOM 노드 레퍼런스로 HTML 스냅샷을 캐싱하므로, 기존 노드에 직접 수정하면 `applyBehavior()` 호출 시 캐시된 구버전으로 덮어쓰임
  - 새 노드로 교체하면 ContentBuilder가 새 노드를 기준으로 재스냅샷하여 변경이 유지됨
- **취소 시 DOM 복원 불필요**: 편집 중 DOM을 건드리지 않으므로 snapshot 복원 로직 제거
- **`parsePromoBannerSlides` 수정**: 실제 저장 HTML 구조(`pb-slide-bg` 자식 요소)에서 배경색/이미지 파싱하도록 수정 (구버전 `.pb-slide` 폴백 포함)
- **`buildSlideHtml` 수정**: `.pb-slide-bg` 분리 구조로 생성 (`overflow:hidden` 클리핑 정상 동작)
- **functional update 패턴 적용**: `openCmsFilesPicker` 콜백의 stale closure 문제 방지
- **배경 이미지 버튼 레이블**: `+ cms/files에서 이미지 선택` → `+ 이미지 선택`

### 2. `EditClient.tsx` — ASSET_SELECTED 충돌 가드 및 debouncedReinit 정리

- **`ASSET_SELECTED` 가드**: SlideEditorModal 열려 있을 때 EditClient 전역 핸들러가 `selectAsset` 호출하지 않도록 `slideEditorBlockRef` 기반 가드 추가
- **`ASSETS_SELECTED` 가드**: SlideEditorModal 열려 있을 때 일반 삽입 모드 건너뜀
- **`slideEditorBlockRef`**: 클로저 내에서 최신 상태를 동기적으로 읽기 위한 ref 추가
- **`debouncedReinit` 가드 제거**: 편집 중 DOM을 건드리지 않으므로 모달 열림 중 reinit 차단 불필요
- **close 후 즉시 `applyBehavior()` 제거**: EventBannerEditor 패턴 일치 — 즉시 호출 시 ContentBuilder가 row 캐시로 DOM을 덮어쓰는 문제 방지

## ⚠️ 고려 및 주의 사항 (선택)

- `replaceWith(clone)` 후 ContentBuilder 편집 핸들러는 `debouncedReinit`이 자연 트리거될 때 재연결됨 (모달 닫은 직후 짧은 시간 동안 row 툴바가 비활성일 수 있음)
- 로컬 환경에서 서버 업로드 이미지 URL 접근 불가 시 배경 이미지가 렌더링되지 않는 것은 네트워크 문제이며 코드 버그 아님 — DOM 검사로 `background-image` CSS 적용 여부 확인 필요

## 💬 리뷰 포인트 (선택)

- `handleConfirm`의 `blockEl.replaceWith(clone)` 패턴이 `EventBannerEditor.applyToBlock`의 `blockEl.replaceWith(newEl)` 패턴과 동일하게 동작하는지 확인
- `slideEditorBlockRef` 가드가 `ASSET_SELECTED` / `ASSETS_SELECTED` 두 케이스 모두 올바르게 처리하는지 확인