### PR TITLE
✨ feat/#247-고정길이전문 한글 파싱 및 userGrade 필드 타입 수정

### DIFF
--- a/admin/docs/sql/oracle/04_alter_tables.sql
+++ b/admin/docs/sql/oracle/04_alter_tables.sql
@@ -753,3 +753,16 @@ WHEN NOT MATCHED THEN
     VALUES ('was_config', 'BT03.MANAGEMENT_SERVER_PORT', 'biz-transfer 관리 포트', 'Admin pool/reload API 대상 포트', 'N', '19280', 'system');
 
 COMMIT;
+
+-- ─────────────────────────────────────────────────────────────────
+-- feat/#247: CORE_USER_*_RES.userGrade C,1 → K,6 변경
+--   mock-core LegacyTcpServer가 EUC-KR 한글(예: "개인")을 writeK(6)으로 기록하도록
+--   핸들러 수정에 맞춰 메타데이터도 동일하게 변경한다.
+-- ─────────────────────────────────────────────────────────────────
+UPDATE FWK_MESSAGE_FIELD
+   SET DATA_TYPE = 'K', DATA_LENGTH = 6, LAST_UPDATE_DTIME = TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS')
+ WHERE ORG_ID = 'DEMO'
+   AND MESSAGE_ID IN ('CORE_USER_AUTH_RES', 'CORE_USER_QUERY_RES')
+   AND MESSAGE_FIELD_ID = 'userGrade';
+
+COMMIT;

