### PR TITLE
✨ feat/#249-Admin AP 서버 소켓 풀 현황 조회

### DIFF
--- a/admin/docs/sql/oracle/04_alter_tables.sql
+++ b/admin/docs/sql/oracle/04_alter_tables.sql
@@ -735,3 +735,21 @@ WHEN NOT MATCHED THEN
     VALUES ('was_config', 'BT02.MANAGEMENT_SERVER_PORT', 'biz-transfer 관리 포트', 'Admin pool/reload API 대상 포트', 'N', '19280', 'system');
 
 COMMIT;
+
+-- =============================================================
+-- feat/#249: BT03 인스턴스 관리 포트 수정 (2026-04-28)
+-- BT03.MANAGEMENT_SERVER_PORT 가 19200(biz-transfer TCP 포트)으로 잘못 설정되어
+-- Admin → biz-transfer pool-status API 호출 실패하는 문제 수정
+-- 올바른 값: 19280 (biz-transfer HTTP 서버 포트)
+-- ※ 아래 쿼리는 개발자가 DB에서 직접 실행해야 합니다.
+-- =============================================================
+MERGE INTO FWK_PROPERTY dst
+USING (SELECT 'was_config' GRP, 'BT03.MANAGEMENT_SERVER_PORT' PID FROM DUAL) src
+ON (dst.PROPERTY_GROUP_ID = src.GRP AND dst.PROPERTY_ID = src.PID)
+WHEN MATCHED THEN
+    UPDATE SET DEFAULT_VALUE = '19280', LAST_UPDATE_USER_ID = 'system'
+WHEN NOT MATCHED THEN
+    INSERT (PROPERTY_GROUP_ID, PROPERTY_ID, PROPERTY_NAME, PROPERTY_DESC, DATA_TYPE, DEFAULT_VALUE, LAST_UPDATE_USER_ID)
+    VALUES ('was_config', 'BT03.MANAGEMENT_SERVER_PORT', 'biz-transfer 관리 포트', 'Admin pool/reload API 대상 포트', 'N', '19280', 'system');
+
+COMMIT;

