### PR TITLE
✨ feat/#24-긴급공지 다국어 지원 및 Admin→biz-channel TCP 구조 정비

### DIFF
--- a/admin/.env.example
+++ b/admin/.env.example
@@ -52,6 +52,11 @@ CMS_APP_BASE_URL=http://localhost:3000/cms
 CMS_DEPLOY_PUSH_URL=http://133.186.135.23/cms/api/deploy/push
 CMS_DEPLOY_SECRET=your-deploy-secret-token
 
+# === biz-channel TCP (Admin → 긴급공지 커맨드 전송) ===
+# biz-channel이 spider-link를 내장하여 TCP 서버를 직접 수신한다 (standalone spider-link 불필요)
+BIZ_CHANNEL_TCP_HOST=localhost
+BIZ_CHANNEL_TCP_PORT=19400
+
 # === Test (E2E/API) ===
 # E2E 테스트 계정은 e2e/docker/e2e-seed.sql에서 Oracle 컨테이너에 직접 시드.
 # e2e/fixtures/test-accounts.ts 참조. 별도 환경변수 불필요.

--- a/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/dto/EmergencyNoticeHistoryResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/emergencynotice/dto/EmergencyNoticeHistoryResponse.java
@@ -48,6 +48,18 @@ public class EmergencyNoticeHistoryResponse {
     private String contentKo;
 
     /**
+     * 영어 공지 제목 (같은 VERSION의 EMERGENCY_EN 행 PROPERTY_DESC).
+     * 배포·배포종료·내용수정 구분의 상세 표시에 사용된다.
+     */
+    private String titleEn;
+
+    /**
+     * 영어 공지 내용 (같은 VERSION의 EMERGENCY_EN 행 DEFAULT_VALUE).
+     * _$BR 마커 포함 가능. 배포·배포종료·내용수정 구분의 상세 표시에 사용된다.
+     */
+    private String contentEn;
+
+    /**
      * 닫기 버튼 노출 여부 (같은 VERSION의 CLOSEABLE_YN 행 DEFAULT_VALUE, Y/N).
      * 설정 변경 구분의 상세 표시에 사용된다.
      */

--- a/admin/src/main/java/com/example/admin_demo/infra/tcp/adapter/DemoBackendAdapter.java
+++ b/admin/src/main/java/com/example/admin_demo/infra/tcp/adapter/DemoBackendAdapter.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
  *
  * <p>JsonCommandRequest를 4바이트 길이 프리픽스 + UTF-8 JSON 형식으로 전송한다.</p>
  *
- * <p>biz-channel은 spider-link를 내장하여 TCP 서버(기본 9997)를 직접 운영한다.
+ * <p>biz-channel은 spider-link를 내장하여 TCP 서버(기본 19400)를 직접 운영한다.
  * standalone spider-link 프로세스 없이 biz-channel 기동만으로 통신이 가능하다.</p>
  *
  * <p>설정값 {@code tcp.demo-backend.host/port}는 biz-channel 내장 TCP 서버 주소를 가리킨다.</p>
@@ -39,8 +39,7 @@ public class DemoBackendAdapter implements ManagementAdapter<JsonCommandRequest,
     }
 
     /**
-     * spider-link TCP 서버에 JsonCommandRequest를 전송한다.
-     * spider-link가 demo/backend(9997)로 프록시한다.
+     * biz-channel 내장 TCP 서버(19400)에 JsonCommandRequest를 전송한다.
      *
      * @param command 실행 커맨드 (NOTICE_SYNC, NOTICE_END, PING 등)
      * @param req     JsonCommandRequest 인스턴스

--- a/admin/src/main/java/com/example/admin_demo/infra/tcp/adapter/DemoBackendAdapter.java
+++ b/admin/src/main/java/com/example/admin_demo/infra/tcp/adapter/DemoBackendAdapter.java
@@ -10,15 +10,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
- * Admin → spider-link 간 TCP 통신 어댑터.
+ * Admin → biz-channel 내장 TCP 서버 통신 어댑터.
  *
  * <p>JsonCommandRequest를 4바이트 길이 프리픽스 + UTF-8 JSON 형식으로 전송한다.</p>
  *
- * <p>분리 이전: Admin이 직접 demo/backend(9997)로 JSON TCP 전송<br>
- * 분리 이후:  Admin이 spider-link(9996)로 JSON TCP 전송 →
- *             spider-link가 demo/backend(9997)로 프록시</p>
+ * <p>biz-channel은 spider-link를 내장하여 TCP 서버(기본 9997)를 직접 운영한다.
+ * standalone spider-link 프로세스 없이 biz-channel 기동만으로 통신이 가능하다.</p>
  *
- * <p>설정값 {@code tcp.demo-backend.host/port}는 실제로 spider-link 주소를 가리킨다.</p>
+ * <p>설정값 {@code tcp.demo-backend.host/port}는 biz-channel 내장 TCP 서버 주소를 가리킨다.</p>
  */
 @Slf4j
 @Component
@@ -30,10 +29,10 @@ public class DemoBackendAdapter implements ManagementAdapter<JsonCommandRequest,
     @Value("${tcp.demo-backend.host:localhost}")
     private String demoBackendHost;
 
-    @Value("${tcp.demo-backend.port:9996}")
+    @Value("${tcp.demo-backend.port:19400}")
     private int demoBackendPort;
 