--- a/admin/src/test/java/com/example/admin_demo/domain/component/controller/ComponentControllerTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/component/controller/ComponentControllerTest.java
@@ -269,7 +269,7 @@ class ComponentControllerTest {
         void delete_notFound_returns404() throws Exception {
             willThrow(new NotFoundException("componentId: NOT-EXIST"))
                     .given(componentService)
-                    .delete("NOT-EXIST");
+                    .delete(anyString(), anyString());
 
             mockMvc.perform(delete(BASE_URL + "/NOT-EXIST").with(csrf())).andExpect(status().isNotFound());
         }

--- a/admin/src/test/java/com/example/admin_demo/domain/component/controller/ComponentControllerTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/component/controller/ComponentControllerTest.java
@@ -260,6 +260,8 @@ class ComponentControllerTest {
         @WithMockUser(authorities = "COMPONENT:W")
         @DisplayName("[삭제] 존재하는 ID 삭제 시 200을 반환해야 한다")
         void delete_found_returns200() throws Exception {
+            given(componentService.getById("CMP-001")).willReturn(buildResponse("CMP-001"));
+
             mockMvc.perform(delete(BASE_URL + "/CMP-001").with(csrf())).andExpect(status().isOk());
         }
 
@@ -267,6 +269,7 @@ class ComponentControllerTest {
         @WithMockUser(authorities = "COMPONENT:W")
         @DisplayName("[삭제] 존재하지 않는 ID 삭제 시 404를 반환해야 한다")
         void delete_notFound_returns404() throws Exception {
+            given(componentService.getById("NOT-EXIST")).willReturn(buildResponse("NOT-EXIST"));
             willThrow(new NotFoundException("componentId: NOT-EXIST"))
                     .given(componentService)
                     .delete(anyString(), anyString());

--- a/admin/src/test/java/com/example/admin_demo/domain/component/service/ComponentServiceTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/component/service/ComponentServiceTest.java
@@ -223,7 +223,7 @@ class ComponentServiceTest {
         void exists_deletesParamsThenComponent() {
             given(componentMapper.countById("CMP-001")).willReturn(1);
 
-            componentService.delete("CMP-001");
+            componentService.delete("CMP-001", "TYPE-A");
 
             then(componentMapper).should().deleteParamsByComponentId("CMP-001");
             then(componentMapper).should().deleteById("CMP-001");
@@ -234,7 +234,7 @@ class ComponentServiceTest {
         void notExists_throwsNotFoundException() {
             given(componentMapper.countById("NOT-EXIST")).willReturn(0);
 
-            assertThatThrownBy(() -> componentService.delete("NOT-EXIST")).isInstanceOf(NotFoundException.class);
+            assertThatThrownBy(() -> componentService.delete("NOT-EXIST", "TYPE-A")).isInstanceOf(NotFoundException.class);
         }
     }
 

--- a/admin/src/test/java/com/example/admin_demo/domain/component/service/ComponentServiceTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/component/service/ComponentServiceTest.java
@@ -234,7 +234,8 @@ class ComponentServiceTest {
         void notExists_throwsNotFoundException() {
             given(componentMapper.countById("NOT-EXIST")).willReturn(0);
 
-            assertThatThrownBy(() -> componentService.delete("NOT-EXIST", "TYPE-A")).isInstanceOf(NotFoundException.class);
+            assertThatThrownBy(() -> componentService.delete("NOT-EXIST", "TYPE-A"))
+                    .isInstanceOf(NotFoundException.class);
         }
     }
 

--- a/admin/src/test/java/com/example/admin_demo/domain/service/controller/FwkServiceControllerTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/service/controller/FwkServiceControllerTest.java
@@ -257,6 +257,8 @@ class FwkServiceControllerTest {
         @WithMockUser(authorities = "FWK_SERVICE:W")
         @DisplayName("[삭제] 존재하는 ID 삭제 시 200을 반환해야 한다")
         void delete_found_returns200() throws Exception {
+            given(fwkServiceService.getById("SVC-001")).willReturn(buildDetailResponse("SVC-001"));
+
             mockMvc.perform(delete(BASE_URL + "/SVC-001").with(csrf())).andExpect(status().isOk());
         }
 
@@ -264,6 +266,7 @@ class FwkServiceControllerTest {
         @WithMockUser(authorities = "FWK_SERVICE:W")
         @DisplayName("[삭제] 존재하지 않는 ID 삭제 시 404를 반환해야 한다")
         void delete_notFound_returns404() throws Exception {
+            given(fwkServiceService.getById("NOT-EXIST")).willReturn(buildDetailResponse("NOT-EXIST"));
             willThrow(new NotFoundException("serviceId: NOT-EXIST"))
                     .given(fwkServiceService)
                     .delete(anyString(), anyString());

--- a/admin/src/test/java/com/example/admin_demo/domain/service/controller/FwkServiceControllerTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/service/controller/FwkServiceControllerTest.java
@@ -266,7 +266,7 @@ class FwkServiceControllerTest {
         void delete_notFound_returns404() throws Exception {
             willThrow(new NotFoundException("serviceId: NOT-EXIST"))
                     .given(fwkServiceService)
-                    .delete("NOT-EXIST");
+                    .delete(anyString(), anyString());
 
             mockMvc.perform(delete(BASE_URL + "/NOT-EXIST").with(csrf())).andExpect(status().isNotFound());
         }

--- a/admin/src/test/java/com/example/admin_demo/domain/service/service/FwkServiceServiceTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/service/service/FwkServiceServiceTest.java
@@ -190,7 +190,7 @@ class FwkServiceServiceTest {
         void delete_exists_deletesInFkOrder() {
             given(fwkServiceMapper.countById("SVC-001")).willReturn(1);
 
-            fwkServiceService.delete("SVC-001");
+            fwkServiceService.delete("SVC-001", "TYPE-A");
 
             org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(fwkServiceRelationMapper, fwkServiceMapper);
             inOrder.verify(fwkServiceRelationMapper).deleteParamsByServiceId("SVC-001");
@@ -203,7 +203,7 @@ class FwkServiceServiceTest {
         void notExists_throwsNotFoundException() {
             given(fwkServiceMapper.countById("NOT-EXIST")).willReturn(0);
 
-            assertThatThrownBy(() -> fwkServiceService.delete("NOT-EXIST")).isInstanceOf(NotFoundException.class);
+            assertThatThrownBy(() -> fwkServiceService.delete("NOT-EXIST", "TYPE-A")).isInstanceOf(NotFoundException.class);
             then(fwkServiceMapper).should(never()).deleteById(any());
         }
     }

--- a/admin/src/test/java/com/example/admin_demo/domain/service/service/FwkServiceServiceTest.java
+++ b/admin/src/test/java/com/example/admin_demo/domain/service/service/FwkServiceServiceTest.java
@@ -203,7 +203,8 @@ class FwkServiceServiceTest {
         void notExists_throwsNotFoundException() {
             given(fwkServiceMapper.countById("NOT-EXIST")).willReturn(0);
 
-            assertThatThrownBy(() -> fwkServiceService.delete("NOT-EXIST", "TYPE-A")).isInstanceOf(NotFoundException.class);
+            assertThatThrownBy(() -> fwkServiceService.delete("NOT-EXIST", "TYPE-A"))
+                    .isInstanceOf(NotFoundException.class);
             then(fwkServiceMapper).should(never()).deleteById(any());
         }
     }

--- a/demo/bizApp/mock-core/src/main/java/com/example/mockcore/handler/CoreUserAuthHandler.java
+++ b/demo/bizApp/mock-core/src/main/java/com/example/mockcore/handler/CoreUserAuthHandler.java
@@ -16,7 +16,7 @@ import java.util.Map;
  *
  * <p>REQ: COMMAND(C,20) + REQUEST_ID(C,36) + userId(C,20) + password(C,20)
  * RES: SUCCESS(C,1) + ERROR_MSG(K,200) + userId(C,20) + userName(K,60)
- *      + userGrade(C,1) + lastLoginDtime(C,14)</p>
+ *      + userGrade(K,6) + lastLoginDtime(C,14)</p>
  */
 @Slf4j
 @Component
@@ -48,7 +48,7 @@ public class CoreUserAuthHandler implements LegacyCoreHandler {
             writer.writeK("", 200);
             writer.writeC(str(info, "userId"), 20);
             writer.writeK(str(info, "userName"), 60);
-            writer.writeC(str(info, "userGrade"), 1);
+            writer.writeK(str(info, "userGrade"), 6);
             writer.writeC(str(info, "lastLoginDtime"), 14);
         } catch (Exception e) {
             log.warn("[CORE_USER_AUTH] 인증 실패 — {}", e.getMessage());
@@ -57,7 +57,7 @@ public class CoreUserAuthHandler implements LegacyCoreHandler {
             writer.writeK(e.getMessage(), 200);
             writer.writeC("", 20);
             writer.writeK("", 60);
-            writer.writeC("", 1);
+            writer.writeK("", 6);
             writer.writeC("", 14);
         }
         return writer.toBytes();

--- a/demo/bizApp/mock-core/src/main/java/com/example/mockcore/handler/CoreUserQueryHandler.java
+++ b/demo/bizApp/mock-core/src/main/java/com/example/mockcore/handler/CoreUserQueryHandler.java
@@ -16,7 +16,7 @@ import java.util.Map;
  *
  * <p>REQ: COMMAND(C,20) + REQUEST_ID(C,36) + userId(C,20)
  * RES: SUCCESS(C,1) + ERROR_MSG(K,200) + userId(C,20) + userName(K,60)
- *      + userGrade(C,1) + lastLoginDtime(C,14)</p>
+ *      + userGrade(K,6) + lastLoginDtime(C,14)</p>
  */
 @Slf4j
 @Component
@@ -47,7 +47,7 @@ public class CoreUserQueryHandler implements LegacyCoreHandler {
             writer.writeK("", 200);
             writer.writeC(str(info, "userId"), 20);
             writer.writeK(str(info, "userName"), 60);
-            writer.writeC(str(info, "userGrade"), 1);
+            writer.writeK(str(info, "userGrade"), 6);
             writer.writeC(str(info, "lastLoginDtime"), 14);
         } catch (Exception e) {
             log.warn("[CORE_USER_QUERY] 조회 실패 — {}", e.getMessage());
@@ -56,7 +56,7 @@ public class CoreUserQueryHandler implements LegacyCoreHandler {
             writer.writeK(e.getMessage(), 200);
             writer.writeC("", 20);
             writer.writeK("", 60);
-            writer.writeC("", 1);
+            writer.writeK("", 6);
             writer.writeC("", 14);
         }
         return writer.toBytes();

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/biz/TcpCallBiz.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/biz/TcpCallBiz.java
@@ -38,6 +38,10 @@ public class TcpCallBiz implements Biz {
     @Value("${tcp.ext.port:19100}")
     private int port;
 
+    /** 기관 ID — FWK_MESSAGE 전문 구조 조회 키 (application.yml app.org-id) */
+    @Value("${app.org-id:DEMO}")
+    private String orgId;
+
     /**
      * 외부시스템으로 TCP 전문을 송신하고 응답 페이로드를 반환한다.
      *
@@ -56,7 +60,7 @@ public class TcpCallBiz implements Biz {
 
         log.debug("[TcpCallBiz] TCP 호출: host={}:{}, command={}", host, port, methodName);
 
-        JsonCommandResponse response = tcpClient.sendJson(host, port, req);
+        JsonCommandResponse response = tcpClient.send(host, port, orgId, req);
         if (!response.isSuccess()) {
             throw new RuntimeException("외부시스템 TCP 호출 실패: command=" + methodName
                     + ", error=" + response.getError());

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/handler/MetaDrivenCommandHandler.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/handler/MetaDrivenCommandHandler.java
@@ -186,8 +186,9 @@ public class MetaDrivenCommandHandler implements CommandHandler<JsonCommandReque
 
     private String toCamelCase(String columnName) {
         if (columnName == null) return null;
+        // "_" 없으면 이미 camelCase 또는 단일 소문자 — 원본 유지
+        if (!columnName.contains("_")) return columnName;
         String lower = columnName.toLowerCase();
-        if (!lower.contains("_")) return lower;
         String[] parts = lower.split("_");
         StringBuilder sb = new StringBuilder(parts[0]);
         for (int i = 1; i < parts.length; i++) {

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/parser/FixedLengthParser.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/parser/FixedLengthParser.java
@@ -23,11 +23,11 @@ import org.springframework.stereotype.Component;
  *
  * <h4>지원 데이터 타입</h4>
  * <pre>
- * C (문자)   → String (trim 없이 원본 유지)
+ * C (문자)   → String (trailing 공백 제거 — 참고소스 FixedLengthMessageParser 동일)
  * N (숫자)   → String (scale > 0 이면 소수점 포함)
  * H (헥사)   → String (hex 문자열)
  * B (바이너리)→ Integer (4byte) / Short (2byte)
- * K (한글)   → String (EUC-KR 디코딩)
+ * K (한글)   → String (EUC-KR 디코딩 후 trailing 공백 제거)
  * </pre>
  */
 @Slf4j
@@ -159,9 +159,9 @@ public class FixedLengthParser {
         };
     }
 
-    /** C 타입: trim 없이 원본 문자열 반환 */
+    /** C 타입: trailing 공백 제거 후 반환 (참고소스 FixedLengthMessageParser 동일) */
     private String readString(byte[] bytes, int offset, int len) {
-        return new String(bytes, offset, len);
+        return new String(bytes, offset, len).stripTrailing();
     }
 
     /**
@@ -206,13 +206,13 @@ public class FixedLengthParser {
     }
 
     /**
-     * K 타입: 한글(EUC-KR) 바이트 배열을 문자열로 디코딩.
-     * 실제 운영 환경에 따라 charset 이 다를 수 있으므로 필요 시 수정.
+     * K 타입: 한글(EUC-KR) 바이트 배열을 문자열로 디코딩 후 trailing 공백 제거.
+     * 참고소스 FixedLengthMessageParser.removeRightFiller 동일 처리.
      */
     private String readKorean(byte[] bytes, int offset, int len) {
         byte[] buf = new byte[len];
         System.arraycopy(bytes, offset, buf, 0, len);
-        return new String(buf, Charset.forName("EUC-KR"));
+        return new String(buf, Charset.forName("EUC-KR")).stripTrailing();
     }
 
     // ── serialize (Map → byte[]) ─────────────────────────────

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/parser/FixedLengthParser.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/parser/FixedLengthParser.java
@@ -34,6 +34,9 @@ import org.springframework.stereotype.Component;
 @Component
 public class FixedLengthParser {
 
+    /** EUC-KR 문자셋 — K 타입 인코딩/디코딩 공통 사용 */
+    private static final Charset EUC_KR = Charset.forName("EUC-KR");
+
     /**
      * byte[] 를 MessageStructure 기반으로 파싱하여 Map으로 반환한다.
      *
@@ -210,9 +213,7 @@ public class FixedLengthParser {
      * 참고소스 FixedLengthMessageParser.removeRightFiller 동일 처리.
      */
     private String readKorean(byte[] bytes, int offset, int len) {
-        byte[] buf = new byte[len];
-        System.arraycopy(bytes, offset, buf, 0, len);
-        return new String(buf, Charset.forName("EUC-KR")).stripTrailing();
+        return new String(bytes, offset, len, EUC_KR).stripTrailing();
     }
 
     // ── serialize (Map → byte[]) ─────────────────────────────
@@ -314,7 +315,7 @@ public class FixedLengthParser {
 
     private byte[] toEucKrBytes(String str) {
         try {
-            return str.getBytes(Charset.forName("EUC-KR"));
+            return str.getBytes(EUC_KR);
         } catch (Exception e) {
             log.warn("[FixedLengthParser] EUC-KR 인코딩 실패: str={}", str);
             return str.getBytes();

--- a/spider-link/src/test/java/com/example/spiderlink/infra/tcp/parser/FixedLengthParserTest.java
+++ b/spider-link/src/test/java/com/example/spiderlink/infra/tcp/parser/FixedLengthParserTest.java
@@ -38,9 +38,9 @@ class FixedLengthParserTest {
         // when
         Map<String, Object> result = parser.parse(structure, bytes);
 
-        // then
-        assertThat(result.get("trxId")).isEqualTo("DEMO_AUTH_LOGIN     ");
-        assertThat(result.get("userId")).isEqualTo("user01    ");
+        // then — trailing 공백 제거됨 (참고소스 FixedLengthMessageParser 동일)
+        assertThat(result.get("trxId")).isEqualTo("DEMO_AUTH_LOGIN");
+        assertThat(result.get("userId")).isEqualTo("user01");
         assertThat(result.get("amt")).isEqualTo("0000001000");
     }
 
@@ -116,7 +116,7 @@ class FixedLengthParserTest {
         Map<String, Object> result = parser.parse(structure, bytes);
 
         // then
-        assertThat(result.get("userId")).isEqualTo("user01    ");
+        assertThat(result.get("userId")).isEqualTo("user01");
 
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> items = (List<Map<String, Object>>) result.get("items");
@@ -150,9 +150,9 @@ class FixedLengthParserTest {
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> codes = (List<Map<String, Object>>) result.get("codes");
         assertThat(codes).hasSize(3);
-        assertThat(codes.get(0).get("code")).isEqualTo("AAA  ");
-        assertThat(codes.get(1).get("code")).isEqualTo("BBB  ");
-        assertThat(codes.get(2).get("code")).isEqualTo("CCC  ");
+        assertThat(codes.get(0).get("code")).isEqualTo("AAA");
+        assertThat(codes.get(1).get("code")).isEqualTo("BBB");
+        assertThat(codes.get(2).get("code")).isEqualTo("CCC");
     }
 
     @Test


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

Closes #247

## ✨ 변경 사항 (Changes)

- **TcpCallBiz**: `sendJson()` → `send()` 변경으로 `FWK_MESSAGE.MESSAGE_TYPE='F'` 시 고정길이 전문 자동 분기
- **FixedLengthParser**: C/K 타입 trailing 공백 제거, K타입 EUC-KR 디코딩 추가 (참고소스 `FixedLengthMessageParser` 기준)
- **MetaDrivenCommandHandler**: `toCamelCase`에서 `_` 없는 camelCase 키(`userName`, `userGrade` 등)가 소문자로 변환되는 버그 수정
- **CoreUserAuthHandler / CoreUserQueryHandler**: `userGrade` 필드 `writeC(1)` → `writeK(6)` 변경 (한글 "개인" 4바이트 대응)
- **04_alter_tables.sql**: `DEMO CORE_USER_AUTH_RES / CORE_USER_QUERY_RES.userGrade` `C,1 → K,6` ALTER SQL 추가
- **FixedLengthParserTest**: trailing 공백 제거 동작 반영하여 기댓값 업데이트

## 🛠 기술적 의사결정

- `toCamelCase` 수정: `_` 포함 없는 키는 Oracle 대문자 컬럼이 아닌 이미 camelCase로 간주하여 원본 유지. 기존 SQL SELECT 결과(`USER_ID` → `userId`)는 그대로 동작
- FixedLengthParser K타입: EUC-KR로 디코딩 후 `stripTrailing()`으로 공백 제거 — 참고소스(`FixedLengthMessageParser`) 동일 방식

## 🧪 테스트

- [x] `FixedLengthParserTest` 6개 단위 테스트 통과 (`spider-link clean install`)
- [x] E2E 검증: `POST /api/auth/login` → `userName=김하나`, `userGrade=개인` 정상 반환 확인
- [x] JWT payload 디코딩으로 한글 정상 인코딩 확인

## ⚠️ 고려 및 주의 사항

- `DEMO` 기관 DB의 `FWK_MESSAGE_FIELD` 업데이트 필요: `04_alter_tables.sql`의 `feat/#247` 섹션 SQL을 DB에서 직접 실행해야 함 (쿼리 수행은 개발자가 DB에서 직접 수행)