--- a/admin/docs/sql/oracle/04_alter_tables.sql
+++ b/admin/docs/sql/oracle/04_alter_tables.sql
@@ -717,3 +717,21 @@ INSERT INTO FWK_PROPERTY (PROPERTY_GROUP_ID, PROPERTY_ID, PROPERTY_NAME, PROPERT
 VALUES ('was_config', 'trf.MANAGEMENT_SERVER_PORT', 'biz-transfer 관리 서버 포트', 'Admin reload API 대상 포트', 'N', '19280', 'system');
 
 COMMIT;
+
+-- =============================================================
+-- feat/#249: BT02 인스턴스 관리 포트 수정 (2026-04-28)
+-- BT02.MANAGEMENT_SERVER_PORT 가 19100(biz-auth TCP 포트)으로 잘못 설정되어
+-- Admin → biz-transfer pool-status API 호출 실패하는 문제 수정
+-- 올바른 값: 19280 (biz-transfer HTTP 서버 포트)
+-- ※ 아래 쿼리는 개발자가 DB에서 직접 실행해야 합니다.
+-- =============================================================
+MERGE INTO FWK_PROPERTY dst
+USING (SELECT 'was_config' GRP, 'BT02.MANAGEMENT_SERVER_PORT' PID FROM DUAL) src
+ON (dst.PROPERTY_GROUP_ID = src.GRP AND dst.PROPERTY_ID = src.PID)
+WHEN MATCHED THEN
+    UPDATE SET DEFAULT_VALUE = '19280', LAST_UPDATE_USER_ID = 'system'
+WHEN NOT MATCHED THEN
+    INSERT (PROPERTY_GROUP_ID, PROPERTY_ID, PROPERTY_NAME, PROPERTY_DESC, DATA_TYPE, DEFAULT_VALUE, LAST_UPDATE_USER_ID)
+    VALUES ('was_config', 'BT02.MANAGEMENT_SERVER_PORT', 'biz-transfer 관리 포트', 'Admin pool/reload API 대상 포트', 'N', '19280', 'system');
+
+COMMIT;

--- a/admin/src/main/java/com/example/admin_demo/domain/wasinstance/controller/WasInstanceController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/wasinstance/controller/WasInstanceController.java
@@ -1,5 +1,6 @@
 package com.example.admin_demo.domain.wasinstance.controller;
 
+import com.example.admin_demo.domain.wasinstance.dto.PoolStatusResponse;
 import com.example.admin_demo.domain.wasinstance.dto.WasInstanceBatchSaveRequest;
 import com.example.admin_demo.domain.wasinstance.dto.WasInstanceRequest;
 import com.example.admin_demo.domain.wasinstance.dto.WasInstanceResponse;
@@ -86,6 +87,12 @@ public class WasInstanceController {
             @Valid @RequestBody List<WasInstanceBatchSaveRequest> requests) {
         int processedCount = wasInstanceService.batchSave(requests);
         return ResponseEntity.ok(ApiResponse.success(processedCount + "개의 인스턴스가 처리되었습니다", processedCount));
+    }
+
+    @GetMapping("/{instanceId}/pool-status")
+    public ResponseEntity<ApiResponse<PoolStatusResponse>> getPoolStatus(@PathVariable String instanceId) {
+        PoolStatusResponse status = wasInstanceService.getPoolStatus(instanceId);
+        return ResponseEntity.ok(ApiResponse.success(status));
     }
 
     @GetMapping("/export")

--- a/admin/src/main/java/com/example/admin_demo/domain/wasinstance/dto/PoolStatusResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/wasinstance/dto/PoolStatusResponse.java
@@ -1,0 +1,40 @@
+package com.example.admin_demo.domain.wasinstance.dto;
+
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * AP 서버 소켓 풀 현황 응답 DTO.
+ *
+ * <p>spider-link {@code GET /api/internal/pool/status} 응답을 래핑한다.</p>
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PoolStatusResponse {
+
+    private String instanceId;
+    private String instanceName;
+    private boolean success;
+    private String errorMessage;
+    /** key: "host:port", value: 소켓 풀 통계 */
+    private Map<String, PoolInfo> pools;
+
+    /** 단일 소켓 풀 통계 */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PoolInfo {
+        private String host;
+        private int port;
+        private int active;
+        private int idle;
+        private int total;
+        private int maxActive;
+    }
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/wasinstance/service/WasInstanceService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/wasinstance/service/WasInstanceService.java
@@ -1,6 +1,9 @@
 package com.example.admin_demo.domain.wasinstance.service;
 
 import com.example.admin_demo.domain.batch.mapper.WasExecBatchMapper;
+import com.example.admin_demo.domain.property.dto.PropertyResponse;
+import com.example.admin_demo.domain.property.mapper.PropertyMapper;
+import com.example.admin_demo.domain.wasinstance.dto.PoolStatusResponse;
 import com.example.admin_demo.domain.wasinstance.dto.WasInstanceBatchSaveRequest;
 import com.example.admin_demo.domain.wasinstance.dto.WasInstanceRequest;
 import com.example.admin_demo.domain.wasinstance.dto.WasInstanceResponse;
@@ -16,13 +19,20 @@ import com.example.admin_demo.global.util.ExcelColumnDefinition;
 import com.example.admin_demo.global.util.ExcelExportUtil;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
 
 @Slf4j
 @Service
@@ -33,6 +43,17 @@ public class WasInstanceService {
     private final WasInstanceMapper wasInstanceMapper;
     private final WasPropertyService wasPropertyService;
     private final WasExecBatchMapper wasExecBatchMapper;
+    private final RestTemplate restTemplate;
+    private final PropertyMapper propertyMapper;
+
+    @Value("${reload.management.default-port:50005}")
+    private int defaultManagementPort;
+
+    @Value("${reload.management.default-ip:localhost}")
+    private String defaultManagementIp;
+
+    @Value("${reload.management.property-group:was_config}")
+    private String propertyGroup;
 
     public List<WasInstanceResponse> getAllInstances() {
         log.info("Fetching all WAS instances");
@@ -205,5 +226,108 @@ public class WasInstanceService {
         } catch (IOException e) {
             throw new InternalException("엑셀 파일 생성 중 오류가 발생했습니다", e);
         }
+    }
+
+    /**
+     * AP 서버 소켓 풀 현황 조회.
+     * spider-link {@code GET /api/internal/pool/status}를 호출하여 반환한다.
+     */
+    public PoolStatusResponse getPoolStatus(String instanceId) {
+        WasInstanceResponse instance = wasInstanceMapper.selectResponseById(instanceId);
+        if (instance == null) {
+            throw new NotFoundException("instanceId: " + instanceId);
+        }
+
+        String managementIp = resolveManagementProperty(instanceId, "MANAGEMENT_SERVER_IP", defaultManagementIp);
+        int managementPort = resolveManagementPort(instanceId);
+        String url = String.format("http://%s:%d/api/internal/pool/status", managementIp, managementPort);
+
+        log.info("풀 현황 조회: instanceId={}, url={}", instanceId, url);
+
+        try {
+            ResponseEntity<Map<String, Object>> response =
+                    restTemplate.exchange(url, HttpMethod.GET, null, new ParameterizedTypeReference<>() {});
+
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                Map<String, Object> body = response.getBody();
+                return PoolStatusResponse.builder()
+                        .instanceId(instanceId)
+                        .instanceName(instance.getInstanceName())
+                        .success(true)
+                        .pools(parsePools(body.get("pools")))
+                        .build();
+            }
+
+            return PoolStatusResponse.builder()
+                    .instanceId(instanceId)
+                    .instanceName(instance.getInstanceName())
+                    .success(false)
+                    .errorMessage("응답 상태: " + response.getStatusCode())
+                    .build();
+
+        } catch (RestClientException e) {
+            String errorMsg = String.format(
+                    "%s 서버에 연결 중 오류가 발생하였습니다.[host=%s,port=%d]", instanceId, managementIp, managementPort);
+            log.error("풀 현황 조회 통신 오류: {}", errorMsg, e);
+            return PoolStatusResponse.builder()
+                    .instanceId(instanceId)
+                    .instanceName(instance.getInstanceName())
+                    .success(false)
+                    .errorMessage(errorMsg)
+                    .build();
+        }
+    }
+
+    private Map<String, PoolStatusResponse.PoolInfo> parsePools(Object poolsObj) {
+        if (!(poolsObj instanceof Map<?, ?> rawPools)) {
+            return Collections.emptyMap();
+        }
+        Map<String, PoolStatusResponse.PoolInfo> result = new LinkedHashMap<>();
+        rawPools.forEach((key, value) -> {
+            if (!(value instanceof Map<?, ?> poolMap)) return;
+            result.put(
+                    String.valueOf(key),
+                    PoolStatusResponse.PoolInfo.builder()
+                            .host(poolMap.get("host") != null ? String.valueOf(poolMap.get("host")) : "")
+                            .port(toPoolInt(poolMap.get("port")))
+                            .active(toPoolInt(poolMap.get("active")))
+                            .idle(toPoolInt(poolMap.get("idle")))
+                            .total(toPoolInt(poolMap.get("total")))
+                            .maxActive(toPoolInt(poolMap.get("maxActive")))
+                            .build());
+        });
+        return result;
+    }
+
+    private int toPoolInt(Object obj) {
+        if (obj instanceof Number n) return n.intValue();
+        return 0;
+    }
+
+    private int resolveManagementPort(String instanceId) {
+        String value = resolveManagementProperty(instanceId, "MANAGEMENT_SERVER_PORT", null);
+        if (value != null) {
+            try {
+                return Integer.parseInt(value);
+            } catch (NumberFormatException e) {
+                log.debug("Management port 파싱 실패, 기본값 사용: instanceId={}", instanceId, e);
+            }
+        }
+        return defaultManagementPort;
+    }
+
+    private String resolveManagementProperty(String instanceId, String suffix, String defaultValue) {
+        try {
+            String propertyId = instanceId + "." + suffix;
+            PropertyResponse property = propertyMapper.selectResponseById(propertyGroup, propertyId);
+            if (property != null
+                    && property.getDefaultValue() != null
+                    && !property.getDefaultValue().isBlank()) {
+                return property.getDefaultValue();
+            }
+        } catch (Exception e) {
+            log.warn("Management property 조회 실패, 기본값 사용: instanceId={}, suffix={}", instanceId, suffix, e);
+        }
+        return defaultValue;
     }
 }

--- a/admin/src/main/resources/templates/pages/was-instance/was-instance.html
+++ b/admin/src/main/resources/templates/pages/was-instance/was-instance.html
@@ -47,6 +47,7 @@
                 <col class="col-w-100">
                 <col class="col-w-120">
                 <col class="col-w-120">
+                <col class="col-w-100">
             </colgroup>
             <thead class="table-light">
             <tr>
@@ -60,11 +61,12 @@
                 <th class="sortable" data-sort="instanceType">유형</th>
                 <th class="sortable" data-sort="operModeType">운영모드</th>
                 <th>프로퍼티</th>
+                <th>풀 현황</th>
             </tr>
             </thead>
             <tbody id="wasInstanceTableBody">
             <tr>
-                <td colspan="10" class="text-center py-4 text-body-secondary">
+                <td colspan="11" class="text-center py-4 text-body-secondary">
                     데이터를 불러오는 중...
                 </td>
             </tr>
@@ -234,6 +236,25 @@
         </div>
     </div>
 
+    <!-- Pool Status Modal -->
+    <div class="modal fade" id="poolStatusModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-lg modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title"><i class="bi bi-bar-chart-fill"></i> AP 서버 소켓 풀 현황</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body" id="poolStatusModalBody"></div>
+                <div class="modal-footer">
+                    <button class="btn btn-outline-primary btn-sm" onclick="refreshPoolStatus()">
+                        <i class="bi bi-arrow-repeat"></i> 새로고침
+                    </button>
+                    <button class="btn btn-outline-secondary btn-sm" data-bs-dismiss="modal">닫기</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- JavaScript -->
     <script>
         // WAS Instance Table Script
@@ -369,7 +390,7 @@
                         tbody.empty();
                         tbody.append(`
                             <tr>
-                                <td colspan="10" class="text-center py-4 text-danger">
+                                <td colspan="11" class="text-center py-4 text-danger">
                                     데이터를 불러오는데 실패했습니다.
                                 </td>
                             </tr>
@@ -480,7 +501,7 @@
                 if (!instances || instances.length === 0) {
                     tbody.append(`
                         <tr>
-                            <td colspan="10" class="text-center py-4 text-body-secondary">
+                            <td colspan="11" class="text-center py-4 text-body-secondary">
                                 조회된 데이터가 없습니다.
                             </td>
                         </tr>
@@ -593,7 +614,21 @@
                         propertyTd.append(propertyBtn);
                     }
                     row.append(propertyTd);
-                    
+
+                    // 풀 현황 버튼 (AP 인스턴스만)
+                    const poolTd = $('<td class="text-center"></td>');
+                    if (!isNew && normalizeInstanceType(instance.instanceType) === '2') {
+                        const poolBtn = $('<button class="btn-property">풀 현황</button>');
+                        poolBtn.click(function(e) {
+                            e.stopPropagation();
+                            showPoolStatus(instance.instanceId);
+                        });
+                        poolTd.append(poolBtn);
+                    } else {
+                        poolTd.text('-');
+                    }
+                    row.append(poolTd);
+
                     tbody.append(row);
                 });
             }
