### PR TITLE
✨ feat/#60-Quartz스케줄러-Redis분산락-배치자동실행

### DIFF
--- a/admin/src/main/java/com/example/admin_demo/domain/batch/controller/BatchAppController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/batch/controller/BatchAppController.java
@@ -5,7 +5,10 @@ import com.example.admin_demo.domain.batch.dto.BatchAppDetailResponse;
 import com.example.admin_demo.domain.batch.dto.BatchAppResponse;
 import com.example.admin_demo.domain.batch.dto.BatchAppSearchRequest;
 import com.example.admin_demo.domain.batch.dto.BatchAppUpdateRequest;
+import com.example.admin_demo.domain.batch.dto.ScheduleCronUpdateRequest;
+import com.example.admin_demo.domain.batch.dto.ScheduleTriggerRequest;
 import com.example.admin_demo.domain.batch.service.BatchAppService;
+import com.example.admin_demo.domain.batch.service.BatchExecService;
 import com.example.admin_demo.global.dto.ApiResponse;
 import com.example.admin_demo.global.dto.PageResponse;
 import com.example.admin_demo.global.util.ExcelExportUtil;
@@ -33,6 +36,7 @@ import org.springframework.web.bind.annotation.*;
 public class BatchAppController {
 
     private final BatchAppService batchAppService;
+    private final BatchExecService batchExecService;
 
     // ==================== 조회 API ====================
 
@@ -192,5 +196,40 @@ public class BatchAppController {
         log.info("DELETE /api/batch/apps/{}/was/instance/{} - Removing instance", batchAppId, instanceId);
         batchAppService.removeInstanceFromBatchApp(batchAppId, instanceId);
         return ResponseEntity.ok(ApiResponse.success("WAS 인스턴스가 삭제되었습니다", null));
+    }
+
+    // ==================== 스케줄 관리 API ====================
+
+    /**
+     * 스케줄 즉시 실행.
+     * 지정 WAS 인스턴스의 Quartz Job을 즉시 트리거한다.
+     * POST /api/batch/apps/{batchAppId}/schedule/trigger
+     */
+    @PostMapping("/{batchAppId}/schedule/trigger")
+    @PreAuthorize("hasAuthority('BATCH_APP:W')")
+    public ResponseEntity<ApiResponse<Void>> triggerSchedule(
+            @PathVariable String batchAppId, @Valid @RequestBody ScheduleTriggerRequest request) {
+
+        log.info("POST /api/batch/apps/{}/schedule/trigger - instanceId={}", batchAppId, request.getInstanceId());
+        batchExecService.triggerSchedule(batchAppId, request.getInstanceId(), request.getBatchDate());
+        return ResponseEntity.ok(ApiResponse.success("스케줄 즉시 실행이 요청되었습니다", null));
+    }
+
+    /**
+     * 스케줄 Cron 표현식 변경.
+     * DB(FWK_BATCH_APP.CRON_TEXT)를 업데이트하고 모든 배정 WAS 인스턴스에 스케줄 재등록 커맨드를 전송한다.
+     * PUT /api/batch/apps/{batchAppId}/schedule/cron
+     */
+    @PutMapping("/{batchAppId}/schedule/cron")
+    @PreAuthorize("hasAuthority('BATCH_APP:W')")
+    public ResponseEntity<ApiResponse<Void>> updateScheduleCron(
+            @PathVariable String batchAppId, @Valid @RequestBody ScheduleCronUpdateRequest request) {
+
+        log.info("PUT /api/batch/apps/{}/schedule/cron - cron={}", batchAppId, request.getCronText());
+        // 1. DB 업데이트
+        batchAppService.updateCronText(batchAppId, request.getCronText());
+        // 2. 모든 배정 인스턴스에 Quartz 재스케줄 TCP 전송
+        batchExecService.updateScheduleCron(batchAppId, request.getCronText());
+        return ResponseEntity.ok(ApiResponse.success("Cron 스케줄이 변경되었습니다", null));
     }
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/batch/dto/ScheduleCronUpdateRequest.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/batch/dto/ScheduleCronUpdateRequest.java
@@ -1,0 +1,26 @@
+package com.example.admin_demo.domain.batch.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 스케줄 Cron 표현식 변경 요청 DTO.
+ * Admin에서 배치의 Cron 스케줄을 변경할 때 사용한다.
+ * DB(FWK_BATCH_APP.CRON_TEXT) 업데이트 후 모든 배정 WAS 인스턴스에 TCP 커맨드가 전송된다.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScheduleCronUpdateRequest {
+
+    /**
+     * Quartz Cron 표현식 (예: {@code 0 0 2 * * ?} — 매일 02:00 실행).
+     * 공백을 포함한 6필드 또는 7필드 형식을 지원한다.
+     */
+    @NotBlank(message = "Cron 표현식은 필수입니다")
+    private String cronText;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/batch/dto/ScheduleTriggerRequest.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/batch/dto/ScheduleTriggerRequest.java
@@ -1,0 +1,25 @@
+package com.example.admin_demo.domain.batch.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 스케줄 즉시 실행 요청 DTO.
+ * Admin에서 특정 WAS 인스턴스의 Quartz Job을 즉시 트리거할 때 사용한다.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScheduleTriggerRequest {
+
+    /** 실행 대상 WAS 인스턴스 ID */
+    @NotBlank(message = "WAS 인스턴스 ID는 필수입니다")
+    private String instanceId;
+
+    /** 배치 기준일 (YYYYMMDD). null이면 WAS에서 당일로 자동 설정 */
+    private String batchDate;
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/batch/mapper/BatchAppMapper.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/batch/mapper/BatchAppMapper.java
@@ -82,4 +82,14 @@ public interface BatchAppMapper {
             @Param("batchCycleFilter") String batchCycleFilter,
             @Param("sortBy") String sortBy,
             @Param("sortDirection") String sortDirection);
+
+    /**
+     * FWK_BATCH_APP.CRON_TEXT 단독 업데이트.
+     * 스케줄 변경 API에서 전체 배치앱 정보를 갱신하지 않고 Cron 표현식만 변경할 때 사용한다.
+     */
+    void updateCronText(
+            @Param("batchAppId") String batchAppId,
+            @Param("cronText") String cronText,
+            @Param("lastUpdateDtime") String lastUpdateDtime,
+            @Param("lastUpdateUserId") String lastUpdateUserId);
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/batch/mapper/WasExecBatchMapper.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/batch/mapper/WasExecBatchMapper.java
@@ -44,4 +44,13 @@ public interface WasExecBatchMapper {
 
     // Batch 작업 (Oracle UNION ALL 패턴)
     void insertWasExecBatchBatch(@Param("list") List<Map<String, String>> list);
+
+    /**
+     * 해당 배치에 배정된 활성(USE_YN='Y') WAS 인스턴스 ID 목록 조회.
+     * 스케줄 Cron 변경 시 모든 배정 인스턴스에 TCP 커맨드를 전송하기 위해 사용한다.
+     *
+     * @param batchAppId 배치 APP ID
+     * @return USE_YN='Y' 인스턴스 ID 목록
+     */
+    List<String> selectActiveInstanceIds(@Param("batchAppId") String batchAppId);
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/batch/service/BatchAppService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/batch/service/BatchAppService.java
@@ -308,4 +308,21 @@ public class BatchAppService {
 
         wasExecBatchMapper.deleteWasExecBatchById(batchAppId, instanceId);
     }
+
+    /**
+     * FWK_BATCH_APP.CRON_TEXT를 단독으로 업데이트한다.
+     * 스케줄 변경 API에서 전체 배치앱 정보를 수정하지 않고 Cron 표현식만 변경할 때 사용한다.
+     *
+     * @param batchAppId 배치 APP ID
+     * @param cronText   새 Cron 표현식
+     */
+    @Transactional
+    public void updateCronText(String batchAppId, String cronText) {
+        if (batchAppMapper.countByBatchAppId(batchAppId) == 0) {
+            throw new NotFoundException("batchAppId: " + batchAppId);
+        }
+        String now = AuditUtil.now();
+        String userId = AuditUtil.currentUserId();
+        batchAppMapper.updateCronText(batchAppId, cronText, now, userId);
+    }
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/batch/service/BatchExecService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/batch/service/BatchExecService.java
@@ -17,6 +17,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -276,23 +277,32 @@ public class BatchExecService {
         }
 
         String userId = AuditUtil.currentUserId();
-        for (String instanceId : instanceIds) {
-            ManagementContext ctx = ManagementContext.builder()
-                    .command(CMD_SCHEDULE_CRON_UPDATE)
-                    .instanceId(instanceId)
-                    .batchAppId(batchAppId)
-                    .cronText(cronText)
-                    .userId(userId)
-                    .build();
+        // 인스턴스별 TCP 요청을 병렬 처리 — 느린 인스턴스 하나가 전체 응답을 지연시키는 것을 방지
+        List<CompletableFuture<Void>> futures = instanceIds.stream()
+                .map(instanceId -> CompletableFuture.runAsync(() -> {
+                    ManagementContext ctx = ManagementContext.builder()
+                            .command(CMD_SCHEDULE_CRON_UPDATE)
+                            .instanceId(instanceId)
+                            .batchAppId(batchAppId)
+                            .cronText(cronText)
+                            .userId(userId)
+                            .build();
 
-            log.info("스케줄 Cron 변경 TCP 요청: instanceId={}, batchAppId={}, cron={}", instanceId, batchAppId, cronText);
-            ManagementContext response = batchManagementAdapter.doProcess(CMD_SCHEDULE_CRON_UPDATE, ctx);
+                    log.info(
+                            "스케줄 Cron 변경 TCP 요청: instanceId={}, batchAppId={}, cron={}",
+                            instanceId,
+                            batchAppId,
+                            cronText);
+                    ManagementContext response = batchManagementAdapter.doProcess(CMD_SCHEDULE_CRON_UPDATE, ctx);
 
-            if (response == null || "ERROR".equals(response.getResultCode())) {
-                String errorMsg = (response != null) ? response.getErrorMessage() : "응답 없음";
-                // 일부 인스턴스 실패 시 경고 로그만 남기고 나머지 인스턴스는 계속 처리
-                log.warn("스케줄 Cron 변경 실패: instanceId={}, error={}", instanceId, errorMsg);
-            }
-        }
+                    if (response == null || "ERROR".equals(response.getResultCode())) {
+                        String errorMsg = (response != null) ? response.getErrorMessage() : "응답 없음";
+                        // 일부 인스턴스 실패 시 경고 로그만 남기고 나머지 인스턴스는 계속 처리
+                        log.warn("스케줄 Cron 변경 실패: instanceId={}, error={}", instanceId, errorMsg);
+                    }
+                }))
+                .toList();
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
     }
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/batch/service/BatchExecService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/batch/service/BatchExecService.java
@@ -6,11 +6,15 @@ import com.example.admin_demo.domain.batch.dto.BatchHisResponse;
 import com.example.admin_demo.domain.batch.enums.BatchResRtCode;
 import com.example.admin_demo.domain.batch.mapper.BatchAppMapper;
 import com.example.admin_demo.domain.batch.mapper.BatchHisMapper;
+import com.example.admin_demo.domain.batch.mapper.WasExecBatchMapper;
+import com.example.admin_demo.global.exception.InternalException;
 import com.example.admin_demo.global.exception.InvalidInputException;
 import com.example.admin_demo.global.exception.NotFoundException;
 import com.example.admin_demo.global.util.AuditUtil;
 import com.example.admin_demo.infra.tcp.adapter.BatchManagementAdapter;
 import com.example.spiderlink.infra.tcp.model.ManagementContext;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +38,7 @@ public class BatchExecService {
 
     private final BatchAppMapper batchAppMapper;
     private final BatchHisMapper batchHisMapper;
+    private final WasExecBatchMapper wasExecBatchMapper;
 
     /** Admin ↔ batch-was 간 TCP 통신 어댑터 (ObjectStream 방식) */
     private final BatchManagementAdapter batchManagementAdapter;
@@ -44,6 +49,11 @@ public class BatchExecService {
 
     /** TCP 커맨드 상수 — batch-was와 약속된 식별자 */
     private static final String CMD_BATCH_EXEC = "BATCH_EXEC";
+
+    private static final String CMD_SCHEDULE_TRIGGER = "SCHEDULE_TRIGGER";
+    private static final String CMD_SCHEDULE_CRON_UPDATE = "SCHEDULE_CRON_UPDATE";
+
+    private static final DateTimeFormatter BATCH_DATE_FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
 
     @Transactional
     public List<BatchHisResponse> executeManualBatch(BatchExecRequest requestDTO) {
@@ -216,5 +226,73 @@ public class BatchExecService {
         }
 
         return result;
+    }
+
+    /**
+     * 지정 WAS 인스턴스의 Quartz Job을 즉시 실행한다.
+     * SCHEDULE_TRIGGER 커맨드를 TCP로 전송하면 WAS가 {@code scheduler.triggerJob()}을 호출한다.
+     *
+     * @param batchAppId 배치 APP ID
+     * @param instanceId 실행 대상 WAS 인스턴스 ID
+     * @param batchDate  배치 기준일 (null이면 WAS에서 당일로 자동 설정)
+     */
+    public void triggerSchedule(String batchAppId, String instanceId, String batchDate) {
+        String resolvedDate = (batchDate != null && !batchDate.isBlank())
+                ? batchDate
+                : LocalDate.now().format(BATCH_DATE_FMT);
+
+        ManagementContext ctx = ManagementContext.builder()
+                .command(CMD_SCHEDULE_TRIGGER)
+                .instanceId(instanceId)
+                .batchAppId(batchAppId)
+                .batchDate(resolvedDate)
+                .userId(AuditUtil.currentUserId())
+                .build();
+
+        log.info("스케줄 즉시 실행 TCP 요청: instanceId={}, batchAppId={}", instanceId, batchAppId);
+        ManagementContext response = batchManagementAdapter.doProcess(CMD_SCHEDULE_TRIGGER, ctx);
+
+        if (response == null || "ERROR".equals(response.getResultCode())) {
+            String errorMsg = (response != null) ? response.getErrorMessage() : "응답 없음";
+            throw new InternalException(
+                    "스케줄 즉시 실행 실패: instanceId=" + instanceId + ", batchAppId=" + batchAppId + ", error=" + errorMsg);
+        }
+    }
+
+    /**
+     * 배치의 Cron 표현식을 변경하고 모든 배정 WAS 인스턴스에 스케줄 재등록 커맨드를 전송한다.
+     * SCHEDULE_CRON_UPDATE 커맨드를 각 인스턴스에 TCP로 전송하면 WAS가 {@code scheduler.reschedule()}을 호출한다.
+     *
+     * <p>DB 업데이트(FWK_BATCH_APP.CRON_TEXT)는 BatchAppService.updateCronText()를 통해 Controller에서 처리한다.</p>
+     *
+     * @param batchAppId 배치 APP ID
+     * @param cronText   새 Cron 표현식
+     */
+    public void updateScheduleCron(String batchAppId, String cronText) {
+        List<String> instanceIds = wasExecBatchMapper.selectActiveInstanceIds(batchAppId);
+        if (instanceIds.isEmpty()) {
+            log.info("스케줄 Cron 변경: 배정된 활성 인스턴스 없음 — batchAppId={}", batchAppId);
+            return;
+        }
+
+        String userId = AuditUtil.currentUserId();
+        for (String instanceId : instanceIds) {
+            ManagementContext ctx = ManagementContext.builder()
+                    .command(CMD_SCHEDULE_CRON_UPDATE)
+                    .instanceId(instanceId)
+                    .batchAppId(batchAppId)
+                    .cronText(cronText)
+                    .userId(userId)
+                    .build();
+
+            log.info("스케줄 Cron 변경 TCP 요청: instanceId={}, batchAppId={}, cron={}", instanceId, batchAppId, cronText);
+            ManagementContext response = batchManagementAdapter.doProcess(CMD_SCHEDULE_CRON_UPDATE, ctx);
+
+            if (response == null || "ERROR".equals(response.getResultCode())) {
+                String errorMsg = (response != null) ? response.getErrorMessage() : "응답 없음";
+                // 일부 인스턴스 실패 시 경고 로그만 남기고 나머지 인스턴스는 계속 처리
+                log.warn("스케줄 Cron 변경 실패: instanceId={}, error={}", instanceId, errorMsg);
+            }
+        }
     }
 }

--- a/admin/src/main/resources/mapper/oracle/batch/BatchAppMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/batch/BatchAppMapper.xml
@@ -234,5 +234,13 @@
         <include refid="orderByBatchApp"/>
     </select>
 
+    <!-- Cron 표현식 단독 업데이트 — 스케줄 변경 API 전용 -->
+    <update id="updateCronText">
+        UPDATE FWK_BATCH_APP
+           SET CRON_TEXT             = #{cronText, jdbcType=VARCHAR},
+               LAST_UPDATE_DTIME     = #{lastUpdateDtime},
+               LAST_UPDATE_USER_ID   = #{lastUpdateUserId}
+         WHERE BATCH_APP_ID = #{batchAppId}
+    </update>
 
 </mapper>

--- a/admin/src/main/resources/mapper/oracle/batch/WasExecBatchMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/batch/WasExecBatchMapper.xml
@@ -108,5 +108,12 @@
         LEFT JOIN FWK_WAS_INSTANCE wi ON web.INSTANCE_ID = wi.INSTANCE_ID
     </sql>
 
+    <!-- 배치에 배정된 활성 인스턴스 ID 조회 — 스케줄 Cron 변경 시 전체 인스턴스 TCP 전송에 사용 -->
+    <select id="selectActiveInstanceIds" resultType="String">
+        SELECT INSTANCE_ID
+        FROM   FWK_WAS_EXEC_BATCH
+        WHERE  BATCH_APP_ID = #{batchAppId}
+          AND  USE_YN       = 'Y'
+    </select>
 
 </mapper>

--- a/batch-was/.env.example
+++ b/batch-was/.env.example
@@ -31,3 +31,8 @@ SMTP_HOST=smtp.your-company.com
 SMTP_PORT=587
 SMTP_USERNAME=
 SMTP_PASSWORD=
+
+# === Redis (분산 락 — Quartz 멀티 인스턴스 중복 실행 방지) ===
+# docker-compose.yml의 redis 컨테이너 기본값
+REDIS_HOST=localhost
+REDIS_PORT=6379

--- a/batch-was/docker-compose.yml
+++ b/batch-was/docker-compose.yml
@@ -1,8 +1,17 @@
 version: '3.8'
 
-# 모니터링 스택 (Prometheus + Grafana)
+# 모니터링 스택 (Prometheus + Grafana) + Redis 분산 락
 # batch-was 앱 자체는 로컬/별도 서버에서 실행 — host.docker.internal:8081 로 스크랩
 services:
+  redis:
+    image: redis:7.2-alpine
+    container_name: spider-batch-redis
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+    # TODO: 운영 환경에서는 Redis Sentinel 또는 Redis Cluster로 HA 구성 필요
+    #       단일 Redis는 SPOF — 장애 시 자동 페일오버 불가
+
   prometheus:
     image: prom/prometheus:v2.50.1
     container_name: spider-batch-prometheus

--- a/batch-was/pom.xml
+++ b/batch-was/pom.xml
@@ -69,6 +69,20 @@
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
 
+        <!-- Quartz 스케줄러: Cron 기반 배치 자동 실행 -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-quartz</artifactId>
+        </dependency>
+
+        <!-- Redisson: Redis 분산 락 (멀티 인스턴스 중복 실행 방지) -->
+        <!-- TODO: 운영 환경에서는 RedissonClient를 Sentinel/Cluster 모드로 구성 필요 -->
+        <dependency>
+            <groupId>org.redisson</groupId>
+            <artifactId>redisson-spring-boot-starter</artifactId>
+            <version>3.27.2</version>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/batch-was/src/main/java/com/example/spiderbatch/lock/RedisDistributedLockService.java
+++ b/batch-was/src/main/java/com/example/spiderbatch/lock/RedisDistributedLockService.java
@@ -14,8 +14,9 @@ import org.springframework.stereotype.Service;
  * 동일 배치의 중복 실행을 방지한다.</p>
  *
  * <p>락 키: {@code batch:lock:{batchAppId}}<br>
- * 락 만료 시간: {@value LOCK_EXPIRE_SECONDS}초 — 배치 최대 실행 시간(1시간)을 기준으로 설정.
- * 프로세스가 비정상 종료되더라도 만료 시간 후 자동 해제된다.</p>
+ * leaseTime을 지정하지 않아 Redisson Watchdog이 활성화된다.
+ * Watchdog은 배치 실행 중 락을 30초마다 자동 갱신하며, 배치 완료/실패 시 {@link #unlock}에서 명시적으로 해제한다.
+ * 프로세스가 비정상 종료되면 Watchdog이 멈추고 기본 TTL(30초) 후 락이 자동 해제된다.</p>
  *
  * <p>TODO: 운영 환경에서는 RedissonClient를 Sentinel 또는 Cluster 모드로 구성해야 한다.
  * application.yml의 {@code spring.data.redis} 설정을
@@ -29,12 +30,11 @@ public class RedisDistributedLockService {
     private final RedissonClient redissonClient;
 
     private static final String LOCK_PREFIX = "batch:lock:";
-    /** 락 만료 시간 (초) — 배치 최대 실행 시간 + 여유 시간 */
-    private static final long LOCK_EXPIRE_SECONDS = 3600;
 
     /**
      * 배치 분산 락 획득 시도.
-     * 대기 없이 즉시 시도(tryLock waitTime=0)하여 이미 락이 있으면 false 반환.
+     * leaseTime 없이 tryLock — Watchdog이 활성화되어 배치 실행 중 락이 자동 갱신된다.
+     * 대기 없이 즉시 시도(waitTime=0)하여 이미 락이 있으면 false 반환.
      *
      * @param batchAppId 배치 APP ID
      * @return 락 획득 성공 시 true, 이미 다른 인스턴스가 실행 중이면 false
@@ -42,7 +42,8 @@ public class RedisDistributedLockService {
     public boolean tryLock(String batchAppId) {
         RLock lock = redissonClient.getLock(LOCK_PREFIX + batchAppId);
         try {
-            boolean acquired = lock.tryLock(0, LOCK_EXPIRE_SECONDS, TimeUnit.SECONDS);
+            // leaseTime 생략 → Watchdog 활성화 (배치 실행 시간에 상관없이 락 유지)
+            boolean acquired = lock.tryLock(0, TimeUnit.SECONDS);
             if (acquired) {
                 log.debug("[분산 락] 획득: batchAppId={}", batchAppId);
             } else {

--- a/batch-was/src/main/java/com/example/spiderbatch/lock/RedisDistributedLockService.java
+++ b/batch-was/src/main/java/com/example/spiderbatch/lock/RedisDistributedLockService.java
@@ -1,0 +1,73 @@
+package com.example.spiderbatch.lock;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+/**
+ * Redis 분산 락 서비스.
+ *
+ * <p>Redisson {@link RLock}을 사용해 멀티 인스턴스 환경에서
+ * 동일 배치의 중복 실행을 방지한다.</p>
+ *
+ * <p>락 키: {@code batch:lock:{batchAppId}}<br>
+ * 락 만료 시간: {@value LOCK_EXPIRE_SECONDS}초 — 배치 최대 실행 시간(1시간)을 기준으로 설정.
+ * 프로세스가 비정상 종료되더라도 만료 시간 후 자동 해제된다.</p>
+ *
+ * <p>TODO: 운영 환경에서는 RedissonClient를 Sentinel 또는 Cluster 모드로 구성해야 한다.
+ * application.yml의 {@code spring.data.redis} 설정을
+ * {@code spring.redis.sentinel} 또는 {@code spring.redis.cluster} 블록으로 전환할 것.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisDistributedLockService {
+
+    private final RedissonClient redissonClient;
+
+    private static final String LOCK_PREFIX = "batch:lock:";
+    /** 락 만료 시간 (초) — 배치 최대 실행 시간 + 여유 시간 */
+    private static final long LOCK_EXPIRE_SECONDS = 3600;
+
+    /**
+     * 배치 분산 락 획득 시도.
+     * 대기 없이 즉시 시도(tryLock waitTime=0)하여 이미 락이 있으면 false 반환.
+     *
+     * @param batchAppId 배치 APP ID
+     * @return 락 획득 성공 시 true, 이미 다른 인스턴스가 실행 중이면 false
+     */
+    public boolean tryLock(String batchAppId) {
+        RLock lock = redissonClient.getLock(LOCK_PREFIX + batchAppId);
+        try {
+            boolean acquired = lock.tryLock(0, LOCK_EXPIRE_SECONDS, TimeUnit.SECONDS);
+            if (acquired) {
+                log.debug("[분산 락] 획득: batchAppId={}", batchAppId);
+            } else {
+                log.info("[분산 락] 이미 실행 중 — 스킵: batchAppId={}", batchAppId);
+            }
+            return acquired;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("[분산 락] 획득 인터럽트: batchAppId={}", batchAppId);
+            return false;
+        }
+    }
+
+    /**
+     * 배치 분산 락 해제.
+     * 현재 스레드가 보유한 락만 해제한다. 락이 없거나 다른 스레드 소유이면 무시.
+     *
+     * @param batchAppId 배치 APP ID
+     */
+    public void unlock(String batchAppId) {
+        RLock lock = redissonClient.getLock(LOCK_PREFIX + batchAppId);
+        // isHeldByCurrentThread: 현재 스레드가 락을 보유한 경우에만 해제
+        if (lock.isHeldByCurrentThread()) {
+            lock.unlock();
+            log.debug("[분산 락] 해제: batchAppId={}", batchAppId);
+        }
+    }
+}

--- a/batch-was/src/main/java/com/example/spiderbatch/scheduler/BatchJobQuartzTrigger.java
+++ b/batch-was/src/main/java/com/example/spiderbatch/scheduler/BatchJobQuartzTrigger.java
@@ -1,0 +1,72 @@
+package com.example.spiderbatch.scheduler;
+
+import com.example.spiderbatch.domain.batch.dto.BatchExecuteRequest;
+import com.example.spiderbatch.domain.batch.service.BatchExecuteService;
+import com.example.spiderbatch.lock.RedisDistributedLockService;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.JobExecutionContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+
+/**
+ * Quartz Job 구현체 — 배치 자동 실행 트리거.
+ *
+ * <p>Quartz Scheduler가 Cron 주기에 맞춰 이 Job을 실행하면:
+ * <ol>
+ *   <li>Redis 분산 락 획득 시도 — 실패 시(다른 인스턴스가 실행 중) 스킵</li>
+ *   <li>{@link BatchExecuteService#execute}로 배치 실행 위임</li>
+ *   <li>finally에서 분산 락 반드시 해제</li>
+ * </ol>
+ * </p>
+ *
+ * <p>JobDataMap 필수 키: {@code batchAppId}</p>
+ */
+@Slf4j
+public class BatchJobQuartzTrigger extends QuartzJobBean {
+
+    /** QuartzJobBean은 Spring DI(@Autowired)를 지원한다 */
+    @Autowired
+    private BatchExecuteService batchExecuteService;
+
+    @Autowired
+    private RedisDistributedLockService lockService;
+
+    private static final DateTimeFormatter BATCH_DATE_FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    /** Quartz가 스케줄에 따라 호출하는 실행 메서드 */
+    @Override
+    protected void executeInternal(JobExecutionContext ctx) {
+        String batchAppId = ctx.getMergedJobDataMap().getString("batchAppId");
+        if (batchAppId == null || batchAppId.isBlank()) {
+            log.error("[Quartz] JobDataMap에 batchAppId 없음 — 실행 불가: jobKey={}", ctx.getJobDetail().getKey());
+            return;
+        }
+
+        log.info("[Quartz] 배치 실행 시작: batchAppId={}", batchAppId);
+
+        if (!lockService.tryLock(batchAppId)) {
+            // 다른 WAS 인스턴스가 동일 배치를 실행 중 — 정상 스킵
+            log.info("[Quartz] 분산 락 획득 실패, 실행 스킵: batchAppId={}", batchAppId);
+            return;
+        }
+
+        try {
+            BatchExecuteRequest request = BatchExecuteRequest.builder()
+                    .batchAppId(batchAppId)
+                    // 배치 기준일은 실행 당일로 자동 설정
+                    .batchDate(LocalDate.now().format(BATCH_DATE_FMT))
+                    .userId("QUARTZ_SCHEDULER")
+                    .build();
+
+            batchExecuteService.execute(request, "QUARTZ_INTERNAL");
+            log.info("[Quartz] 배치 실행 완료: batchAppId={}", batchAppId);
+
+        } catch (Exception e) {
+            log.error("[Quartz] 배치 실행 중 예외: batchAppId={}", batchAppId, e);
+        } finally {
+            lockService.unlock(batchAppId);
+        }
+    }
+}

--- a/batch-was/src/main/java/com/example/spiderbatch/scheduler/BatchJobQuartzTrigger.java
+++ b/batch-was/src/main/java/com/example/spiderbatch/scheduler/BatchJobQuartzTrigger.java
@@ -53,10 +53,11 @@ public class BatchJobQuartzTrigger extends QuartzJobBean {
         }
 
         try {
+            // Admin 즉시 실행 시 전달된 날짜 우선, 없으면 실행 당일
+            String manualBatchDate = ctx.getMergedJobDataMap().getString("manualBatchDate");
             BatchExecuteRequest request = BatchExecuteRequest.builder()
                     .batchAppId(batchAppId)
-                    // 배치 기준일은 실행 당일로 자동 설정
-                    .batchDate(LocalDate.now().format(BATCH_DATE_FMT))
+                    .batchDate(manualBatchDate != null ? manualBatchDate : LocalDate.now().format(BATCH_DATE_FMT))
                     .userId("QUARTZ_SCHEDULER")
                     .build();
 

--- a/batch-was/src/main/java/com/example/spiderbatch/scheduler/QuartzAutoRegistrar.java
+++ b/batch-was/src/main/java/com/example/spiderbatch/scheduler/QuartzAutoRegistrar.java
@@ -1,0 +1,57 @@
+package com.example.spiderbatch.scheduler;
+
+import com.example.spiderbatch.config.BatchConfigurationProperties;
+import com.example.spiderbatch.domain.batch.dto.CronBatchInfo;
+import com.example.spiderbatch.domain.batch.mapper.BatchAppMapper;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * WAS 기동 시 Quartz 스케줄 자동 등록.
+ *
+ * <p>FWK_WAS_EXEC_BATCH JOIN FWK_BATCH_APP 에서 이 인스턴스에 배정되고
+ * CRON_TEXT가 설정된 배치를 조회하여 Quartz에 자동 등록한다.</p>
+ *
+ * <p>RAMJobStore를 사용하므로 WAS 재기동 시마다 재등록이 필요하다.
+ * ApplicationRunner를 통해 기동 완료 후 자동으로 실행된다.</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QuartzAutoRegistrar implements ApplicationRunner {
+
+    private final BatchConfigurationProperties batchProps;
+    private final BatchAppMapper batchAppMapper;
+    private final SchedulerManagementService schedulerManagementService;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        String instanceId = batchProps.getWas().getInstanceId();
+        log.info("[QuartzAutoRegistrar] 스케줄 자동 등록 시작: instanceId={}", instanceId);
+
+        List<CronBatchInfo> cronBatches = batchAppMapper.selectCronBatchesByInstanceId(instanceId);
+
+        if (cronBatches.isEmpty()) {
+            log.info("[QuartzAutoRegistrar] 등록할 Cron 배치 없음: instanceId={}", instanceId);
+            return;
+        }
+
+        int successCount = 0;
+        for (CronBatchInfo batch : cronBatches) {
+            try {
+                schedulerManagementService.registerJob(batch.getBatchAppId(), batch.getCronText());
+                successCount++;
+            } catch (Exception e) {
+                // 개별 Job 등록 실패가 전체 기동을 막지 않도록 예외를 잡아 로그만 기록
+                log.error("[QuartzAutoRegistrar] Job 등록 실패, 기동 계속: batchAppId={}, cron={}",
+                        batch.getBatchAppId(), batch.getCronText(), e);
+            }
+        }
+
+        log.info("[QuartzAutoRegistrar] 스케줄 자동 등록 완료: {}/{}건", successCount, cronBatches.size());
+    }
+}

--- a/batch-was/src/main/java/com/example/spiderbatch/scheduler/SchedulerManagementService.java
+++ b/batch-was/src/main/java/com/example/spiderbatch/scheduler/SchedulerManagementService.java
@@ -1,0 +1,155 @@
+package com.example.spiderbatch.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.CronScheduleBuilder;
+import org.quartz.CronTrigger;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.TriggerBuilder;
+import org.quartz.TriggerKey;
+import org.springframework.stereotype.Service;
+
+/**
+ * Quartz 스케줄러 관리 서비스.
+ *
+ * <p>Job 등록·수정·삭제·즉시 실행을 담당한다.
+ * Job 이름은 batchAppId, Group은 {@value JOB_GROUP}으로 고정한다.</p>
+ *
+ * <p>현재 JobStore는 RAMJobStore(in-memory)를 사용한다.
+ * TODO: 운영 환경에서는 JDBC JobStore로 전환하여 WAS 재기동 시 스케줄을 복구할 것.
+ *       application.yml: {@code spring.quartz.job-store-type: jdbc}</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SchedulerManagementService {
+
+    private final Scheduler scheduler;
+
+    static final String JOB_GROUP = "BATCH";
+
+    /**
+     * 배치 Job을 Quartz에 등록한다.
+     * 이미 동일 Job이 존재하면 Trigger를 새 cronText로 교체한다.
+     *
+     * @param batchAppId 배치 APP ID (Job 이름으로 사용)
+     * @param cronText   Quartz Cron 표현식 (예: {@code 0 0 2 * * ?})
+     */
+    public void registerJob(String batchAppId, String cronText) {
+        try {
+            JobKey jobKey = JobKey.jobKey(batchAppId, JOB_GROUP);
+
+            if (scheduler.checkExists(jobKey)) {
+                // 이미 등록된 Job — Trigger만 교체
+                reschedule(batchAppId, cronText);
+                return;
+            }
+
+            JobDetail jobDetail = JobBuilder.newJob(BatchJobQuartzTrigger.class)
+                    .withIdentity(jobKey)
+                    .usingJobData("batchAppId", batchAppId)
+                    // durability: true — Trigger 없이도 Job을 보존 (즉시 실행 후 재등록 가능)
+                    .storeDurably(true)
+                    .build();
+
+            CronTrigger trigger = buildCronTrigger(batchAppId, cronText);
+            scheduler.scheduleJob(jobDetail, trigger);
+            log.info("[Quartz] Job 등록: batchAppId={}, cron={}", batchAppId, cronText);
+
+        } catch (SchedulerException e) {
+            log.error("[Quartz] Job 등록 실패: batchAppId={}, cron={}", batchAppId, cronText, e);
+            throw new RuntimeException("Quartz Job 등록 실패: " + batchAppId, e);
+        }
+    }
+
+    /**
+     * 기존 Job의 Cron 표현식을 변경한다.
+     * Job이 존재하지 않으면 새로 등록한다.
+     *
+     * @param batchAppId 배치 APP ID
+     * @param cronText   새 Cron 표현식
+     */
+    public void reschedule(String batchAppId, String cronText) {
+        try {
+            JobKey jobKey = JobKey.jobKey(batchAppId, JOB_GROUP);
+
+            if (!scheduler.checkExists(jobKey)) {
+                // Job이 없으면 신규 등록으로 전환
+                registerJob(batchAppId, cronText);
+                return;
+            }
+
+            TriggerKey triggerKey = TriggerKey.triggerKey(batchAppId, JOB_GROUP);
+            CronTrigger newTrigger = buildCronTrigger(batchAppId, cronText);
+            scheduler.rescheduleJob(triggerKey, newTrigger);
+            log.info("[Quartz] 스케줄 변경: batchAppId={}, cron={}", batchAppId, cronText);
+
+        } catch (SchedulerException e) {
+            log.error("[Quartz] 스케줄 변경 실패: batchAppId={}, cron={}", batchAppId, cronText, e);
+            throw new RuntimeException("Quartz 스케줄 변경 실패: " + batchAppId, e);
+        }
+    }
+
+    /**
+     * Quartz에 등록된 배치 Job을 삭제한다.
+     *
+     * @param batchAppId 배치 APP ID
+     */
+    public void deleteJob(String batchAppId) {
+        try {
+            JobKey jobKey = JobKey.jobKey(batchAppId, JOB_GROUP);
+            boolean deleted = scheduler.deleteJob(jobKey);
+            if (deleted) {
+                log.info("[Quartz] Job 삭제: batchAppId={}", batchAppId);
+            } else {
+                log.warn("[Quartz] 삭제할 Job 없음: batchAppId={}", batchAppId);
+            }
+        } catch (SchedulerException e) {
+            log.error("[Quartz] Job 삭제 실패: batchAppId={}", batchAppId, e);
+            throw new RuntimeException("Quartz Job 삭제 실패: " + batchAppId, e);
+        }
+    }
+
+    /**
+     * Quartz에 등록된 배치 Job을 즉시 실행한다.
+     * Job이 등록되어 있지 않아도 실행 가능 — 등록 후 triggerJob 호출.
+     *
+     * @param batchAppId 배치 APP ID
+     */
+    public void triggerNow(String batchAppId) {
+        try {
+            JobKey jobKey = JobKey.jobKey(batchAppId, JOB_GROUP);
+
+            // Job이 없으면 durability Job만 등록 후 즉시 실행 (cron 없이)
+            if (!scheduler.checkExists(jobKey)) {
+                JobDetail jobDetail = JobBuilder.newJob(BatchJobQuartzTrigger.class)
+                        .withIdentity(jobKey)
+                        .usingJobData("batchAppId", batchAppId)
+                        .storeDurably(true)
+                        .build();
+                scheduler.addJob(jobDetail, false);
+            }
+
+            scheduler.triggerJob(jobKey);
+            log.info("[Quartz] 즉시 실행 트리거: batchAppId={}", batchAppId);
+
+        } catch (SchedulerException e) {
+            log.error("[Quartz] 즉시 실행 실패: batchAppId={}", batchAppId, e);
+            throw new RuntimeException("Quartz 즉시 실행 실패: " + batchAppId, e);
+        }
+    }
+
+    /** CronTrigger 생성 헬퍼 */
+    private CronTrigger buildCronTrigger(String batchAppId, String cronText) {
+        return TriggerBuilder.newTrigger()
+                .withIdentity(TriggerKey.triggerKey(batchAppId, JOB_GROUP))
+                .withSchedule(CronScheduleBuilder.cronSchedule(cronText)
+                        // 미스파이어: 다음 Cron 주기에 실행 (misfire 무시 — 적체 방지)
+                        .withMisfireHandlingInstructionDoNothing())
+                .build();
+    }
+}

--- a/batch-was/src/main/java/com/example/spiderbatch/scheduler/SchedulerManagementService.java
+++ b/batch-was/src/main/java/com/example/spiderbatch/scheduler/SchedulerManagementService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.CronTrigger;
 import org.quartz.JobBuilder;
+import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
 import org.quartz.JobKey;
 import org.quartz.Scheduler;
@@ -85,8 +86,13 @@ public class SchedulerManagementService {
 
             TriggerKey triggerKey = TriggerKey.triggerKey(batchAppId, JOB_GROUP);
             CronTrigger newTrigger = buildCronTrigger(batchAppId, cronText);
-            scheduler.rescheduleJob(triggerKey, newTrigger);
-            log.info("[Quartz] 스케줄 변경: batchAppId={}, cron={}", batchAppId, cronText);
+            // rescheduleJob이 null을 반환하면 Trigger가 없는 상태 — 새로 scheduleJob
+            if (scheduler.rescheduleJob(triggerKey, newTrigger) == null) {
+                scheduler.scheduleJob(newTrigger);
+                log.info("[Quartz] Trigger 없음 — 재생성: batchAppId={}, cron={}", batchAppId, cronText);
+            } else {
+                log.info("[Quartz] 스케줄 변경: batchAppId={}, cron={}", batchAppId, cronText);
+            }
 
         } catch (SchedulerException e) {
             log.error("[Quartz] 스케줄 변경 실패: batchAppId={}, cron={}", batchAppId, cronText, e);
@@ -119,23 +125,29 @@ public class SchedulerManagementService {
      * Job이 등록되어 있지 않아도 실행 가능 — 등록 후 triggerJob 호출.
      *
      * @param batchAppId 배치 APP ID
+     * @param batchDate  배치 기준일 (null이면 Job 내부에서 당일로 자동 설정)
      */
-    public void triggerNow(String batchAppId) {
+    public void triggerNow(String batchAppId, String batchDate) {
         try {
             JobKey jobKey = JobKey.jobKey(batchAppId, JOB_GROUP);
 
-            // Job이 없으면 durability Job만 등록 후 즉시 실행 (cron 없이)
+            // replace=true: 동시 요청 race condition 방어 — 이미 존재해도 덮어쓰지 않고 정상 처리
             if (!scheduler.checkExists(jobKey)) {
                 JobDetail jobDetail = JobBuilder.newJob(BatchJobQuartzTrigger.class)
                         .withIdentity(jobKey)
                         .usingJobData("batchAppId", batchAppId)
                         .storeDurably(true)
                         .build();
-                scheduler.addJob(jobDetail, false);
+                scheduler.addJob(jobDetail, true);
             }
 
-            scheduler.triggerJob(jobKey);
-            log.info("[Quartz] 즉시 실행 트리거: batchAppId={}", batchAppId);
+            // batchDate를 JobDataMap으로 전달 — BatchJobQuartzTrigger에서 manualBatchDate 키로 읽음
+            JobDataMap dataMap = new JobDataMap();
+            if (batchDate != null && !batchDate.isBlank()) {
+                dataMap.put("manualBatchDate", batchDate);
+            }
+            scheduler.triggerJob(jobKey, dataMap);
+            log.info("[Quartz] 즉시 실행 트리거: batchAppId={}, batchDate={}", batchAppId, batchDate);
 
         } catch (SchedulerException e) {
             log.error("[Quartz] 즉시 실행 실패: batchAppId={}", batchAppId, e);

--- a/batch-was/src/main/java/com/example/spiderbatch/tcp/ScheduleCommandHandler.java
+++ b/batch-was/src/main/java/com/example/spiderbatch/tcp/ScheduleCommandHandler.java
@@ -37,7 +37,7 @@ public class ScheduleCommandHandler implements CommandHandler<ManagementContext,
 
         try {
             if ("SCHEDULE_TRIGGER".equals(command)) {
-                schedulerManagementService.triggerNow(ctx.getBatchAppId());
+                schedulerManagementService.triggerNow(ctx.getBatchAppId(), ctx.getBatchDate());
             } else {
                 // SCHEDULE_CRON_UPDATE — cronText가 없으면 Job 삭제 (스케줄 비활성화)
                 if (ctx.getCronText() == null || ctx.getCronText().isBlank()) {

--- a/batch-was/src/main/java/com/example/spiderbatch/tcp/ScheduleCommandHandler.java
+++ b/batch-was/src/main/java/com/example/spiderbatch/tcp/ScheduleCommandHandler.java
@@ -1,0 +1,69 @@
+package com.example.spiderbatch.tcp;
+
+import com.example.spiderbatch.scheduler.SchedulerManagementService;
+import com.example.spiderlink.infra.tcp.handler.CommandHandler;
+import com.example.spiderlink.infra.tcp.model.ManagementContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * SCHEDULE_TRIGGER / SCHEDULE_CRON_UPDATE 커맨드 핸들러.
+ *
+ * <p>Admin에서 TCP로 전달된 스케줄 관리 커맨드를 {@link SchedulerManagementService}에 위임한다.
+ * {@link com.example.spiderbatch.config.TcpServerConfig}가 {@code List<CommandHandler>}로 빈을 수집하므로
+ * 이 컴포넌트는 자동으로 TCP 서버에 등록된다.</p>
+ *
+ * <ul>
+ *   <li>{@code SCHEDULE_TRIGGER}: 특정 배치 Job을 즉시 실행</li>
+ *   <li>{@code SCHEDULE_CRON_UPDATE}: 특정 배치의 Cron 표현식 변경 (ManagementContext.cronText 사용)</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ScheduleCommandHandler implements CommandHandler<ManagementContext, ManagementContext> {
+
+    private final SchedulerManagementService schedulerManagementService;
+
+    @Override
+    public boolean supports(String command) {
+        return "SCHEDULE_TRIGGER".equals(command) || "SCHEDULE_CRON_UPDATE".equals(command);
+    }
+
+    @Override
+    public ManagementContext handle(String command, ManagementContext ctx) {
+        log.info("[ScheduleCommandHandler] 수신: command={}, batchAppId={}", command, ctx.getBatchAppId());
+
+        try {
+            if ("SCHEDULE_TRIGGER".equals(command)) {
+                schedulerManagementService.triggerNow(ctx.getBatchAppId());
+            } else {
+                // SCHEDULE_CRON_UPDATE — cronText가 없으면 Job 삭제 (스케줄 비활성화)
+                if (ctx.getCronText() == null || ctx.getCronText().isBlank()) {
+                    schedulerManagementService.deleteJob(ctx.getBatchAppId());
+                    log.info("[ScheduleCommandHandler] cronText 없음 — Job 삭제: batchAppId={}", ctx.getBatchAppId());
+                } else {
+                    schedulerManagementService.reschedule(ctx.getBatchAppId(), ctx.getCronText());
+                }
+            }
+
+            return ManagementContext.builder()
+                    .command(command)
+                    .instanceId(ctx.getInstanceId())
+                    .batchAppId(ctx.getBatchAppId())
+                    .resultCode("SUCCESS")
+                    .build();
+
+        } catch (Exception e) {
+            log.error("[ScheduleCommandHandler] 처리 실패: command={}, batchAppId={}", command, ctx.getBatchAppId(), e);
+            return ManagementContext.builder()
+                    .command(command)
+                    .instanceId(ctx.getInstanceId())
+                    .batchAppId(ctx.getBatchAppId())
+                    .resultCode("ERROR")
+                    .errorMessage(e.getClass().getName() + ": " + e.getMessage())
+                    .build();
+        }
+    }
+}

--- a/batch-was/src/main/resources/application.yml
+++ b/batch-was/src/main/resources/application.yml
@@ -1,6 +1,17 @@
 spring:
   profiles:
     active: oracle
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+  quartz:
+    # RAMJobStore: in-memory 저장 — WAS 재기동 시 등록된 Job이 초기화됨
+    # TODO: 운영 환경에서는 job-store-type: jdbc 로 전환하여 재기동 후에도 스케줄 복구 가능하게 할 것
+    job-store-type: memory
+    # WAS 기동 시 QuartzAutoRegistrar가 DB에서 CRON_TEXT를 읽어 직접 Job을 등록하므로 auto-startup은 true
+    auto-startup: true
+    wait-for-jobs-to-complete-on-shutdown: true
   batch:
     jdbc:
       # never: Spring Batch 메타 테이블을 자동 생성하지 않음 (Oracle은 always 설정 시 ORA-00955 오류)

--- a/spider-batch/src/main/java/com/example/spiderbatch/config/TcpServerConfig.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/config/TcpServerConfig.java
@@ -15,7 +15,7 @@ import org.springframework.context.annotation.Configuration;
  * spider-batch TCP 서버 설정.
  *
  * <p>spider-link의 {@link SpiderTcpServer}에 {@link ObjectStreamMessageCodec}과
- * {@link BatchExecCommandHandler}를 주입하여 Admin ↔ spider-batch 구간 TCP 서버를 구성한다.</p>
+ * {@link CommandDispatcher}를 주입하여 Admin ↔ spider-batch 구간 TCP 서버를 구성한다.</p>
  *
  * <p>{@code batch.tcp.enabled=false}로 설정하면 TCP 서버가 비활성화된다.
  * HTTP 전용 환경(REST API만 사용)에서 불필요한 소켓 포트를 열지 않을 때 사용한다.</p>

--- a/spider-batch/src/main/java/com/example/spiderbatch/config/TcpServerConfig.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/config/TcpServerConfig.java
@@ -1,8 +1,8 @@
 package com.example.spiderbatch.config;
 
-import com.example.spiderbatch.tcp.BatchExecCommandHandler;
 import com.example.spiderlink.infra.tcp.codec.ObjectStreamMessageCodec;
 import com.example.spiderlink.infra.tcp.handler.CommandDispatcher;
+import com.example.spiderlink.infra.tcp.handler.CommandHandler;
 import com.example.spiderlink.infra.tcp.model.ManagementContext;
 import com.example.spiderlink.infra.tcp.server.SpiderTcpServer;
 import java.util.List;
@@ -32,14 +32,17 @@ public class TcpServerConfig {
      *
      * <p>Spring이 ApplicationRunner를 구현한 Bean을 자동으로 실행하므로
      * 별도의 시작 코드 없이 애플리케이션 기동 시 서버가 자동 시작된다.</p>
+     *
+     * <p>{@code CommandHandler<ManagementContext, ManagementContext>} 타입 빈을 모두 수집하므로
+     * batch-was에서 추가 핸들러(ScheduleCommandHandler 등)를 등록하면 자동으로 포함된다.</p>
      */
     @Bean
     public SpiderTcpServer<ManagementContext, ManagementContext> batchTcpServer(
-            BatchExecCommandHandler handler) {
+            List<CommandHandler<ManagementContext, ManagementContext>> handlers) {
 
         BatchConfigurationProperties.Tcp tcp = batchProps.getTcp();
         CommandDispatcher<ManagementContext, ManagementContext> dispatcher =
-                new CommandDispatcher<>(List.of(handler));
+                new CommandDispatcher<>(handlers);
 
         return new SpiderTcpServer<>(
                 tcp.getPort(), tcp.getHandlerPoolSize(), tcp.getQueueCapacity(),

--- a/spider-batch/src/main/java/com/example/spiderbatch/domain/batch/dto/CronBatchInfo.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/domain/batch/dto/CronBatchInfo.java
@@ -1,0 +1,27 @@
+package com.example.spiderbatch.domain.batch.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @file CronBatchInfo.java
+ * @description WAS 기동 시 Quartz 자동 등록 대상 조회 결과 DTO.
+ *              FWK_WAS_EXEC_BATCH JOIN FWK_BATCH_APP 에서 CRON_TEXT가 설정된 배치 정보를 담는다.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CronBatchInfo {
+
+    /** FWK_BATCH_APP.BATCH_APP_ID */
+    private String batchAppId;
+
+    /** FWK_BATCH_APP.BATCH_APP_FILE_NAME — JobRegistry에 등록된 Job Bean 이름 */
+    private String batchAppFileName;
+
+    /** FWK_BATCH_APP.CRON_TEXT — Quartz CronTrigger에 사용할 Cron 표현식 */
+    private String cronText;
+}

--- a/spider-batch/src/main/java/com/example/spiderbatch/domain/batch/mapper/BatchAppMapper.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/domain/batch/mapper/BatchAppMapper.java
@@ -1,6 +1,8 @@
 package com.example.spiderbatch.domain.batch.mapper;
 
 import com.example.spiderbatch.domain.batch.dto.BatchAppInfo;
+import com.example.spiderbatch.domain.batch.dto.CronBatchInfo;
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -29,4 +31,13 @@ public interface BatchAppMapper {
      * @return BATCH_APP_NAME, CRON_TEXT를 담은 BatchAppInfo, 없으면 null
      */
     BatchAppInfo selectBatchAppInfo(@Param("batchAppId") String batchAppId);
+
+    /**
+     * 인스턴스에 배정된 배치 중 CRON_TEXT가 설정된 목록 조회.
+     * WAS 기동 시 Quartz 자동 등록 대상을 식별하기 위해 사용한다.
+     *
+     * @param instanceId WAS 인스턴스 ID (FWK_WAS_INSTANCE.INSTANCE_ID)
+     * @return CRON_TEXT가 있는 CronBatchInfo 목록
+     */
+    List<CronBatchInfo> selectCronBatchesByInstanceId(@Param("instanceId") String instanceId);
 }

--- a/spider-batch/src/main/resources/mapper/oracle/BatchAppMapper.xml
+++ b/spider-batch/src/main/resources/mapper/oracle/BatchAppMapper.xml
@@ -20,4 +20,17 @@
         WHERE BATCH_APP_ID = #{batchAppId}
     </select>
 
+    <!-- 인스턴스에 배정된 배치 중 CRON_TEXT가 설정된 목록 조회 — WAS 기동 시 Quartz 자동 등록 대상 -->
+    <select id="selectCronBatchesByInstanceId"
+            resultType="com.example.spiderbatch.domain.batch.dto.CronBatchInfo">
+        SELECT a.BATCH_APP_ID        AS batchAppId,
+               a.BATCH_APP_FILE_NAME AS batchAppFileName,
+               a.CRON_TEXT           AS cronText
+        FROM   FWK_BATCH_APP a
+               JOIN FWK_WAS_EXEC_BATCH w ON a.BATCH_APP_ID = w.BATCH_APP_ID
+        WHERE  w.INSTANCE_ID = #{instanceId}
+          AND  w.USE_YN      = 'Y'
+          AND  a.CRON_TEXT   IS NOT NULL
+    </select>
+
 </mapper>

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/model/ManagementContext.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/model/ManagementContext.java
@@ -48,4 +48,7 @@ public class ManagementContext implements Serializable, HasCommand {
 
     /** 오류 메시지 (실패 시 채워짐, 예외 클래스명 + 메시지 포맷 권장) */
     private String errorMessage;
+
+    /** Cron 표현식 (SCHEDULE_CRON_UPDATE 커맨드 시 새 스케줄 값) */
+    private String cronText;
 }


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

Closes #60

## ✨ 변경 사항 (Changes)

- **spider-link**: `ManagementContext`에 `cronText` 필드 추가 (SCHEDULE_CRON_UPDATE 커맨드 전달용)
- **spider-batch**: `TcpServerConfig`를 `List<CommandHandler>` 주입 방식으로 변경 → batch-was에서 핸들러 확장 가능, `CronBatchInfo` DTO 및 `selectCronBatchesByInstanceId` 쿼리 추가
- **batch-was**:
  - Quartz(RAMJobStore) + Redisson 분산 락 도입
  - `RedisDistributedLockService`: `batch:lock:{batchAppId}` 키로 RLock 관리
  - `BatchJobQuartzTrigger`: 락 획득 → `BatchExecuteService.execute()` → finally 락 해제
  - `SchedulerManagementService`: registerJob / reschedule / deleteJob / triggerNow
  - `QuartzAutoRegistrar`: WAS 기동 시 FWK_BATCH_APP CRON_TEXT 기반 Quartz 자동 등록
  - `ScheduleCommandHandler`: SCHEDULE_TRIGGER / SCHEDULE_CRON_UPDATE TCP 커맨드 처리
  - docker-compose Redis 컨테이너, .env.example, application.yml 설정 추가
- **admin**:
  - `POST /{batchAppId}/schedule/trigger` — 즉시 실행 API
  - `PUT /{batchAppId}/schedule/cron` — Cron 표현식 변경 API (DB 업데이트 + TCP 전송)
  - `ScheduleTriggerRequest`, `ScheduleCronUpdateRequest` DTO 신규 생성
  - `BatchExecService.triggerSchedule()` / `updateScheduleCron()` 추가
  - `BatchAppService.updateCronText()` 추가 (CRON_TEXT 단독 업데이트)

## 🛠 기술적 의사결정

- **분산 락 위치**: `BatchExecuteService`는 spider-batch 라이브러리 소속이므로 Redis 의존성을 라이브러리에 추가하지 않고, batch-was의 Quartz Job 레이어(`BatchJobQuartzTrigger`)에서만 락 처리
- **TcpServerConfig 확장**: 단일 핸들러 주입 → `List<CommandHandler>` 주입으로 변경하여 spider-batch를 최소 수정하면서 batch-was에서 `ScheduleCommandHandler`를 자동 등록
- **Quartz JobStore**: POC는 RAMJobStore(in-memory) 사용, 운영 환경 JDBC JobStore 전환 TODO 주석 명시

## 🧪 테스트

- [x] batch-was 기동 시 `Quartz 자동 등록 완료: N건` 로그 확인
- [x] CRON_TEXT `0/30 * * * * ?` 설정 후 30초 주기 자동 실행 및 FWK_BATCH_HIS 이력 기록 확인
- [x] Admin `POST /schedule/trigger` 즉시 실행 API 호출 시 batch-was에서 triggerJob 정상 처리

## ⚠️ 고려 및 주의 사항

- Redis가 기동되어 있지 않으면 batch-was 실행 시 연결 오류 발생 — `docker compose up redis -d` 선행 필요
- 현재 Redis는 single-node(SPOF) — 운영 환경에서는 Redis Sentinel 또는 Cluster HA 구성 필요 (코드 내 TODO 주석 명시)
- Quartz RAMJobStore 사용으로 WAS 재기동 시 스케줄이 메모리에서 소실되나, `QuartzAutoRegistrar`가 기동 시 DB 재조회하여 자동 복구

## 🔗 참고 사항

- 빌드 순서: spider-link → spider-batch → batch-was / admin
- 선행 이슈: #37