-    /** spider-link는 항상 별도 프로세스이므로 로컬 실행 없음 */
+    /** biz-channel은 별도 프로세스이므로 로컬 실행 없음 */
     @Override
     public boolean isLocal() {
         return false;
@@ -58,7 +57,7 @@ public class DemoBackendAdapter implements ManagementAdapter<JsonCommandRequest,
             return tcpClient.sendJson(demoBackendHost, demoBackendPort, req);
         } catch (IOException e) {
             log.error(
-                    "[DemoBackendAdapter] TCP 전송 실패: command={}, host={}:{}, error={} — spider-link가 기동 중인지 확인하세요.",
+                    "[DemoBackendAdapter] TCP 전송 실패: command={}, host={}:{}, error={} — biz-channel이 기동 중인지 확인하세요.",
                     command,
                     demoBackendHost,
                     demoBackendPort,

--- a/admin/src/main/java/com/example/admin_demo/infra/tcp/handler/EmergencyNoticeSyncCommandHandler.java
+++ b/admin/src/main/java/com/example/admin_demo/infra/tcp/handler/EmergencyNoticeSyncCommandHandler.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
  * NOTICE_SYNC / NOTICE_END 커맨드 핸들러.
  *
  * <p>Admin TCP 서버(9999)에 수신된 긴급공지 커맨드를
- * DemoBackendAdapter를 통해 biz-channel 내장 TCP 서버(9997)로 중계한다.</p>
+ * DemoBackendAdapter를 통해 biz-channel 내장 TCP 서버(19400)로 중계한다.</p>
  */
 @Slf4j
 @Component

--- a/admin/src/main/java/com/example/admin_demo/infra/tcp/handler/EmergencyNoticeSyncCommandHandler.java
+++ b/admin/src/main/java/com/example/admin_demo/infra/tcp/handler/EmergencyNoticeSyncCommandHandler.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
  * NOTICE_SYNC / NOTICE_END 커맨드 핸들러.
  *
  * <p>Admin TCP 서버(9999)에 수신된 긴급공지 커맨드를
- * DemoBackendAdapter를 통해 demo/backend TCP 서버(9997)로 중계한다.</p>
+ * DemoBackendAdapter를 통해 biz-channel 내장 TCP 서버(9997)로 중계한다.</p>
  */
 @Slf4j
 @Component

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -214,7 +214,7 @@ spiderlink:
   reload-url: ${SPIDERLINK_RELOAD_URL:http://localhost:8082/api/internal/sql/reload}
 
 # TCP 통신 설정
-# Admin TCP 서버(9999), batch-was TCP 서버(9998), biz-channel 내장 TCP 서버(9997)
+# Admin TCP 서버(9999), batch-was TCP 서버(9998), biz-channel 내장 TCP 서버(19400)
 tcp:
   server:
     port: ${TCP_SERVER_PORT:9999}

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -214,13 +214,13 @@ spiderlink:
   reload-url: ${SPIDERLINK_RELOAD_URL:http://localhost:8082/api/internal/sql/reload}
 
 # TCP 통신 설정
-# Admin TCP 서버(9999), batch-was TCP 서버(9998), spider-link TCP 서버(9996) → demo/backend(9997)
+# Admin TCP 서버(9999), batch-was TCP 서버(9998), biz-channel 내장 TCP 서버(9997)
 tcp:
   server:
     port: ${TCP_SERVER_PORT:9999}
   batch-was:
     port: ${BATCH_WAS_TCP_PORT:9998}
-  # 실제 대상은 spider-link(9996) — spider-link가 demo/backend(9997)로 프록시한다
+  # 대상은 biz-channel 내장 TCP 서버(9997) — spider-link를 내장한 biz-channel이 직접 수신
   demo-backend:
-    host: ${SPIDER_LINK_TCP_HOST:localhost}
-    port: ${SPIDER_LINK_TCP_PORT:9996}
+    host: ${BIZ_CHANNEL_TCP_HOST:localhost}
+    port: ${BIZ_CHANNEL_TCP_PORT:19400}

--- a/admin/src/main/resources/mapper/oracle/emergencynotice/EmergencyNoticeDeployMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/emergencynotice/EmergencyNoticeDeployMapper.xml
@@ -51,7 +51,7 @@
     -->
     <select id="selectHistory" resultType="com.example.admin_demo.domain.emergencynotice.dto.EmergencyNoticeHistoryResponse">
         SELECT version, reason, lastUpdateDtime, lastUpdateUserId,
-               titleKo, contentKo, closeableYn, hideTodayYn
+               titleKo, contentKo, titleEn, contentEn, closeableYn, hideTodayYn
         FROM (
             SELECT a.*, ROWNUM AS rnum
             FROM (
@@ -61,6 +61,8 @@
                        h_use.LAST_UPDATE_USER_ID AS lastUpdateUserId,
                        h_ko.PROPERTY_DESC        AS titleKo,
                        h_ko.DEFAULT_VALUE        AS contentKo,
+                       h_en.PROPERTY_DESC        AS titleEn,
+                       h_en.DEFAULT_VALUE        AS contentEn,
                        h_cl.DEFAULT_VALUE        AS closeableYn,
                        h_ht.DEFAULT_VALUE        AS hideTodayYn
                 FROM   FWK_PROPERTY_HISTORY h_use
@@ -68,6 +70,10 @@
                        ON h_ko.PROPERTY_GROUP_ID = 'notice'
                       AND h_ko.PROPERTY_ID       = 'EMERGENCY_KO'
                       AND h_ko.VERSION           = h_use.VERSION
+                LEFT JOIN FWK_PROPERTY_HISTORY h_en
+                       ON h_en.PROPERTY_GROUP_ID = 'notice'
+                      AND h_en.PROPERTY_ID       = 'EMERGENCY_EN'
+                      AND h_en.VERSION           = h_use.VERSION
                 LEFT JOIN FWK_PROPERTY_HISTORY h_cl
                        ON h_cl.PROPERTY_GROUP_ID = 'notice'
                       AND h_cl.PROPERTY_ID       = 'CLOSEABLE_YN'

--- a/admin/src/main/resources/templates/pages/emergency-notice-deploy-manage/emergency-notice-deploy-manage-script.html
+++ b/admin/src/main/resources/templates/pages/emergency-notice-deploy-manage/emergency-notice-deploy-manage-script.html
@@ -212,23 +212,35 @@
                 return '<div class="d-flex align-items-center flex-wrap gap-1">' + clBadge + htBadge + '</div>';
             }
 
-            /* 배포·배포종료·내용수정 — 공지 내용 미리보기 */
-            var title   = row.titleKo   || '';
+            /* 배포·배포종료·내용수정 — 한국어·영어 공지 내용 미리보기 */
+            var titleKo   = row.titleKo   || '';
+            var titleEn   = row.titleEn   || '';
             // _$BR 마커를 공백으로 치환하여 한 줄 미리보기로 표시
-            var content = (row.contentKo || '').replace(/_\$BR/g, ' ');
+            var contentKo = (row.contentKo || '').replace(/_\$BR/g, ' ');
+            var contentEn = (row.contentEn || '').replace(/_\$BR/g, ' ');
 
-            if (!title && !content) {
+            if (!titleKo && !contentKo && !titleEn && !contentEn) {
                 return '<span class="text-body-secondary small">(미작성)</span>';
             }
 
             var parts = [];
-            if (title) {
+            if (titleKo) {
                 parts.push('<span class="fw-semibold small text-body">'
-                    + HtmlUtils.escape(this.truncate(title, 30)) + '</span>');
+                    + '<span class="badge bg-secondary-subtle text-secondary-emphasis border me-1" style="font-size:0.65em;">KO</span>'
+                    + HtmlUtils.escape(this.truncate(titleKo, 28)) + '</span>');
             }
-            if (content) {
+            if (contentKo) {
                 parts.push('<span class="text-body-secondary small">'
-                    + HtmlUtils.escape(this.truncate(content, 50)) + '</span>');
+                    + HtmlUtils.escape(this.truncate(contentKo, 48)) + '</span>');
+            }
+            if (titleEn) {
+                parts.push('<span class="fw-semibold small text-body">'
+                    + '<span class="badge bg-info-subtle text-info-emphasis border me-1" style="font-size:0.65em;">EN</span>'
+                    + HtmlUtils.escape(this.truncate(titleEn, 28)) + '</span>');
+            }
+            if (contentEn) {
+                parts.push('<span class="text-body-secondary small">'
+                    + HtmlUtils.escape(this.truncate(contentEn, 48)) + '</span>');
             }
             return '<div class="d-flex flex-column gap-0">' + parts.join('') + '</div>';
         },

--- a/demo/bizApp/biz-auth/src/main/resources/application.yml
+++ b/demo/bizApp/biz-auth/src/main/resources/application.yml
@@ -33,8 +33,8 @@ app:
   org-id: ${APP_ORG_ID:DEMO}
 
 mybatis:
-  # spider-link JAR 내부의 XML 매퍼 파일 위치를 명시한다 (spider-link에서 optional로 선언되어 자동 적용 안 됨)
-  mapper-locations: classpath:mapper/oracle/**/*.xml
+  # classpath*: 로 현재 프로젝트 + spider-link JAR 내부 XML 매퍼까지 탐색
+  mapper-locations: classpath*:mapper/oracle/**/*.xml
   configuration:
     map-underscore-to-camel-case: true
     jdbc-type-for-null: VARCHAR

--- a/demo/bizApp/biz-channel/.env.example
+++ b/demo/bizApp/biz-channel/.env.example
@@ -6,6 +6,11 @@ DB_PASSWORD=
 # HTTP Server
 SERVER_PORT=18080
 
+# Admin → biz-channel 공지 커맨드 수신용 내장 TCP 서버
+TCP_SERVER_PORT=19400
+TCP_SERVER_HANDLER_POOL_SIZE=5
+TCP_SERVER_QUEUE_CAPACITY=20
+
 # biz-auth connection
 BIZ_AUTH_HOST=localhost
 BIZ_AUTH_PORT=19100

--- a/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/client/BizClient.java
+++ b/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/client/BizClient.java
@@ -68,7 +68,7 @@ public class BizClient {
                 .requestId(requestId)
                 .payload(payload)
                 .build();
-        log.debug("[BizClient] → 인증AP | command={} host={}:{} requestId={}", command, authHost, authPort, requestId);
+        log.debug("[BizClient] → biz-auth | command={} host={}:{} requestId={}", command, authHost, authPort, requestId);
         return tcpClient.sendJson(authHost, authPort, req);
     }
 
@@ -87,7 +87,7 @@ public class BizClient {
                 .requestId(requestId)
                 .payload(payload)
                 .build();
-        log.debug("[BizClient] → 이체AP | command={} host={}:{} requestId={}", command, transferHost, transferPort, requestId);
+        log.debug("[BizClient] → biz-transfer | command={} host={}:{} requestId={}", command, transferHost, transferPort, requestId);
         return tcpClient.sendJson(transferHost, transferPort, req);
     }
 }

--- a/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/config/BizChannelConfig.java
+++ b/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/config/BizChannelConfig.java
@@ -4,7 +4,14 @@ import com.example.bizchannel.web.filter.JwtAuthFilter;
 import com.example.bizchannel.web.interceptor.HttpLoggingInterceptor;
 import com.example.spiderlink.domain.messageinstance.MessageInstanceRecorder;
 import com.example.spiderlink.infra.tcp.client.TcpClient;
+import com.example.spiderlink.infra.tcp.codec.JsonMessageCodec;
+import com.example.spiderlink.infra.tcp.handler.CommandDispatcher;
+import com.example.spiderlink.infra.tcp.handler.CommandHandler;
+import com.example.spiderlink.infra.tcp.model.JsonCommandRequest;
+import com.example.spiderlink.infra.tcp.model.JsonCommandResponse;
+import com.example.spiderlink.infra.tcp.server.SpiderTcpServer;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import java.util.Optional;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,7 +28,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 /**
  * 채널AP 공통 설정 클래스.
  *
- * <p>CORS 정책, JWT 필터 등록을 담당한다.</p>
+ * <p>CORS 정책, JWT 필터, Admin 수신용 내장 TCP 서버 등록을 담당한다.</p>
  *
  * <pre>{@code
  *   // application.yml 설정 예시
@@ -30,6 +37,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  *   biz.transfer.host: localhost
  *   biz.transfer.port: 19200
  *   admin.secret: admin-secret
+ *   tcp.server.port: 9997          # Admin이 공지 커맨드를 전송하는 내장 TCP 포트
  * }</pre>
  */
 @Getter
@@ -55,6 +63,18 @@ public class BizChannelConfig implements WebMvcConfigurer {
     /** 공지 관리 API 보호용 어드민 시크릿 키 */
     @Value("${admin.secret:admin-secret}")
     private String adminSecret;
+
+    /** Admin → biz-channel 인바운드 TCP 포트 (기본값: 19400) */
+    @Value("${tcp.server.port:19400}")
+    private int tcpServerPort;
+
+    /** 요청 처리 스레드 풀 크기 (기본값: 5) */
+    @Value("${tcp.server.handler-pool-size:5}")
+    private int tcpHandlerPoolSize;
+
+    /** 요청 대기 큐 최대 크기 (기본값: 20) */
+    @Value("${tcp.server.queue-capacity:20}")
+    private int tcpQueueCapacity;
 
     private final HttpLoggingInterceptor httpLoggingInterceptor;
 
@@ -83,6 +103,31 @@ public class BizChannelConfig implements WebMvcConfigurer {
     public TcpClient tcpClient(ObjectMapper objectMapper,
                                 Optional<MessageInstanceRecorder> recorder) {
         return new TcpClient(objectMapper, recorder.orElse(null));
+    }
+
+    /**
+     * Admin 공지 커맨드 수신용 내장 TCP 서버 빈.
+     *
+     * <p>Admin이 NOTICE_SYNC / NOTICE_END 커맨드를 전송하면
+     * {@link com.example.bizchannel.domain.notice.NoticeSyncCommandHandler}가 처리하여
+     * {@link com.example.bizchannel.domain.notice.NoticeManager}를 통해 SSE 브로드캐스트한다.</p>
+     *
+     * @param objectMapper JSON 직렬화·역직렬화에 사용할 ObjectMapper
+     * @param handlers     스프링 컨텍스트에 등록된 모든 CommandHandler 구현체 목록
+     * @param recorder     전문 이력 기록기 (JdbcTemplate 빈이 없으면 empty)
+     * @return {@code tcp.server.port}에서 수신 대기하는 SpiderTcpServer 인스턴스
+     */
+    @Bean
+    public SpiderTcpServer<JsonCommandRequest, JsonCommandResponse> bizChannelTcpServer(
+            ObjectMapper objectMapper,
+            List<CommandHandler<JsonCommandRequest, JsonCommandResponse>> handlers,
+            Optional<MessageInstanceRecorder> recorder) {
+
+        CommandDispatcher<JsonCommandRequest, JsonCommandResponse> dispatcher =
+                new CommandDispatcher<>(handlers);
+
+        return new SpiderTcpServer<>(tcpServerPort, tcpHandlerPoolSize, tcpQueueCapacity,
+                new JsonMessageCodec(objectMapper), dispatcher, recorder.orElse(null));
     }
 
     /**

--- a/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/config/BizChannelConfig.java
+++ b/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/config/BizChannelConfig.java
@@ -37,7 +37,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  *   biz.transfer.host: localhost
  *   biz.transfer.port: 19200
  *   admin.secret: admin-secret
- *   tcp.server.port: 9997          # Admin이 공지 커맨드를 전송하는 내장 TCP 포트
+ *   tcp.server.port: 19400          # Admin이 공지 커맨드를 전송하는 내장 TCP 포트
  * }</pre>
  */
 @Getter

--- a/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/domain/notice/NoticeManager.java
+++ b/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/domain/notice/NoticeManager.java
@@ -50,11 +50,11 @@ public class NoticeManager {
         });
         emitter.onError(e -> {
             clients.remove(emitter);
-            log.debug("[NoticeManager] SSE 클라이언트 오류로 제거: {}", e.getMessage());
+            log.debug("[NoticeManager] SSE client removed due to error: {}", e.getMessage());
         });
 
         clients.add(emitter);
-        log.debug("[NoticeManager] SSE 클라이언트 등록. 현재 연결 수={}", clients.size());
+        log.debug("[NoticeManager] SSE client registered. active connections={}", clients.size());
 
         // 신규 연결 시 현재 활성 공지가 있으면 즉시 전송
         if (currentNotice != null) {
@@ -71,7 +71,7 @@ public class NoticeManager {
      */
     public void broadcast(Map<String, Object> notice) {
         this.currentNotice = notice;
-        log.info("[NoticeManager] 공지 브로드캐스트. 클라이언트 수={}, notice={}", clients.size(), notice != null ? "있음" : "없음(종료)");
+        log.info("[NoticeManager] Broadcasting notice. clients={}, notice={}", clients.size(), notice != null ? "active" : "none(ended)");
 
         for (SseEmitter emitter : clients) {
             sendToEmitter(emitter, notice);
@@ -107,7 +107,7 @@ public class NoticeManager {
         } catch (IOException e) {
             // 연결이 끊어진 클라이언트 — 목록에서 제거
             clients.remove(emitter);
-            log.debug("[NoticeManager] SSE 전송 실패로 클라이언트 제거: {}", e.getMessage());
+            log.debug("[NoticeManager] SSE send failed, removing client: {}", e.getMessage());
         }
     }
 }

--- a/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/domain/notice/NoticeSyncCommandHandler.java
+++ b/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/domain/notice/NoticeSyncCommandHandler.java
@@ -1,0 +1,57 @@
+package com.example.bizchannel.domain.notice;
+
+import com.example.spiderlink.infra.tcp.handler.CommandHandler;
+import com.example.spiderlink.infra.tcp.model.JsonCommandRequest;
+import com.example.spiderlink.infra.tcp.model.JsonCommandResponse;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * TCP NOTICE_SYNC / NOTICE_END 커맨드 핸들러.
+ *
+ * <p>Admin → biz-channel 내장 TCP 서버로 수신된 공지 커맨드를
+ * {@link NoticeManager}를 통해 SSE 브로드캐스트로 처리한다.</p>
+ *
+ * <p>수신 흐름: Admin(8080) → TCP:9997 → SpiderTcpServer → NoticeSyncCommandHandler → NoticeManager → SSE</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NoticeSyncCommandHandler implements CommandHandler<JsonCommandRequest, JsonCommandResponse> {
+
+    private final NoticeManager noticeManager;
+
+    @Override
+    public boolean supports(String command) {
+        return "NOTICE_SYNC".equals(command) || "NOTICE_END".equals(command);
+    }
+
+    @Override
+    public JsonCommandResponse handle(String command, JsonCommandRequest request) {
+        try {
+            if ("NOTICE_SYNC".equals(command)) {
+                Map<String, Object> payload = request.getPayload();
+                noticeManager.broadcast(payload);
+                log.info("[NoticeSyncCommandHandler] Notice broadcast done: payload keys={}", payload != null ? payload.keySet() : "null");
+            } else {
+                // NOTICE_END: null broadcast → NoticeManager sends notice-end event
+                noticeManager.broadcast(null);
+                log.info("[NoticeSyncCommandHandler] Notice end broadcast done");
+            }
+            return JsonCommandResponse.builder()
+                    .command(command)
+                    .success(true)
+                    .message("OK")
+                    .build();
+        } catch (Exception e) {
+            log.error("[NoticeSyncCommandHandler] Failed to handle command={}, error={}", command, e.getMessage());
+            return JsonCommandResponse.builder()
+                    .command(command)
+                    .success(false)
+                    .error(e.getMessage())
+                    .build();
+        }
+    }
+}

--- a/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/domain/notice/NoticeSyncCommandHandler.java
+++ b/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/domain/notice/NoticeSyncCommandHandler.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
  * <p>Admin → biz-channel 내장 TCP 서버로 수신된 공지 커맨드를
  * {@link NoticeManager}를 통해 SSE 브로드캐스트로 처리한다.</p>
  *
- * <p>수신 흐름: Admin(8080) → TCP:9997 → SpiderTcpServer → NoticeSyncCommandHandler → NoticeManager → SSE</p>
+ * <p>수신 흐름: Admin(8080) → TCP:19400 → SpiderTcpServer → NoticeSyncCommandHandler → NoticeManager → SSE</p>
  */
 @Slf4j
 @Component
@@ -46,7 +46,7 @@ public class NoticeSyncCommandHandler implements CommandHandler<JsonCommandReque
                     .message("OK")
                     .build();
         } catch (Exception e) {
-            log.error("[NoticeSyncCommandHandler] Failed to handle command={}, error={}", command, e.getMessage());
+            log.error("[NoticeSyncCommandHandler] Failed to handle command={}, error={}", command, e.getMessage(), e);
             return JsonCommandResponse.builder()
                     .command(command)
                     .success(false)

--- a/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/controller/AuthController.java
+++ b/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/controller/AuthController.java
@@ -113,7 +113,7 @@ public class AuthController {
         // HttpLoggingInterceptor가 HTTP 수신 시 생성한 UUID — TCP 구간과 동일한 TRX_TRACKING_NO로 연결
         String requestId = (String) request.getAttribute("requestId");
 
-        log.info("[AuthController] 로그인 요청: userId={}", userId);
+        log.info("[AuthController] Login request: userId={}", userId);
 
         Map<String, Object> payload = new HashMap<>();
         payload.put("userId", userId);
@@ -132,7 +132,7 @@ public class AuthController {
 
             // isSuccess=true 이지만 payload가 null인 경우 방어 (인증AP 버그 또는 빈 응답)
             if (authResp.getPayload() == null) {
-                log.warn("[AuthController] 인증AP 응답 payload null: userId={}", userId);
+                log.warn("[AuthController] biz-auth response payload null: userId={}", userId);
                 return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
                         .body(Map.of("error", "인증 서버 응답 오류"));
             }
@@ -166,11 +166,11 @@ public class AuthController {
             result.put("userGrade", userGrade);
             result.put("lastLogin", lastLogin);
 
-            log.info("[AuthController] 로그인 성공: userId={}", userId);
+            log.info("[AuthController] Login success: userId={}", userId);
             return ResponseEntity.ok(result);
 
         } catch (IOException e) {
-            log.error("[AuthController] 인증AP 통신 오류: {}", e.getMessage(), e);
+            log.error("[AuthController] biz-auth TCP error: {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(Map.of("error", "인증 서버 통신 오류"));
         }
@@ -195,7 +195,7 @@ public class AuthController {
         String userId = (String) request.getAttribute("userId");
         // HttpLoggingInterceptor가 HTTP 수신 시 생성한 UUID
         String requestId = (String) request.getAttribute("requestId");
-        log.debug("[AuthController] 사용자 정보 조회: userId={}", userId);
+        log.debug("[AuthController] Get user info: userId={}", userId);
 
         Map<String, Object> payload = new HashMap<>();
         payload.put("userId", userId);
@@ -210,7 +210,7 @@ public class AuthController {
 
             // isSuccess=true 이지만 payload가 null인 경우 방어
             if (authResp.getPayload() == null) {
-                log.warn("[AuthController] 인증AP 응답 payload null (me): userId={}", userId);
+                log.warn("[AuthController] biz-auth response payload null (me): userId={}", userId);
                 return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
                         .body(Map.of("error", "인증 서버 응답 오류"));
             }
@@ -227,7 +227,7 @@ public class AuthController {
             return ResponseEntity.ok(result);
 
         } catch (IOException e) {
-            log.error("[AuthController] 인증AP 통신 오류 (me): {}", e.getMessage(), e);
+            log.error("[AuthController] biz-auth TCP error (me): {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(Map.of("error", "인증 서버 통신 오류"));
         }
@@ -290,11 +290,11 @@ public class AuthController {
             result.put("accessToken", newAccessToken);
             // lastLogin 은 리프레시 응답에서는 포함하지 않음 (me API 에서 조회)
 
-            log.debug("[AuthController] 토큰 갱신 성공: userId={}", userId);
+            log.debug("[AuthController] Token refresh success: userId={}", userId);
             return ResponseEntity.ok(result);
 
         } catch (io.jsonwebtoken.JwtException e) {
-            log.warn("[AuthController] 리프레시 토큰 검증 실패: {}", e.getMessage());
+            log.warn("[AuthController] Refresh token validation failed: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(Map.of("error", "리프레시 토큰이 만료되었거나 유효하지 않습니다."));
         }
@@ -320,7 +320,7 @@ public class AuthController {
             HttpServletResponse response) {
 
         String userId = (String) request.getAttribute("userId");
-        log.info("[AuthController] 로그아웃: userId={}", userId);
+        log.info("[AuthController] Logout: userId={}", userId);
 
         // 인메모리 리프레시 토큰 제거
         refreshTokenStore.remove(userId);

--- a/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/controller/CardController.java
+++ b/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/controller/CardController.java
@@ -53,7 +53,7 @@ public class CardController {
     public ResponseEntity<Map<String, Object>> getCards(HttpServletRequest request) {
         String userId = (String) request.getAttribute("userId");
         String requestId = (String) request.getAttribute("requestId");
-        log.debug("[CardController] 카드 목록 조회: userId={}", userId);
+        log.debug("[CardController] Get card list: userId={}", userId);
 
         Map<String, Object> payload = new HashMap<>();
         payload.put("userId", userId);
@@ -66,7 +66,7 @@ public class CardController {
             }
             return ResponseEntity.ok(resp.getPayload());
         } catch (IOException e) {
-            log.error("[CardController] 이체AP 통신 오류 (cards): {}", e.getMessage(), e);
+            log.error("[CardController] biz-transfer TCP error (cards): {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(Map.of("error", "이체 서버 통신 오류"));
         }
@@ -100,7 +100,7 @@ public class CardController {
 
         String userId = (String) request.getAttribute("userId");
         String requestId = (String) request.getAttribute("requestId");
-        log.debug("[CardController] 이용내역 조회: userId={}, cardId={}, period={}", userId, cardId, period);
+        log.debug("[CardController] Get transactions: userId={}, cardId={}, period={}", userId, cardId, period);
 
         Map<String, Object> payload = new HashMap<>();
         payload.put("userId", userId);
@@ -120,7 +120,7 @@ public class CardController {
             }
             return ResponseEntity.ok(resp.getPayload());
         } catch (IOException e) {
-            log.error("[CardController] 이체AP 통신 오류 (transactions): {}", e.getMessage(), e);
+            log.error("[CardController] biz-transfer TCP error (transactions): {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(Map.of("error", "이체 서버 통신 오류"));
         }
@@ -146,7 +146,7 @@ public class CardController {
 
         String userId = (String) request.getAttribute("userId");
         String requestId = (String) request.getAttribute("requestId");
-        log.debug("[CardController] 결제명세서 조회: userId={}, yearMonth={}, paymentDay={}", userId, yearMonth, paymentDay);
+        log.debug("[CardController] Get payment statement: userId={}, yearMonth={}, paymentDay={}", userId, yearMonth, paymentDay);
 
         Map<String, Object> payload = new HashMap<>();
         payload.put("userId", userId);
@@ -161,7 +161,7 @@ public class CardController {
             }
             return ResponseEntity.ok(resp.getPayload());
         } catch (IOException e) {
-            log.error("[CardController] 이체AP 통신 오류 (payment-statement): {}", e.getMessage(), e);
+            log.error("[CardController] biz-transfer TCP error (payment-statement): {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(Map.of("error", "이체 서버 통신 오류"));
         }
@@ -185,7 +185,7 @@ public class CardController {
 
         String userId = (String) request.getAttribute("userId");
         String requestId = (String) request.getAttribute("requestId");
-        log.debug("[CardController] 즉시결제 가능금액 조회: userId={}, cardId={}", userId, cardId);
+        log.debug("[CardController] Get payable amount: userId={}, cardId={}", userId, cardId);
 
         Map<String, Object> payload = new HashMap<>();
         payload.put("userId", userId);
@@ -199,7 +199,7 @@ public class CardController {
             }
             return ResponseEntity.ok(resp.getPayload());
         } catch (IOException e) {
-            log.error("[CardController] 이체AP 통신 오류 (payable-amount): {}", e.getMessage(), e);
+            log.error("[CardController] biz-transfer TCP error (payable-amount): {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(Map.of("error", "이체 서버 통신 오류"));
         }
@@ -225,7 +225,7 @@ public class CardController {
 
         String userId = (String) request.getAttribute("userId");
         String requestId = (String) request.getAttribute("requestId");
-        log.info("[CardController] 즉시결제 요청: userId={}, cardId={}", userId, cardId);
+        log.info("[CardController] Immediate pay request: userId={}, cardId={}", userId, cardId);
 
         Map<String, Object> payload = new HashMap<>();
         payload.put("userId", userId);
@@ -242,7 +242,7 @@ public class CardController {
             }
             return ResponseEntity.ok(resp.getPayload());
         } catch (IOException e) {
-            log.error("[CardController] 이체AP 통신 오류 (immediate-pay): {}", e.getMessage(), e);
+            log.error("[CardController] biz-transfer TCP error (immediate-pay): {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(Map.of("error", "이체 서버 통신 오류"));
         }
@@ -269,7 +269,7 @@ public class CardController {
             @PathVariable String cardId) {
 
         String userId = (String) request.getAttribute("userId");
-        log.info("[CardController] PIN 시도 초기화: userId={}, cardId={}", userId, cardId);
+        log.info("[CardController] Reset PIN attempts: userId={}, cardId={}", userId, cardId);
 
         // PIN 시도 횟수는 이체AP(biz-transfer) 내부에서 관리
         // 채널AP 는 현재 단순 OK 응답만 반환 (이체AP 연동은 추후 확장)

--- a/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/controller/NoticeController.java
+++ b/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/controller/NoticeController.java
@@ -59,7 +59,7 @@ public class NoticeController {
      */
     @GetMapping(value = "/sse", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribeSse() {
-        log.debug("[NoticeController] SSE 클라이언트 연결 요청");
+        log.debug("[NoticeController] SSE client connect");
         return noticeManager.addClient();
     }
 
@@ -83,12 +83,12 @@ public class NoticeController {
             @RequestBody Map<String, Object> body) {
 
         if (!adminSecret.equals(adminSecretHeader)) {
-            log.warn("[NoticeController] 공지 sync 인증 실패 — X-Admin-Secret 불일치");
+            log.warn("[NoticeController] Notice sync rejected — invalid X-Admin-Secret");
             return ResponseEntity.status(HttpStatus.FORBIDDEN)
                     .body(Map.of("error", "어드민 시크릿이 올바르지 않습니다."));
         }
 
-        log.info("[NoticeController] 공지 동기화 요청: displayType={}", body.get("displayType"));
+        log.info("[NoticeController] Notice sync request: displayType={}", body.get("displayType"));
         noticeManager.broadcast(body);
 
         return ResponseEntity.ok(Map.of("success", true));
@@ -112,12 +112,12 @@ public class NoticeController {
             @RequestHeader(value = "X-Admin-Secret", required = false) String adminSecretHeader) {
 
         if (!adminSecret.equals(adminSecretHeader)) {
-            log.warn("[NoticeController] 공지 end 인증 실패 — X-Admin-Secret 불일치");
+            log.warn("[NoticeController] Notice end rejected — invalid X-Admin-Secret");
             return ResponseEntity.status(HttpStatus.FORBIDDEN)
                     .body(Map.of("error", "어드민 시크릿이 올바르지 않습니다."));
         }
 
-        log.info("[NoticeController] 공지 종료 처리");
+        log.info("[NoticeController] Notice end");
         // null 브로드캐스트 → NoticeManager 가 notice-end 이벤트 전송
         noticeManager.broadcast(null);
 

--- a/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/filter/JwtAuthFilter.java
+++ b/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/filter/JwtAuthFilter.java
@@ -105,12 +105,12 @@ public class JwtAuthFilter implements Filter {
             // 이후 컨트롤러에서 request.getAttribute("userId") 로 참조
             httpReq.setAttribute("userId", userId);
 
-            log.debug("[JwtAuthFilter] 인증 성공: userId={}, path={}", userId, path);
+            log.debug("[JwtAuthFilter] Auth success: userId={}, path={}", userId, path);
             chain.doFilter(request, response);
 
         } catch (JwtException e) {
             // 서명 불일치, 토큰 만료, 형식 오류 등 모든 JWT 관련 예외
-            log.warn("[JwtAuthFilter] 토큰 검증 실패: path={}, error={}", path, e.getMessage());
+            log.warn("[JwtAuthFilter] Token validation failed: path={}, error={}", path, e.getMessage());
             sendUnauthorized(httpRes, "유효하지 않거나 만료된 토큰입니다.");
         }
     }

--- a/demo/bizApp/biz-channel/src/main/resources/application.yml
+++ b/demo/bizApp/biz-channel/src/main/resources/application.yml
@@ -15,6 +15,13 @@ spring:
 server:
   port: ${SERVER_PORT}
 
+# Admin → biz-channel 공지 커맨드 수신용 내장 TCP 서버
+tcp:
+  server:
+    port: ${TCP_SERVER_PORT:19400}
+    handler-pool-size: ${TCP_SERVER_HANDLER_POOL_SIZE:5}
+    queue-capacity: ${TCP_SERVER_QUEUE_CAPACITY:20}
+
 biz:
   auth:
     host: ${BIZ_AUTH_HOST}

--- a/demo/bizApp/biz-transfer/src/main/resources/application.yml
+++ b/demo/bizApp/biz-transfer/src/main/resources/application.yml
@@ -33,8 +33,8 @@ app:
   org-id: ${APP_ORG_ID:DEMO}
 
 mybatis:
-  # spider-link JAR 내부의 XML 매퍼 파일 위치를 명시한다 (spider-link에서 optional로 선언되어 자동 적용 안 됨)
-  mapper-locations: classpath:mapper/oracle/**/*.xml
+  # classpath*: 로 현재 프로젝트 + spider-link JAR 내부 XML 매퍼까지 탐색
+  mapper-locations: classpath*:mapper/oracle/**/*.xml
   configuration:
     map-underscore-to-camel-case: true
     jdbc-type-for-null: VARCHAR

--- a/demo/front/src/components/EmergencyNoticeBanner.tsx
+++ b/demo/front/src/components/EmergencyNoticeBanner.tsx
@@ -4,7 +4,7 @@
  *
  * Admin에서 배포된 긴급공지를 화면 중앙 모달로 표시한다.
  * 언어 설정에 따라 한국어(EMERGENCY_KO) 또는 영어(EMERGENCY_EN) 공지를 표시하며,
- * 현재는 한국어를 기본으로 표시한다.
+ * 브라우저 언어(navigator.language)가 'en'으로 시작하면 영어를, 그 외에는 한국어를 기본으로 표시한다.
  *
  * 줄바꿈 마커(_$BR) 처리:
  *   DB에 저장된 _$BR 마커를 줄바꿈으로 변환하여 렌더링한다.
@@ -29,7 +29,7 @@ interface EmergencyNoticeBannerProps {
   onClose?: () => void;
   /** 미리보기 모드에서 localStorage 오늘 하루 보지 않기 설정을 무시하고 강제 표시한다. */
   forceOpen?: boolean;
-  /** 표시할 언어 코드 (예: 'EMERGENCY_KO' | 'EMERGENCY_EN'). 생략 시 한국어(EMERGENCY_KO)를 기본으로 사용한다. */
+  /** 표시할 언어 코드 (예: 'EMERGENCY_KO' | 'EMERGENCY_EN'). 생략 시 브라우저 언어를 기반으로 자동 결정한다. */
   lang?: string;
 }
 
@@ -60,7 +60,7 @@ function parseContent(content: string): string {
   return content.replace(/_\$BR/g, "\n");
 }
 
-export function EmergencyNoticeBanner({ data, onClose, forceOpen = false, lang = "EMERGENCY_KO" }: EmergencyNoticeBannerProps) {
+export function EmergencyNoticeBanner({ data, onClose, forceOpen = false, lang = navigator.language.startsWith("en") ? "EMERGENCY_EN" : "EMERGENCY_KO" }: EmergencyNoticeBannerProps) {
   const [hideToday, setHideToday] = useState(false);
 
   /* 닫기 버튼 허용 여부 — N이면 사용자가 모달을 닫을 수 없음 (critical 장애 시) */

--- a/demo/front/src/components/EmergencyNoticeBanner.tsx
+++ b/demo/front/src/components/EmergencyNoticeBanner.tsx
@@ -60,7 +60,7 @@ function parseContent(content: string): string {
   return content.replace(/_\$BR/g, "\n");
 }
 
-export function EmergencyNoticeBanner({ data, onClose, forceOpen = false, lang = navigator.language.startsWith("en") ? "EMERGENCY_EN" : "EMERGENCY_KO" }: EmergencyNoticeBannerProps) {
+export function EmergencyNoticeBanner({ data, onClose, forceOpen = false, lang = (typeof window !== 'undefined' && navigator.language.startsWith("en")) ? "EMERGENCY_EN" : "EMERGENCY_KO" }: EmergencyNoticeBannerProps) {
   const [hideToday, setHideToday] = useState(false);
 
   /* 닫기 버튼 허용 여부 — N이면 사용자가 모달을 닫을 수 없음 (critical 장애 시) */

--- a/spider-link/src/main/java/com/example/spiderlink/SpiderLinkApplication.java
+++ b/spider-link/src/main/java/com/example/spiderlink/SpiderLinkApplication.java
@@ -1,5 +1,7 @@
 package com.example.spiderlink;
 
+import org.apache.ibatis.annotations.Mapper;
+import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -10,6 +12,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * demo/backend가 Spring Boot으로 전환되면 이 standalone 프로세스는 제거 예정.</p>
  */
 @SpringBootApplication
+// Spring DevTools RestartClassLoader 환경에서 @Mapper 인터페이스가 스캔에서 누락되는 현상 방지
+@MapperScan(annotationClass = Mapper.class)
 public class SpiderLinkApplication {
 
     public static void main(String[] args) {


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

Closes #24

## ✨ 변경 사항 (Changes)

- **긴급공지 다국어(KO/EN) 지원**
  - `EmergencyNoticeHistoryResponse` — `titleEn`, `contentEn` 필드 추가
  - `EmergencyNoticeDeployMapper.xml` — 배포 이력 조회 시 `EMERGENCY_EN` 행 LEFT JOIN 추가
  - `emergency-notice-deploy-manage-script.html` — 이력 상세에서 KO/EN 공지 내용 함께 표시
  - `EmergencyNoticeBanner.tsx` — `lang` prop 기본값을 `navigator.language` 기반 자동 감지로 변경

- **Admin → biz-channel 내장 TCP 구조로 전환** (standalone spider-link 불필요)
  - `NoticeSyncCommandHandler` 신규 — `NOTICE_SYNC`/`NOTICE_END` 수신 시 `NoticeManager.broadcast()` 호출
  - `BizChannelConfig` — `SpiderTcpServer` 빈 추가 (TCP:19400)
  - `biz-channel/application.yml`, `.env.example` — TCP 서버 포트 설정 추가
  - `admin/application.yml`, `.env.example` — `SPIDER_LINK_TCP_PORT:9996` → `BIZ_CHANNEL_TCP_PORT:19400`
  - `DemoBackendAdapter` — 주석 및 기본 포트 수정

- **버그 수정**
  - `biz-auth`, `biz-transfer` `application.yml` — `mybatis` 중복 키 제거, `classpath*:` 적용
  - `SpiderLinkApplication` — DevTools RestartClassLoader 환경 `@Mapper` 스캔 누락 방지 (`@MapperScan` 추가)

- **biz-channel 로그 영어 변환** — IntelliJ PowerShell 한글 인코딩 깨짐 대응

## 🛠 기술적 의사결정

**standalone spider-link 제거 배경**: PR #164에서 `demo/backend`가 멀티모듈(biz-auth/biz-transfer/biz-channel)로 분리되면서 Admin → TCP:9996 → 프록시 → TCP:9997 흐름의 수신 서버가 사라졌다. biz-channel이 이미 spider-link를 JAR로 내장하고 있으므로, biz-channel에 `SpiderTcpServer`를 직접 등록하여 Admin이 포트 19400으로 직접 전달하도록 변경했다. 다른 biz-xx 서버들의 포트 규칙(19100, 19200)에 맞춰 19400으로 지정했다.

## ⚠️ 고려 및 주의 사항

- `biz-channel/.env`에 `TCP_SERVER_PORT=19400` 추가 필요
- `admin/.env`에서 `SPIDER_LINK_TCP_PORT` → `BIZ_CHANNEL_TCP_PORT=19400`으로 변경 필요
- standalone `spider-link` 프로세스 기동 불필요 (biz-channel 기동만으로 대체)