@@ -1828,6 +1863,84 @@
             }
 
             // Expose functions to window
+            // Pool Status
+            let currentPoolInstanceId = null;
+
+            function showPoolStatus(instanceId) {
+                currentPoolInstanceId = instanceId;
+                const modal = new bootstrap.Modal(document.getElementById('poolStatusModal'));
+                modal.show();
+                loadPoolStatus(instanceId);
+            }
+
+            function refreshPoolStatus() {
+                if (currentPoolInstanceId) loadPoolStatus(currentPoolInstanceId);
+            }
+
+            function loadPoolStatus(instanceId) {
+                const body = $('#poolStatusModalBody');
+                body.html('<div class="text-center py-3"><i class="bi bi-arrow-repeat sp-spin"></i> 조회 중...</div>');
+                $.ajax({
+                    url: `/api/was/instance/${instanceId}/pool-status`,
+                    method: 'GET',
+                    success: function(response) { renderPoolStatus(response.data); },
+                    error: function(xhr) {
+                        body.html(`<div class="alert alert-danger"><i class="bi bi-exclamation-triangle-fill"></i> ${xhr.responseJSON?.message || '풀 현황 조회에 실패했습니다.'}</div>`);
+                    }
+                });
+            }
+
+            function renderPoolStatus(data) {
+                const body = $('#poolStatusModalBody');
+                if (!data || !data.success) {
+                    body.html(`<div class="alert alert-warning"><i class="bi bi-exclamation-triangle-fill"></i> ${data?.errorMessage || '풀 현황 조회 실패'}</div>`);
+                    return;
+                }
+                const pools = data.pools || {};
+                const entries = Object.entries(pools);
+                if (entries.length === 0) {
+                    body.html('<div class="text-muted text-center py-3"><i class="bi bi-info-circle"></i> 등록된 소켓 풀이 없습니다.</div>');
+                    return;
+                }
+                let rows = '';
+                entries.forEach(([key, pool]) => {
+                    const usageRate = pool.maxActive > 0 ? Math.round((pool.active / pool.maxActive) * 100) : 0;
+                    const barClass = usageRate >= 80 ? 'bg-danger' : usageRate >= 50 ? 'bg-warning' : 'bg-success';
+                    rows += `<tr>
+                        <td>${key}</td>
+                        <td class="text-center ${pool.active > 0 ? 'fw-bold text-primary' : ''}">${pool.active}</td>
+                        <td class="text-center">${pool.idle}</td>
+                        <td class="text-center">${pool.total}</td>
+                        <td class="text-center">${pool.maxActive}</td>
+                        <td><div class="d-flex align-items-center gap-1">
+                            <div class="progress flex-grow-1" style="height:12px;"><div class="progress-bar ${barClass}" style="width:${usageRate}%"></div></div>
+                            <small>${usageRate}%</small>
+                        </div></td>
+                    </tr>`;
+                });
+                body.html(`
+                    <p class="mb-2 text-body-secondary small">인스턴스: <strong>${data.instanceId}</strong> (${data.instanceName || '-'})</p>
+                    <div class="table-responsive">
+                        <table class="table table-sm table-bordered">
+                            <thead class="table-light">
+                                <tr>
+                                    <th>대상 (host:port)</th>
+                                    <th class="text-center">Active</th>
+                                    <th class="text-center">Idle</th>
+                                    <th class="text-center">Total</th>
+                                    <th class="text-center">Max</th>
+                                    <th>사용률</th>
+                                </tr>
+                            </thead>
+                            <tbody>${rows}</tbody>
+                        </table>
+                    </div>
+                `);
+            }
+
+            window.showPoolStatus = showPoolStatus;
+            window.refreshPoolStatus = refreshPoolStatus;
+
             window.showPropertySection = showPropertySection;
             window.closePropertySection = closePropertySection;
             window.addPropertyRow = addPropertyRow;

--- a/spider-link/src/main/java/com/example/spiderlink/infra/http/SocketPoolStatusController.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/http/SocketPoolStatusController.java
@@ -1,0 +1,55 @@
+package com.example.spiderlink.infra.http;
+
+import com.example.spiderlink.infra.tcp.client.pool.SocketPoolManager;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * SocketPool 상태 조회 내부 API.
+ *
+ * <p>Admin에서 AP 서버 접속 현황을 실시간으로 조회할 때 사용한다.
+ * {@code GET /api/internal/pool/status} 를 호출하면 이 WAS에 등록된
+ * 모든 (host:port) 풀의 active / idle / total 수를 반환한다.</p>
+ *
+ * <pre>{@code
+ * GET /api/internal/pool/status
+ * →
+ * {
+ *   "success": true,
+ *   "pools": {
+ *     "localhost:19300": { "host": "localhost", "port": 19300, "active": 1, "idle": 2, "total": 3, "maxActive": 5 }
+ *   }
+ * }
+ * }</pre>
+ *
+ * <p>보안: {@link com.example.spiderlink.config.WebMvcConfig}의 인터셉터가
+ * {@code /api/internal/**} 경로를 허용 IP(기본: localhost)로만 제한한다.</p>
+ *
+ * <p>주의: {@code @ConditionalOnBean}을 사용하지 않는다.
+ * 해당 애노테이션은 컴포넌트 스캔 중 평가되어 auto-configuration에서 등록되는
+ * {@link SocketPoolManager} 빈을 아직 인식하지 못하는 타이밍 문제가 있다.
+ * spider-link를 사용하는 모든 앱에서 {@code SpiderLinkAutoConfiguration}이
+ * {@link SocketPoolManager}를 항상 등록하므로 조건이 불필요하다.</p>
+ */
+@RestController
+@RequestMapping("/api/internal/pool")
+@RequiredArgsConstructor
+public class SocketPoolStatusController {
+
+    private final SocketPoolManager socketPoolManager;
+
+    /**
+     * 전체 소켓 풀 상태 조회.
+     *
+     * @return 엔드포인트별 active / idle / total / maxActive 수
+     */
+    @GetMapping("/status")
+    public ResponseEntity<Map<String, Object>> getPoolStatus() {
+        Map<String, Map<String, Object>> pools = socketPoolManager.getAllPoolInfo();
+        return ResponseEntity.ok(Map.of("success", true, "pools", pools));
+    }
+}

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/client/pool/SocketPool.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/client/pool/SocketPool.java
@@ -166,6 +166,22 @@ public class SocketPool {
         }
     }
 
+    /** Admin 모니터링용 상태 맵 — REST API 응답에 사용 */
+    public java.util.Map<String, Object> getInfoMap() {
+        synchronized (lock) {
+            int idleCount = idle.size();
+            int activeCount = totalCount - idleCount;
+            java.util.Map<String, Object> map = new java.util.LinkedHashMap<>();
+            map.put("host", host);
+            map.put("port", port);
+            map.put("active", activeCount);
+            map.put("idle", idleCount);
+            map.put("total", totalCount);
+            map.put("maxActive", MAX_ACTIVE);
+            return map;
+        }
+    }
+
     public String getHost() { return host; }
     public int getPort() { return port; }
 }

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/client/pool/SocketPoolManager.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/client/pool/SocketPoolManager.java
@@ -87,6 +87,19 @@ public class SocketPoolManager implements SmartLifecycle {
         return pool != null ? pool.getInfo() : key + " — 풀 없음";
     }
 
+    /**
+     * Admin 모니터링용 — 등록된 모든 풀의 상태를 구조화된 맵으로 반환한다.
+     *
+     * <p>키: "host:port", 값: active / idle / total / maxActive 필드를 담은 맵.</p>
+     *
+     * @return 엔드포인트별 풀 상태 맵 (등록된 풀이 없으면 빈 맵)
+     */
+    public java.util.Map<String, java.util.Map<String, Object>> getAllPoolInfo() {
+        java.util.Map<String, java.util.Map<String, Object>> result = new java.util.LinkedHashMap<>();
+        pools.forEach((key, pool) -> result.put(key, pool.getInfoMap()));
+        return result;
+    }
+
     /** 등록된 모든 풀의 상태를 로그에 출력한다 */
     public void logPoolState() {
         if (pools.isEmpty()) {


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

Closes #249

## ✨ 변경 사항 (Changes)

- `SocketPoolStatusController` (spider-link 신규): `GET /api/internal/pool/status` — 이 WAS에 등록된 모든 (host:port) 소켓풀의 active/idle/total/maxActive 반환
- `SocketPool`, `SocketPoolManager`: `getAllPoolInfo()` 집계 메서드 추가
- Admin `GET /api/was/instance/{instanceId}/pool-status`: FWK_PROPERTY 기반 관리 IP/포트 조회 후 spider-link 내부 API 호출
- `PoolStatusResponse` DTO 신규
- `was-instance.html`: AP 인스턴스 행에 '풀 현황' 버튼 추가 + Bootstrap 모달 (새로고침 버튼 포함)
- DB: BT02/BT03 `MANAGEMENT_SERVER_PORT` 오설정 수정 SQL 추가 (19100/19200 → 19280)

## 🛠 기술적 의사결정

**`@ConditionalOnBean` 제거**

`SocketPoolStatusController`에 `@ConditionalOnBean(SocketPoolManager.class)`를 붙였으나, 해당 애노테이션은 컴포넌트 스캔 중에 평가된다. `SocketPoolManager`는 `SpiderLinkAutoConfiguration`(auto-configuration)에서 등록되므로 컴포넌트 스캔보다 나중에 처리된다. 결과적으로 조건이 항상 false로 평가되어 컨트롤러가 bean으로 등록되지 않는 문제 발생.

spider-link를 사용하는 모든 앱에서 `SpiderLinkAutoConfiguration`이 `SocketPoolManager`를 항상 등록하므로 조건 자체가 불필요하여 제거했다.

## 🧪 테스트

- [x] biz-auth `GET localhost:19180/api/internal/pool/status` → `{"success":true,"pools":{"localhost:19300":{"active":0,"idle":1,"total":1,"maxActive":5}}}`
- [x] biz-transfer `GET localhost:19280/api/internal/pool/status` → 동일
- [x] Admin UI `was-instance` 화면에서 AP 인스턴스 행 '풀 현황' 버튼 클릭 → 모달 팝업 및 풀 데이터 정상 표시 확인

## 📸 변경 사항 확인

| 변경 전 (Before) | 변경 후 (After) |
| :--- | :--- |
| AP 인스턴스 행에 풀 현황 버튼 없음 | '풀 현황' 버튼 클릭 → 모달에서 host:port별 active/idle/total/maxActive 표시 |

## ⚠️ 고려 및 주의 사항

- `FWK_PROPERTY` BT02/BT03 관리 포트 수정 쿼리는 `admin/docs/sql/oracle/04_alter_tables.sql` 최하단에 추가됨. DB에 이미 반영 완료.
- `SocketPoolStatusController`의 `/api/internal/**` 경로는 `WebMvcConfig`의 `InternalApiInterceptor`가 localhost에서만 접근 가능하도록 제한함.

## 🔗 참고 사항

- 관련 이슈: #246 (TcpClient 커넥션 풀), #248 (Admin 동적 리로드 API)