### PR TITLE
✨ feat/#264-React CMS 로컬 TypeScript 배포 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ HELP.md
 TASKS.md
 target/
 admin/.mvn/wrapper/maven-wrapper.jar
+admin/worklist-scripts
 !**/src/main/**/target/
 !**/src/test/**/target/
 docs/dev

--- a/admin/.env.example
+++ b/admin/.env.example
@@ -61,6 +61,12 @@ RELOAD_DEFAULT_GROUP=POC_HNC_GROUP
 BIZ_CHANNEL_TCP_HOST=localhost
 BIZ_CHANNEL_TCP_PORT=19400
 
+# === React CMS Deploy (승인 후 배포 전략) ===
+# --- local 모드 경로 설정 ---
+# 미설정 시 application.yml 기본값(../demo/front/src/reactcms/generated, ../demo/front/src/reactcms/containers) 사용
+# REACT_DEPLOY_LOCAL_COMPONENT_DIR=../demo/front/src/reactcms/generated
+# REACT_DEPLOY_LOCAL_CONTAINER_DIR=../demo/front/src/reactcms/containers
+
 # === Test (E2E/API) ===
 # E2E 테스트 계정은 e2e/docker/e2e-seed.sql에서 Oracle 컨테이너에 직접 시드.
 # e2e/fixtures/test-accounts.ts 참조. 별도 환경변수 불필요.

--- a/admin/docs/sql/oracle/03_insert_initial_data.sql
+++ b/admin/docs/sql/oracle/03_insert_initial_data.sql
@@ -648,6 +648,7 @@ INSERT INTO FWK_USER_MENU (USER_ID, MENU_ID, AUTH_CODE, LAST_UPDATE_DTIME, LAST_
 INSERT INTO FWK_USER_MENU (USER_ID, MENU_ID, AUTH_CODE, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID) VALUES ('cmsAdmin01', 'v3_cms_admin_statistics', 'W', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), 'system');
 INSERT INTO FWK_USER_MENU (USER_ID, MENU_ID, AUTH_CODE, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID) VALUES ('cmsAdmin01', 'v3_cms_admin_components', 'W', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), 'system');
 INSERT INTO FWK_USER_MENU (USER_ID, MENU_ID, AUTH_CODE, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID) VALUES ('cmsAdmin01', 'v3_cms_admin_asset_approvals', 'W', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), 'system');
+INSERT INTO FWK_USER_MENU (USER_ID, MENU_ID, AUTH_CODE, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID) VALUES ('cmsAdmin01', 'v3_react_cms_admin_approvals', 'W', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), 'system');
 INSERT INTO FWK_USER_MENU (USER_ID, MENU_ID, AUTH_CODE, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID) VALUES ('cmsUser01', 'v3_cms_manage', 'W', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), 'system');
 INSERT INTO FWK_USER_MENU (USER_ID, MENU_ID, AUTH_CODE, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID) VALUES ('cmsUser01', 'v3_cms_dashboard', 'W', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), 'system');
 INSERT INTO FWK_USER_MENU (USER_ID, MENU_ID, AUTH_CODE, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID) VALUES ('cmsUser01', 'v3_cms_edit', 'W', TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS'), 'system');
@@ -678,6 +679,31 @@ INSERT INTO FWK_CMS_SERVER_INSTANCE (
     'Y',
     'system'
 );
+
+-- React CMS 로컬 개발 서버 인스턴스 — 로컬 배포(local file deploy) 이력 기록에 사용
+-- ⚠ 개발자가 DB에서 직접 실행해야 합니다.
+INSERT INTO FWK_CMS_SERVER_INSTANCE (
+    INSTANCE_ID,
+    INSTANCE_NAME,
+    INSTANCE_DESC,
+    INSTANCE_IP,
+    INSTANCE_PORT,
+    SERVER_TYPE,
+    ALIVE_YN,
+    LAST_MODIFIER_ID,
+    CREATE_DTIME
+) VALUES (
+    'demo-local-react',
+    '데모 로컬 리액트 서버',
+    'React CMS demo/front 데모 로컬 리액트 서버 (localhost:5173)',
+    'localhost',
+    5173,
+    'WEB',
+    'Y',
+    'system' ,
+    TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS')
+);
+COMMIT;
 
 
 -- ============================================================

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsadmindeployment/config/ReactDeployLocalProperties.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsadmindeployment/config/ReactDeployLocalProperties.java
@@ -1,0 +1,28 @@
+package com.example.admin_demo.domain.reactcmsadmindeployment.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * React CMS 로컬 배포 경로 설정.
+ *
+ * <p>application.yml의 react.deploy.local 섹션에서 읽어옵니다.
+ * 경로는 admin 프로젝트 루트 기준 상대 경로로 지정하며, 절대 경로도 허용합니다.</p>
+ */
+@Component
+@ConfigurationProperties(prefix = "react.deploy.local")
+@Getter
+@Setter
+public class ReactDeployLocalProperties {
+
+    /** 생성된 JSX 컴포넌트 파일을 저장할 디렉토리 — PAGE_DESC 내용을 {pageId}.tsx로 저장 */
+    private String componentDir = "../demo/front/src/reactcms/generated";
+
+    /** demo/front 라우팅용 컨테이너 파일을 저장할 디렉토리 — {pageId}.tsx re-export 래퍼 */
+    private String containerDir = "../demo/front/src/reactcms/containers";
+
+    /** 배포 이력 기록에 사용할 FWK_CMS_SERVER_INSTANCE.INSTANCE_ID */
+    private String instanceId = "demo-local-react";
+}

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsadmindeployment/dto/ReactCmsAdminDeployPageResponse.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsadmindeployment/dto/ReactCmsAdminDeployPageResponse.java
@@ -27,8 +27,17 @@ public class ReactCmsAdminDeployPageResponse {
     /** 작성자명 */
     private String createUserName;
 
+    /** 노출 시작일 (YYYY-MM-DD, null 가능) */
+    private String beginningDate;
+
+    /** 노출 종료일 (YYYY-MM-DD, null 가능) */
+    private String expiredDate;
+
     /** 최근 배포된 파일 URL (배포 이력 없으면 null) — 서비스 레이어에서 instanceIp/Port + 설정값으로 조합 */
     private String deployedUrl;
+
+    /** 최근 배포 서버 인스턴스 ID (URL 조합 방식 결정에 사용, 배포 이력 없으면 null) */
+    private String instanceId;
 
     /** 최근 배포 서버 IP (URL 조합용, 배포 이력 없으면 null) */
     private String instanceIp;

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsadmindeployment/mapper/ReactCmsAdminDeployMapper.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsadmindeployment/mapper/ReactCmsAdminDeployMapper.java
@@ -36,4 +36,24 @@ public interface ReactCmsAdminDeployMapper {
      * 0이면 미존재, 1이면 존재.
      */
     int existsApprovedPage(@Param("pageId") String pageId);
+
+    /**
+     * 승인된 React 페이지의 PAGE_DESC(사전 생성된 JSX 코드) 조회.
+     * 로컬 파일 배포 시 이 코드를 {pageId}.tsx 파일로 저장한다.
+     */
+    String findPageDescById(@Param("pageId") String pageId);
+
+    /**
+     * 특정 pageId에 대한 최대 배포 버전 번호 조회.
+     * FILE_ID 패턴 {pageId}_v{n}.(html|tsx) 에서 n의 최댓값을 반환하며, 이력이 없으면 0을 반환한다.
+     */
+    int findMaxDeployVersion(@Param("pageId") String pageId);
+
+    /** 배포 이력을 FWK_CMS_FILE_SEND_HIS 에 INSERT */
+    void insertDeployHistory(
+            @Param("instanceId") String instanceId,
+            @Param("fileId") String fileId,
+            @Param("fileSize") long fileSize,
+            @Param("fileCrcValue") String fileCrcValue,
+            @Param("lastModifierId") String lastModifierId);
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsadmindeployment/service/ReactCmsAdminDeployService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsadmindeployment/service/ReactCmsAdminDeployService.java
@@ -10,6 +10,7 @@ import com.example.admin_demo.domain.reactcmsadmindeployment.mapper.ReactCmsAdmi
 import com.example.admin_demo.global.dto.PageRequest;
 import com.example.admin_demo.global.dto.PageResponse;
 import com.example.admin_demo.global.exception.InternalException;
+import com.example.admin_demo.global.exception.InvalidInputException;
 import com.example.admin_demo.global.exception.NotFoundException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -19,10 +20,13 @@ import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /** React CMS Admin 배포 관리 서비스 */
 @Slf4j
@@ -30,6 +34,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ReactCmsAdminDeployService {
+
+    /** ../와 같은 경로 탐색 문자 차단 — 영문자·숫자·하이픈·언더스코어만 허용 */
+    private static final Pattern SAFE_PAGE_ID = Pattern.compile("^[a-zA-Z0-9_-]+$");
 
     private final ReactCmsAdminDeployMapper reactCmsAdminDeployMapper;
     private final CmsDeployProperties deployProperties;
@@ -50,7 +57,7 @@ public class ReactCmsAdminDeployService {
             if (item.getInstanceIp() == null || item.getInstancePort() == null) return;
             if (localInstanceId.equals(item.getInstanceId())) {
                 // 로컬 TypeScript 배포: demo/front Vite 뷰어 라우트로 연결
-                item.setDeployedUrl("http://" + item.getInstanceIp() + ":" + item.getInstancePort()
+                item.setDeployedUrl(protocol + "://" + item.getInstanceIp() + ":" + item.getInstancePort()
                         + "/react-cms/viewer/" + item.getPageId());
             } else {
                 item.setDeployedUrl(protocol + "://" + item.getInstanceIp() + ":" + item.getInstancePort()
@@ -78,6 +85,8 @@ public class ReactCmsAdminDeployService {
      */
     @Transactional
     public void push(String pageId, String userId) {
+        validatePageId(pageId);
+
         if (reactCmsAdminDeployMapper.existsApprovedPage(pageId) == 0) {
             throw new NotFoundException("승인된 React 페이지를 찾을 수 없습니다. pageId=" + pageId);
         }
@@ -87,33 +96,44 @@ public class ReactCmsAdminDeployService {
             throw new InternalException("배포할 코드가 없습니다. CMS 빌더에서 페이지를 저장한 뒤 다시 시도해주세요.");
         }
 
-        long fileSize = writeLocalFiles(pageId, pageDesc);
-
-        int nextVersion = reactCmsAdminDeployMapper.findMaxDeployVersion(pageId) + 1;
-        String fileId = pageId + "_v" + nextVersion + ".tsx";
+        // fileId는 실제 저장 파일명과 일치 — 이력 조회 시 파일 시스템과 혼선 방지
+        String fileId = pageId + ".tsx";
+        long fileSize = pageDesc.getBytes(StandardCharsets.UTF_8).length;
         String fileCrcValue = computeSha256Prefix(pageDesc);
 
         reactCmsAdminDeployMapper.insertDeployHistory(
                 localProperties.getInstanceId(), fileId, fileSize, fileCrcValue, userId);
 
+        // 파일 쓰기는 DB 커밋 후 실행 — 커밋 전 파일 생성 시 DB 롤백과 불일치 방지
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                writeLocalFiles(pageId, pageDesc);
+            }
+        });
+
         log.info("React CMS 로컬 배포 완료: pageId={}, userId={}, fileId={}", pageId, userId, fileId);
     }
 
-    /** 컴포넌트 파일과 컨테이너 파일을 로컬 디렉토리에 저장하고 컴포넌트 파일 크기(bytes)를 반환 */
-    private long writeLocalFiles(String pageId, String pageDesc) {
+    /** pageId가 안전한 형식인지 검증 (Path Traversal 방지) */
+    private void validatePageId(String pageId) {
+        if (pageId == null || !SAFE_PAGE_ID.matcher(pageId).matches()) {
+            throw new InvalidInputException("유효하지 않은 pageId 형식입니다: " + pageId);
+        }
+    }
+
+    /** 컴포넌트 파일과 컨테이너 파일을 로컬 디렉토리에 저장 */
+    private void writeLocalFiles(String pageId, String pageDesc) {
         try {
             // 컴포넌트 파일: PAGE_DESC(generateJSX 결과) 그대로 저장
             Path componentDir = resolveDir(localProperties.getComponentDir());
-            byte[] componentBytes = pageDesc.getBytes(StandardCharsets.UTF_8);
-            Files.write(componentDir.resolve(pageId + ".tsx"), componentBytes);
+            Files.write(componentDir.resolve(pageId + ".tsx"), pageDesc.getBytes(StandardCharsets.UTF_8));
 
             // 컨테이너 파일: demo/front 라우팅을 위한 re-export 래퍼
             Path containerDir = resolveDir(localProperties.getContainerDir());
             String containerCode = "// Auto-generated container for " + pageId + " — do not edit manually\n"
                     + "export { default } from \"@/reactcms/generated/" + pageId + "\";\n";
             Files.writeString(containerDir.resolve(pageId + ".tsx"), containerCode, StandardCharsets.UTF_8);
-
-            return componentBytes.length;
         } catch (IOException e) {
             throw new InternalException("배포 파일 저장 중 오류가 발생했습니다: " + e.getMessage(), e);
         }

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsadmindeployment/service/ReactCmsAdminDeployService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsadmindeployment/service/ReactCmsAdminDeployService.java
@@ -1,6 +1,7 @@
 package com.example.admin_demo.domain.reactcmsadmindeployment.service;
 
 import com.example.admin_demo.domain.cmsdeployment.config.CmsDeployProperties;
+import com.example.admin_demo.domain.reactcmsadmindeployment.config.ReactDeployLocalProperties;
 import com.example.admin_demo.domain.reactcmsadmindeployment.dto.ReactCmsAdminDeployHistoryRequest;
 import com.example.admin_demo.domain.reactcmsadmindeployment.dto.ReactCmsAdminDeployHistoryResponse;
 import com.example.admin_demo.domain.reactcmsadmindeployment.dto.ReactCmsAdminDeployPageRequest;
@@ -10,20 +11,18 @@ import com.example.admin_demo.global.dto.PageRequest;
 import com.example.admin_demo.global.dto.PageResponse;
 import com.example.admin_demo.global.exception.InternalException;
 import com.example.admin_demo.global.exception.NotFoundException;
-import java.util.HashMap;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 
 /** React CMS Admin 배포 관리 서비스 */
 @Slf4j
@@ -33,9 +32,8 @@ import org.springframework.web.client.RestTemplate;
 public class ReactCmsAdminDeployService {
 
     private final ReactCmsAdminDeployMapper reactCmsAdminDeployMapper;
-    private final RestTemplate restTemplate;
-    // CMS push API URL과 인증 토큰은 HTML CMS와 동일한 설정 공유
     private final CmsDeployProperties deployProperties;
+    private final ReactDeployLocalProperties localProperties;
 
     /** 배포 대상 페이지 목록 조회 (PAGE_TYPE='REACT', APPROVE_STATE='APPROVED') */
     public PageResponse<ReactCmsAdminDeployPageResponse> findApprovedPageList(
@@ -44,13 +42,19 @@ public class ReactCmsAdminDeployService {
         List<ReactCmsAdminDeployPageResponse> list =
                 reactCmsAdminDeployMapper.findApprovedPageList(req, pageRequest.getOffset(), pageRequest.getEndRow());
 
-        // 프로토콜과 경로는 application.yml 설정값으로 관리 — 하드코딩 대신 환경별 변경 가능
+        // 로컬 TypeScript 배포는 Vite 뷰어 경로, 그 외는 기존 HTML 정적 파일 경로 사용
         String protocol = deployProperties.getDeployedProtocol();
         String pathPrefix = deployProperties.getDeployedPathPrefix();
+        String localInstanceId = localProperties.getInstanceId();
         list.forEach(item -> {
-            if (item.getInstanceIp() != null && item.getInstancePort() != null) {
-                item.setDeployedUrl(protocol + "://" + item.getInstanceIp() + ":" + item.getInstancePort() + pathPrefix
-                        + "/" + item.getPageId() + ".html");
+            if (item.getInstanceIp() == null || item.getInstancePort() == null) return;
+            if (localInstanceId.equals(item.getInstanceId())) {
+                // 로컬 TypeScript 배포: demo/front Vite 뷰어 라우트로 연결
+                item.setDeployedUrl("http://" + item.getInstanceIp() + ":" + item.getInstancePort()
+                        + "/react-cms/viewer/" + item.getPageId());
+            } else {
+                item.setDeployedUrl(protocol + "://" + item.getInstanceIp() + ":" + item.getInstancePort()
+                        + pathPrefix + "/" + item.getPageId() + ".html");
             }
         });
 
@@ -67,50 +71,73 @@ public class ReactCmsAdminDeployService {
     }
 
     /**
-     * 배포 실행
+     * 배포 실행 — PAGE_DESC(사전 생성된 JSX)를 로컬 파일로 저장하고 FWK_CMS_FILE_SEND_HIS에 이력을 기록한다.
      *
-     * <p>PAGE_TYPE='REACT', APPROVE_STATE='APPROVED' 사전 검증 후 CMS push API 호출.
-     * HTML 조립·파일 저장·이력 기록은 CMS push API가 담당한다.
+     * <p>PAGE_TYPE='REACT', APPROVE_STATE='APPROVED' 사전 검증 후
+     * COMPONENT_DIR/{pageId}.tsx, CONTAINER_DIR/{pageId}.tsx 두 파일을 생성한다.</p>
      */
+    @Transactional
     public void push(String pageId, String userId) {
-        // REACT 타입이고 APPROVED 상태인지 사전 검증 — CLOB 전체 로드 대신 COUNT 쿼리로 경량 확인
         if (reactCmsAdminDeployMapper.existsApprovedPage(pageId) == 0) {
             throw new NotFoundException("승인된 React 페이지를 찾을 수 없습니다. pageId=" + pageId);
         }
-        callCmsPush(pageId, userId);
-        log.info("React CMS Admin 배포 요청 완료: pageId={}, userId={}", pageId, userId);
+
+        String pageDesc = reactCmsAdminDeployMapper.findPageDescById(pageId);
+        if (pageDesc == null || pageDesc.isBlank()) {
+            throw new InternalException("배포할 코드가 없습니다. CMS 빌더에서 페이지를 저장한 뒤 다시 시도해주세요.");
+        }
+
+        long fileSize = writeLocalFiles(pageId, pageDesc);
+
+        int nextVersion = reactCmsAdminDeployMapper.findMaxDeployVersion(pageId) + 1;
+        String fileId = pageId + "_v" + nextVersion + ".tsx";
+        String fileCrcValue = computeSha256Prefix(pageDesc);
+
+        reactCmsAdminDeployMapper.insertDeployHistory(
+                localProperties.getInstanceId(), fileId, fileSize, fileCrcValue, userId);
+
+        log.info("React CMS 로컬 배포 완료: pageId={}, userId={}, fileId={}", pageId, userId, fileId);
     }
 
-    /** CMS push API 호출 — x-deploy-token 서버 간 인증 사용 */
-    @SuppressWarnings("unchecked")
-    private void callCmsPush(String pageId, String userId) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.set("x-deploy-token", deployProperties.getSecret());
-
-        Map<String, Object> body = new HashMap<>();
-        body.put("pageId", pageId);
-        body.put("userId", userId);
-
+    /** 컴포넌트 파일과 컨테이너 파일을 로컬 디렉토리에 저장하고 컴포넌트 파일 크기(bytes)를 반환 */
+    private long writeLocalFiles(String pageId, String pageDesc) {
         try {
-            ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
-                    deployProperties.getPushUrl(),
-                    HttpMethod.POST,
-                    new HttpEntity<>(body, headers),
-                    new ParameterizedTypeReference<Map<String, Object>>() {});
+            // 컴포넌트 파일: PAGE_DESC(generateJSX 결과) 그대로 저장
+            Path componentDir = resolveDir(localProperties.getComponentDir());
+            byte[] componentBytes = pageDesc.getBytes(StandardCharsets.UTF_8);
+            Files.write(componentDir.resolve(pageId + ".tsx"), componentBytes);
 
-            Map<String, Object> responseBody = response.getBody();
-            if (responseBody == null) {
-                throw new InternalException("CMS 배포 서버에서 빈 응답을 반환했습니다.");
-            }
-            if (!Boolean.TRUE.equals(responseBody.get("ok"))) {
-                Object error = responseBody.get("error");
-                throw new InternalException("CMS 배포 서버 오류: " + error);
-            }
-        } catch (InternalException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new InternalException("CMS 배포 서버 오류: " + e.getMessage(), e);
+            // 컨테이너 파일: demo/front 라우팅을 위한 re-export 래퍼
+            Path containerDir = resolveDir(localProperties.getContainerDir());
+            String containerCode = "// Auto-generated container for " + pageId + " — do not edit manually\n"
+                    + "export { default } from \"@/reactcms/generated/" + pageId + "\";\n";
+            Files.writeString(containerDir.resolve(pageId + ".tsx"), containerCode, StandardCharsets.UTF_8);
+
+            return componentBytes.length;
+        } catch (IOException e) {
+            throw new InternalException("배포 파일 저장 중 오류가 발생했습니다: " + e.getMessage(), e);
         }
+    }
+
+    /** 파일 내용의 SHA-256 해시 앞 16자리를 반환 (FILE_CRC_VALUE 용) */
+    private String computeSha256Prefix(String content) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(content.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(32);
+            for (byte b : digest) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.substring(0, 16);
+        } catch (NoSuchAlgorithmException e) {
+            return "0000000000000000";
+        }
+    }
+
+    /** 경로를 절대 경로로 변환하고 디렉토리가 없으면 생성 */
+    private Path resolveDir(String dirPath) throws IOException {
+        Path path = Paths.get(dirPath).toAbsolutePath().normalize();
+        Files.createDirectories(path);
+        return path;
     }
 }

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsadmindeployment/service/ReactCmsAdminDeployService.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsadmindeployment/service/ReactCmsAdminDeployService.java
@@ -60,8 +60,8 @@ public class ReactCmsAdminDeployService {
                 item.setDeployedUrl(protocol + "://" + item.getInstanceIp() + ":" + item.getInstancePort()
                         + "/react-cms/viewer/" + item.getPageId());
             } else {
-                item.setDeployedUrl(protocol + "://" + item.getInstanceIp() + ":" + item.getInstancePort()
-                        + pathPrefix + "/" + item.getPageId() + ".html");
+                item.setDeployedUrl(protocol + "://" + item.getInstanceIp() + ":" + item.getInstancePort() + pathPrefix
+                        + "/" + item.getPageId() + ".html");
             }
         });
 

--- a/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/controller/ReactCmsDashboardController.java
+++ b/admin/src/main/java/com/example/admin_demo/domain/reactcmsdashboard/controller/ReactCmsDashboardController.java
@@ -43,9 +43,9 @@ public class ReactCmsDashboardController {
 
     private final ReactCmsDashboardService reactCmsDashboardService;
 
-    /** 내 페이지 목록 조회 (REACT-CMS:R) */
+    /** 내 페이지 목록 조회 (REACT_CMS:R) */
     @GetMapping("/api/react-cms-dashboard/pages")
-    @PreAuthorize("hasAuthority('REACT-CMS:R')")
+    @PreAuthorize("hasAuthority('REACT_CMS:R')")
     public ResponseEntity<ApiResponse<PageResponse<ReactCmsDashboardPageResponse>>> findMyPageList(
             @ModelAttribute ReactCmsDashboardListRequest req,
             @RequestParam(defaultValue = "1") int page,
@@ -59,20 +59,20 @@ public class ReactCmsDashboardController {
                 reactCmsDashboardService.findMyPageList(req, userDetails.getUserId(), pageRequest)));
     }
 
-    /** 승인 상태 조회 — react-cms 빌더가 편집 모드 진입 시 호출 (REACT-CMS:R) */
+    /** 승인 상태 조회 — react-cms 빌더가 편집 모드 진입 시 호출 (REACT_CMS:R) */
     @GetMapping("/api/react-cms-dashboard/pages/{pageId}/approval-status")
-    @PreAuthorize("hasAuthority('REACT-CMS:R')")
+    @PreAuthorize("hasAuthority('REACT_CMS:R')")
     public ResponseEntity<ApiResponse<ReactCmsApprovalStatusResponse>> findApprovalStatus(@PathVariable String pageId) {
 
         return ResponseEntity.ok(ApiResponse.success(reactCmsDashboardService.findApprovalStatus(pageId)));
     }
 
     /**
-     * 페이지 삭제 (REACT-CMS:W)
+     * 페이지 삭제 (REACT_CMS:W)
      * 이력 있으면 소프트(USE_YN='N'), 없으면 하드 삭제.
      */
     @DeleteMapping("/api/react-cms-dashboard/pages/{pageId}")
-    @PreAuthorize("hasAuthority('REACT-CMS:W')")
+    @PreAuthorize("hasAuthority('REACT_CMS:W')")
     public ResponseEntity<ApiResponse<Void>> deletePage(
             @PathVariable String pageId, @AuthenticationPrincipal CustomUserDetails userDetails) {
 
@@ -80,9 +80,9 @@ public class ReactCmsDashboardController {
         return ResponseEntity.ok(ApiResponse.success("페이지가 삭제되었습니다.", null));
     }
 
-    /** 승인 요청 — APPROVE_STATE → PENDING (REACT-CMS:W) */
+    /** 승인 요청 — APPROVE_STATE → PENDING (REACT_CMS:W) */
     @PatchMapping("/api/react-cms-dashboard/pages/{pageId}/approve-request")
-    @PreAuthorize("hasAuthority('REACT-CMS:W')")
+    @PreAuthorize("hasAuthority('REACT_CMS:W')")
     public ResponseEntity<ApiResponse<Void>> requestApproval(
             @PathVariable String pageId,
             @RequestBody ReactCmsDashboardApproveRequestDto req,

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -194,6 +194,16 @@ cms:
     # CMS /cms/api/assets/{id}/deploy 엔드포인트 인증 토큰 — 페이지 배포와 동일한 CMS DEPLOY_SECRET 사용
     deploy-secret: ${CMS_DEPLOY_SECRET:}
 
+react:
+  deploy:
+    local:
+      # React CMS 페이지 배포 시 생성된 JSX 파일을 저장할 로컬 디렉토리 (admin 프로젝트 기준 상대 경로)
+      component-dir: ${REACT_DEPLOY_LOCAL_COMPONENT_DIR:../demo/front/src/reactcms/generated}
+      # demo/front 라우팅용 컨테이너 파일을 저장할 로컬 디렉토리
+      container-dir: ${REACT_DEPLOY_LOCAL_CONTAINER_DIR:../demo/front/src/reactcms/containers}
+      # 배포 이력 기록에 사용할 FWK_CMS_SERVER_INSTANCE.INSTANCE_ID
+      instance-id: ${REACT_DEPLOY_LOCAL_INSTANCE_ID:demo-local-react}
+
 # Scheduling Configuration (배치 이력 정리 스케줄러)
 scheduling:
   batch-his-cleanup:

--- a/admin/src/main/resources/mapper/oracle/reactcmsadmindeployment/ReactCmsAdminDeployMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/reactcmsadmindeployment/ReactCmsAdminDeployMapper.xml
@@ -26,32 +26,32 @@
         </where>
     </sql>
 
+    <!--
+        LATERAL JOIN으로 페이지별 최신 배포 이력 1건만 조회.
+        FILE_ID LIKE p.PAGE_ID || '%' — 전방 일치(leading wildcard 없음)로 인덱스 활용 가능.
+    -->
     <select id="findApprovedPageList" resultType="com.example.admin_demo.domain.reactcmsadmindeployment.dto.ReactCmsAdminDeployPageResponse">
         SELECT * FROM (
             SELECT INNER_QRY.*, ROWNUM AS RNUM FROM (
                 SELECT
-                    p.PAGE_ID                                                       AS pageId,
-                    p.PAGE_NAME                                                     AS pageName,
-                    p.CREATE_USER_NAME                                              AS createUserName,
-                    TO_CHAR(p.BEGINNING_DATE, 'YYYY-MM-DD')                        AS beginningDate,
-                    TO_CHAR(p.EXPIRED_DATE,   'YYYY-MM-DD')                        AS expiredDate,
-                    <!-- 하드코딩 대신 서비스 레이어에서 application.yml 설정값(protocol, path-prefix)으로 URL 조합 -->
-                    CASE WHEN lh.FILE_ID IS NOT NULL THEN si.INSTANCE_ID END        AS instanceId,
-                    CASE WHEN lh.FILE_ID IS NOT NULL THEN si.INSTANCE_IP END        AS instanceIp,
-                    CASE WHEN lh.FILE_ID IS NOT NULL THEN si.INSTANCE_PORT END      AS instancePort
+                    p.PAGE_ID                                AS pageId,
+                    p.PAGE_NAME                              AS pageName,
+                    p.CREATE_USER_NAME                       AS createUserName,
+                    TO_CHAR(p.BEGINNING_DATE, 'YYYY-MM-DD') AS beginningDate,
+                    TO_CHAR(p.EXPIRED_DATE,   'YYYY-MM-DD') AS expiredDate,
+                    <!-- 서비스 레이어에서 application.yml 설정값(protocol, path-prefix)으로 URL 조합 -->
+                    si.INSTANCE_ID                           AS instanceId,
+                    si.INSTANCE_IP                           AS instanceIp,
+                    si.INSTANCE_PORT                         AS instancePort
                 FROM SPW_CMS_PAGE p
-                LEFT JOIN (
-                    SELECT
-                        REGEXP_REPLACE(FILE_ID, '_v\d+\.(html|tsx)$', '') AS PAGE_ID,
-                        FILE_ID,
-                        INSTANCE_ID,
-                        ROW_NUMBER() OVER (
-                            PARTITION BY REGEXP_REPLACE(FILE_ID, '_v\d+\.(html|tsx)$', '')
-                            ORDER BY LAST_MODIFIED_DTIME DESC
-                        ) AS RN
+                LEFT JOIN LATERAL (
+                    SELECT FILE_ID, INSTANCE_ID
                     FROM FWK_CMS_FILE_SEND_HIS
-                    WHERE FILE_ID LIKE '%_v%.html' OR FILE_ID LIKE '%_v%.tsx'
-                ) lh ON lh.PAGE_ID = p.PAGE_ID AND lh.RN = 1
+                    WHERE FILE_ID LIKE p.PAGE_ID || '%.html'
+                       OR FILE_ID LIKE p.PAGE_ID || '%.tsx'
+                    ORDER BY LAST_MODIFIED_DTIME DESC
+                    FETCH FIRST 1 ROW ONLY
+                ) lh ON 1=1
                 LEFT JOIN FWK_CMS_SERVER_INSTANCE si ON lh.INSTANCE_ID = si.INSTANCE_ID
                 <include refid="approvedPageConditions"/>
                 ORDER BY p.LAST_MODIFIED_DTIME DESC NULLS LAST
@@ -68,11 +68,12 @@
 
     <!-- ==================== 배포 이력 조회 ==================== -->
 
+    <!-- FILE_ID LIKE #{req.pageId} || '%' — 전방 일치로 인덱스 활용 가능 -->
     <sql id="historySearchConditions">
         <where>
             <if test="req.pageId != null and req.pageId != ''">
-                (h.FILE_ID LIKE #{req.pageId} || '_v%.html'
-                OR h.FILE_ID LIKE #{req.pageId} || '_v%.tsx')
+                (h.FILE_ID LIKE #{req.pageId} || '%.html'
+                OR h.FILE_ID LIKE #{req.pageId} || '%.tsx')
             </if>
         </where>
     </sql>
@@ -123,19 +124,15 @@
     <!-- ==================== 배포 버전 관리 ==================== -->
 
     <!--
-        pageId 기준 최대 배포 버전 번호 조회.
-        FILE_ID 패턴: {pageId}_v{n}.html 또는 {pageId}_v{n}.tsx
-        이력이 없으면 0을 반환해 호출부에서 +1하여 첫 버전(1)으로 사용.
+        pageId 기준 누적 배포 횟수 조회.
+        FILE_ID LIKE #{pageId} || '%' — 전방 일치로 인덱스 활용 가능.
+        이력이 없으면 0을 반환한다.
     -->
     <select id="findMaxDeployVersion" resultType="int">
-        SELECT NVL(MAX(
-            TO_NUMBER(REGEXP_REPLACE(
-                REGEXP_SUBSTR(FILE_ID, '_v\d+\.(html|tsx)$'),
-                '[^0-9]', ''
-            ))
-        ), 0)
+        SELECT COUNT(*)
         FROM FWK_CMS_FILE_SEND_HIS
-        WHERE FILE_ID LIKE #{pageId} || '_v%'
+        WHERE FILE_ID LIKE #{pageId} || '%.tsx'
+           OR FILE_ID LIKE #{pageId} || '%.html'
     </select>
 
     <!--

--- a/admin/src/main/resources/mapper/oracle/reactcmsadmindeployment/ReactCmsAdminDeployMapper.xml
+++ b/admin/src/main/resources/mapper/oracle/reactcmsadmindeployment/ReactCmsAdminDeployMapper.xml
@@ -30,24 +30,27 @@
         SELECT * FROM (
             SELECT INNER_QRY.*, ROWNUM AS RNUM FROM (
                 SELECT
-                    p.PAGE_ID                                                   AS pageId,
-                    p.PAGE_NAME                                                 AS pageName,
-                    p.CREATE_USER_NAME                                          AS createUserName,
+                    p.PAGE_ID                                                       AS pageId,
+                    p.PAGE_NAME                                                     AS pageName,
+                    p.CREATE_USER_NAME                                              AS createUserName,
+                    TO_CHAR(p.BEGINNING_DATE, 'YYYY-MM-DD')                        AS beginningDate,
+                    TO_CHAR(p.EXPIRED_DATE,   'YYYY-MM-DD')                        AS expiredDate,
                     <!-- 하드코딩 대신 서비스 레이어에서 application.yml 설정값(protocol, path-prefix)으로 URL 조합 -->
-                    CASE WHEN lh.FILE_ID IS NOT NULL THEN si.INSTANCE_IP END    AS instanceIp,
-                    CASE WHEN lh.FILE_ID IS NOT NULL THEN si.INSTANCE_PORT END  AS instancePort
+                    CASE WHEN lh.FILE_ID IS NOT NULL THEN si.INSTANCE_ID END        AS instanceId,
+                    CASE WHEN lh.FILE_ID IS NOT NULL THEN si.INSTANCE_IP END        AS instanceIp,
+                    CASE WHEN lh.FILE_ID IS NOT NULL THEN si.INSTANCE_PORT END      AS instancePort
                 FROM SPW_CMS_PAGE p
                 LEFT JOIN (
                     SELECT
-                        REGEXP_REPLACE(FILE_ID, '_v\d+\.html$', '') AS PAGE_ID,
+                        REGEXP_REPLACE(FILE_ID, '_v\d+\.(html|tsx)$', '') AS PAGE_ID,
                         FILE_ID,
                         INSTANCE_ID,
                         ROW_NUMBER() OVER (
-                            PARTITION BY REGEXP_REPLACE(FILE_ID, '_v\d+\.html$', '')
+                            PARTITION BY REGEXP_REPLACE(FILE_ID, '_v\d+\.(html|tsx)$', '')
                             ORDER BY LAST_MODIFIED_DTIME DESC
                         ) AS RN
                     FROM FWK_CMS_FILE_SEND_HIS
-                    WHERE FILE_ID LIKE '%_v%.html'
+                    WHERE FILE_ID LIKE '%_v%.html' OR FILE_ID LIKE '%_v%.tsx'
                 ) lh ON lh.PAGE_ID = p.PAGE_ID AND lh.RN = 1
                 LEFT JOIN FWK_CMS_SERVER_INSTANCE si ON lh.INSTANCE_ID = si.INSTANCE_ID
                 <include refid="approvedPageConditions"/>
@@ -68,7 +71,8 @@
     <sql id="historySearchConditions">
         <where>
             <if test="req.pageId != null and req.pageId != ''">
-                h.FILE_ID LIKE #{req.pageId} || '_v%.html'
+                (h.FILE_ID LIKE #{req.pageId} || '_v%.html'
+                OR h.FILE_ID LIKE #{req.pageId} || '_v%.tsx')
             </if>
         </where>
     </sql>
@@ -114,6 +118,60 @@
           AND PAGE_TYPE    = 'REACT'
           AND APPROVE_STATE = 'APPROVED'
           AND USE_YN       = 'Y'
+    </select>
+
+    <!-- ==================== 배포 버전 관리 ==================== -->
+
+    <!--
+        pageId 기준 최대 배포 버전 번호 조회.
+        FILE_ID 패턴: {pageId}_v{n}.html 또는 {pageId}_v{n}.tsx
+        이력이 없으면 0을 반환해 호출부에서 +1하여 첫 버전(1)으로 사용.
+    -->
+    <select id="findMaxDeployVersion" resultType="int">
+        SELECT NVL(MAX(
+            TO_NUMBER(REGEXP_REPLACE(
+                REGEXP_SUBSTR(FILE_ID, '_v\d+\.(html|tsx)$'),
+                '[^0-9]', ''
+            ))
+        ), 0)
+        FROM FWK_CMS_FILE_SEND_HIS
+        WHERE FILE_ID LIKE #{pageId} || '_v%'
+    </select>
+
+    <!--
+        배포 이력 INSERT.
+        LAST_MODIFIED_DTIME은 DB SYSDATE로 자동 기록한다.
+    -->
+    <insert id="insertDeployHistory">
+        INSERT INTO FWK_CMS_FILE_SEND_HIS (
+            INSTANCE_ID,
+            FILE_ID,
+            FILE_SIZE,
+            FILE_CRC_VALUE,
+            LAST_MODIFIER_ID,
+            LAST_MODIFIED_DTIME
+        ) VALUES (
+            #{instanceId},
+            #{fileId},
+            #{fileSize},
+            #{fileCrcValue},
+            #{lastModifierId},
+            TO_CHAR(SYSDATE, 'YYYYMMDDHH24MISS')
+        )
+    </insert>
+
+    <!-- ==================== PAGE_DESC 조회 (로컬 파일 배포용) ==================== -->
+    <!--
+        PAGE_DESC 컬럼에는 CMS 빌더 저장 시 generateJSX()로 생성된 React JSX 코드가 저장된다.
+        로컬 배포 모드에서 이 코드를 {pageId}.tsx 파일로 직접 저장한다.
+    -->
+    <select id="findPageDescById" resultType="String">
+        SELECT PAGE_DESC
+        FROM SPW_CMS_PAGE
+        WHERE PAGE_ID       = #{pageId}
+          AND PAGE_TYPE     = 'REACT'
+          AND APPROVE_STATE = 'APPROVED'
+          AND USE_YN        = 'Y'
     </select>
 
 </mapper>

--- a/admin/src/main/resources/templates/pages/react-cms-admin-approval/react-cms-admin-approval-script.html
+++ b/admin/src/main/resources/templates/pages/react-cms-admin-approval/react-cms-admin-approval-script.html
@@ -131,7 +131,7 @@
                 return `<tr>
                     <td>
                         <span class="clickable-cell"
-                              onclick="ReactCmsAdminApprovalPage.openPreview('${pid}')"
+                              onclick="ReactCmsAdminApprovalPage.openReactPreview('${pid}')"
                               title="미리보기">${HtmlUtils.escape(row.pageName)}</span>
                     </td>
                     <td class="text-center">${HtmlUtils.escape(row.viewMode || '')}</td>
@@ -209,10 +209,16 @@
             this.load(1);
         },
 
-        // ── CMS 페이지 미리보기 ──
+        // ── CMS 페이지 미리보기 (HTML CMS 런타임 서버) ──
         openPreview: function(pageId) {
             const url = REACT_CMS_PREVIEW_URL.replace(/\/$/, '') + '/cms/view?bank=' + encodeURIComponent(pageId) + '&preview=1';
             window.open(url, 'reactCmsPreview', 'width=1280,height=800,scrollbars=yes,resizable=yes');
+        },
+
+        // ── React CMS 페이지 프리뷰 (/react-cms/preview?pageType=REACT&pageId=xxx) ──
+        openReactPreview: function(pageId) {
+            const url = '/react-cms/preview?pageType=REACT&pageId=' + encodeURIComponent(pageId);
+            window.open(url, 'reactCmsBuilderPreview', 'width=1280,height=800,scrollbars=yes,resizable=yes');
         },
 
         // ── 승인 모달 ──

--- a/admin/src/main/resources/templates/pages/react-cms-admin-deployment/react-cms-admin-deployment-script.html
+++ b/admin/src/main/resources/templates/pages/react-cms-admin-deployment/react-cms-admin-deployment-script.html
@@ -9,8 +9,7 @@
           currentPage: 1,
           totalItems: 0,
           itemsPerPage: 10,
-          canWrite:
-            /*[[${userAuthorities != null && userAuthorities.contains('REACT_CMS:W')}]]*/ false,
+          canWrite: /*[[${userAuthorities != null && userAuthorities.contains('REACT_CMS:W')}]]*/ false,
 
           load: function (page) {
             if (page !== undefined) this.currentPage = page;
@@ -37,40 +36,70 @@
 
           renderTable: function (rows) {
             const $tbody = $("#reactCmsAdminDeployPageTableBody");
-            const colspan = this.canWrite ? 6 : 5;
+            // 배포 컬럼은 쓰기 권한 보유 시 추가 — colspan 계산에 반영
+            const colspan = this.canWrite ? 8 : 7;
 
             if (!rows || rows.length === 0) {
               $tbody.html(
-                `<tr><td colspan="${colspan}" class="text-center py-4 text-body-secondary">조회된 데이터가 없습니다.</td></tr>`
+                `<tr><td colspan="${colspan}" class="text-center py-4 text-body-secondary">조회된 데이터가 없습니다.</td></tr>`,
               );
               return;
             }
 
             const html = rows
               .map((row) => {
-                const previewBtn = row.deployedUrl
-                  ? `<a href="${HtmlUtils.escape(row.deployedUrl)}" target="_blank" rel="noopener"
-                         class="btn btn-outline-info btn-xs"><i class="bi bi-box-arrow-up-right"></i> 보기</a>`
-                  : '<span class="text-body-secondary small">-</span>';
+                const pid = HtmlUtils.escape(row.pageId);
+                const pname = HtmlUtils.escape(row.pageName || "");
 
-                const deployBtn = this.canWrite
+                // 노출기간: beginningDate ~ expiredDate, 둘 다 없으면 "-"
+                const period =
+                  row.beginningDate || row.expiredDate
+                    ? `${HtmlUtils.escape(row.beginningDate || "-")} ~ ${HtmlUtils.escape(row.expiredDate || "-")}`
+                    : "-";
+
+                // 배포 컬럼 (쓰기 권한 보유 시만 렌더링) — XSS 방지: pageId를 data-* 속성에만 저장
+                const deployTd = this.canWrite
                   ? `<td class="text-center">
-                         <button class="btn btn-primary btn-xs"
-                                 onclick="ReactCmsAdminDeployPage.confirmPush('${HtmlUtils.escape(row.pageId)}', '${HtmlUtils.escape(row.pageName || "")}')">
+                         <button class="btn btn-primary btn-xs js-deploy-push"
+                                 data-page-id="${pid}" data-page-name="${pname}">
                              <i class="bi bi-send"></i> 배포
                          </button>
                      </td>`
                   : "";
 
+                // 배포 미리보기: react-cms 빌더 미리보기 페이지로 팝업 오픈
+                const previewBtn = `<button class="btn btn-outline-info btn-xs js-deploy-preview"
+                        data-page-id="${pid}">
+                    <i class="bi bi-box-arrow-up-right"></i> 보기
+                </button>`;
+
+                // 배포 URL: 이력이 있으면 링크 + 복사 버튼, 없으면 "-"
+                const escapedUrl = row.deployedUrl
+                  ? HtmlUtils.escape(row.deployedUrl)
+                  : "";
+                const deployedUrlTd = row.deployedUrl
+                  ? `<div class="d-flex flex-column gap-1">
+                         <a href="${escapedUrl}" target="_blank" rel="noopener"
+                            class="small text-break">${escapedUrl}</a>
+                         <button class="btn btn-outline-secondary btn-xs js-copy-url align-self-center"
+                                 data-url="${escapedUrl}"
+                                 title="URL 복사">
+                             URL 복사
+                         </button>
+                     </div>`
+                  : '<span class="text-body-secondary small">-</span>';
+
                 return `<tr>
-                    <td class="small">${HtmlUtils.escape(row.pageId)}</td>
-                    <td>${HtmlUtils.escape(row.pageName || "")}</td>
-                    <td>${HtmlUtils.escape(row.createUserName || "")}</td>
+                    <td class="small">${pid}</td>
+                    <td>${pname}</td>
+                    <td class="text-center">${HtmlUtils.escape(row.createUserName || "")}</td>
+                    <td class="text-center small">${period}</td>
+                    ${deployTd}
                     <td class="text-center">${previewBtn}</td>
-                    ${deployBtn}
+                    <td class="text-center">${deployedUrlTd}</td>
                     <td class="text-center">
-                        <button class="btn btn-outline-secondary btn-xs"
-                                onclick="ReactCmsAdminDeployPage.openHistoryModal('${HtmlUtils.escape(row.pageId)}', '${HtmlUtils.escape(row.pageName || "")}')">
+                        <button class="btn btn-outline-secondary btn-xs js-deploy-history"
+                                data-page-id="${pid}" data-page-name="${pname}">
                             <i class="bi bi-clock-history"></i> 이력
                         </button>
                     </td>
@@ -82,9 +111,7 @@
           },
 
           renderPagination: function () {
-            const totalPages = Math.ceil(
-              this.totalItems / this.itemsPerPage
-            );
+            const totalPages = Math.ceil(this.totalItems / this.itemsPerPage);
             const pagination = $("#pagination");
             pagination.empty();
 
@@ -100,7 +127,7 @@
             const maxButtons = 5;
             let startPage = Math.max(
               1,
-              this.currentPage - Math.floor(maxButtons / 2)
+              this.currentPage - Math.floor(maxButtons / 2),
             );
             let endPage = Math.min(totalPages, startPage + maxButtons - 1);
             if (endPage - startPage + 1 < maxButtons) {
@@ -130,15 +157,15 @@
                 : (this.currentPage - 1) * this.itemsPerPage + 1;
             const end = Math.min(
               this.currentPage * this.itemsPerPage,
-              this.totalItems
+              this.totalItems,
             );
-            $("#pageInfo").text(`${start} - ${end} of ${this.totalItems} items`);
+            $("#pageInfo").text(
+              `${start} - ${end} of ${this.totalItems} items`,
+            );
           },
 
           changePage: function (page) {
-            const totalPages = Math.ceil(
-              this.totalItems / this.itemsPerPage
-            );
+            const totalPages = Math.ceil(this.totalItems / this.itemsPerPage);
             if (page < 1 || page > totalPages) return;
             this.currentPage = page;
             this.load();
@@ -172,18 +199,29 @@
               .catch(() => Toast.error("배포 중 오류가 발생했습니다."));
           },
 
+          // ── 배포 미리보기 ──
+
+          openDeployPreview: function (pageId) {
+            const url =
+              "/react-cms/preview?pageType=REACT&pageId=" +
+              encodeURIComponent(pageId);
+            window.open(
+              url,
+              "reactCmsDeployPreview",
+              "width=430,height=860,scrollbars=yes,resizable=yes",
+            );
+          },
+
           // ── 배포이력 상세 모달 ──
 
           openHistoryModal: function (pageId, pageName) {
             $("#deployHistoryModalPageInfo").text(
-              `페이지: ${pageName} (${pageId})`
+              `페이지: ${pageName} (${pageId})`,
             );
             $("#deployHistoryModalTableBody").html(
-              '<tr><td colspan="5" class="text-center text-body-secondary">불러오는 중...</td></tr>'
+              '<tr><td colspan="5" class="text-center text-body-secondary">불러오는 중...</td></tr>',
             );
-            new bootstrap.Modal(
-              "#reactCmsAdminDeployHistoryModal"
-            ).show();
+            new bootstrap.Modal("#reactCmsAdminDeployHistoryModal").show();
 
             const params = new URLSearchParams({ pageId, page: 1, size: 50 });
             fetch("/api/react-cms-admin/deployments?" + params)
@@ -191,14 +229,14 @@
               .then((res) => {
                 if (!res.success) {
                   $("#deployHistoryModalTableBody").html(
-                    '<tr><td colspan="5" class="text-center text-danger">이력 조회 실패</td></tr>'
+                    '<tr><td colspan="5" class="text-center text-danger">이력 조회 실패</td></tr>',
                   );
                   return;
                 }
                 const rows = res.data.content;
                 if (!rows || rows.length === 0) {
                   $("#deployHistoryModalTableBody").html(
-                    '<tr><td colspan="5" class="text-center text-body-secondary">배포 이력이 없습니다.</td></tr>'
+                    '<tr><td colspan="5" class="text-center text-body-secondary">배포 이력이 없습니다.</td></tr>',
                   );
                   return;
                 }
@@ -212,14 +250,14 @@
                         <td>${HtmlUtils.escape(row.lastModifierId || "")}</td>
                         <td class="small">${ReactCmsAdminDeployPage.formatDtime(row.lastModifiedDtime)}</td>
                     </tr>
-                `
+                `,
                   )
                   .join("");
                 $("#deployHistoryModalTableBody").html(html);
               })
               .catch(() => {
                 $("#deployHistoryModalTableBody").html(
-                  '<tr><td colspan="5" class="text-center text-danger">이력 조회 중 오류가 발생했습니다.</td></tr>'
+                  '<tr><td colspan="5" class="text-center text-danger">이력 조회 중 오류가 발생했습니다.</td></tr>',
                 );
               });
           },
@@ -268,6 +306,34 @@
           $("#btnRefresh").on("click", function () {
             ReactCmsAdminDeployPage.load();
           });
+
+          // 이벤트 위임 — XSS 방지: onclick 인라인 대신 data-* 속성으로 pageId/pageName 전달
+          $(document)
+            .on("click", ".js-copy-url", function () {
+              const url = $(this).data("url");
+              const $btn = $(this);
+              navigator.clipboard
+                .writeText(url)
+                .then(() => Toast.success("URL이 복사되었습니다."))
+                .catch(() => Toast.error("URL 복사에 실패했습니다."));
+            })
+            .on("click", ".js-deploy-push", function () {
+              ReactCmsAdminDeployPage.confirmPush(
+                $(this).data("page-id"),
+                $(this).data("page-name"),
+              );
+            })
+            .on("click", ".js-deploy-preview", function () {
+              ReactCmsAdminDeployPage.openDeployPreview(
+                $(this).data("page-id"),
+              );
+            })
+            .on("click", ".js-deploy-history", function () {
+              ReactCmsAdminDeployPage.openHistoryModal(
+                $(this).data("page-id"),
+                $(this).data("page-name"),
+              );
+            });
         });
       </script>
     </th:block>

--- a/admin/src/main/resources/templates/pages/react-cms-admin-deployment/react-cms-admin-deployment-table.html
+++ b/admin/src/main/resources/templates/pages/react-cms-admin-deployment/react-cms-admin-deployment-table.html
@@ -12,19 +12,21 @@
             <th class="col-w-120">페이지 ID</th>
             <th>페이지명</th>
             <th class="col-w-100">작성자</th>
-            <th class="col-w-90">배포 미리보기</th>
+            <th class="col-w-180">노출기간</th>
             <th
               class="col-w-70"
               th:if="${userAuthorities != null && userAuthorities.contains('REACT_CMS:W')}"
             >
               배포
             </th>
-            <th class="col-w-80">배포이력 상세</th>
+            <th class="col-w-90">배포 미리보기</th>
+            <th class="col-w-200">배포 URL</th>
+            <th class="col-w-90">배포이력 상세</th>
           </tr>
         </thead>
         <tbody id="reactCmsAdminDeployPageTableBody">
           <tr>
-            <td colspan="6" class="text-center py-4 text-body-secondary">
+            <td colspan="8" class="text-center py-4 text-body-secondary">
               조회 버튼을 클릭하여 데이터를 불러오세요.
             </td>
           </tr>

--- a/admin/src/main/resources/templates/pages/react-cms-admin-deployment/react-cms-admin-deployment.html
+++ b/admin/src/main/resources/templates/pages/react-cms-admin-deployment/react-cms-admin-deployment.html
@@ -18,18 +18,25 @@
             id="filterSearch"
             class="form-control form-control-sm flex-fixed-200"
             placeholder="페이지명 또는 작성자"
-            onkeypress="if(event.key === 'Enter') ReactCmsAdminDeployPage.load(1)"
+            onkeypress="
+              if (event.key === 'Enter') ReactCmsAdminDeployPage.load(1);
+            "
           />
 
           <div class="flex-grow-1"></div>
 
-          <select id="limitRows" class="form-select form-select-sm sp-limit-select">
+          <select
+            id="limitRows"
+            class="form-select form-select-sm sp-limit-select"
+          >
             <option value="10" selected>10</option>
             <option value="20">20</option>
             <option value="50">50</option>
             <option value="100">100</option>
           </select>
-          <label class="form-label mb-0 small fw-medium ms-1 me-2 fs-xs">건씩</label>
+          <label class="form-label mb-0 small fw-medium ms-1 me-2 fs-xs"
+            >건씩</label
+          >
 
           <button
             class="btn btn-primary btn-sm"
@@ -59,11 +66,6 @@
         </div>
       </div>
 
-      <div class="alert alert-info py-2 small" role="alert">
-        <strong>React CMS 리소스 경계</strong>
-        이 화면은 승인완료(APPROVED) React 페이지의 배포 실행과 배포이력 조회만 제공합니다.
-      </div>
-
       <!-- 테이블 -->
       <div
         th:replace="~{pages/react-cms-admin-deployment/react-cms-admin-deployment-table :: table}"
@@ -73,7 +75,11 @@
       <div th:replace="~{fragments/page-content-layout :: pagination}"></div>
 
       <!-- ==================== 배포이력 상세 모달 ==================== -->
-      <div class="modal fade" id="reactCmsAdminDeployHistoryModal" tabindex="-1">
+      <div
+        class="modal fade"
+        id="reactCmsAdminDeployHistoryModal"
+        tabindex="-1"
+      >
         <div class="modal-dialog modal-xl">
           <div class="modal-content">
             <div class="modal-header">

--- a/admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard-script.html
+++ b/admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard-script.html
@@ -1,364 +1,430 @@
-<!DOCTYPE html>
+<!doctype html>
 <html xmlns:th="http://www.thymeleaf.org">
-<body>
-<th:block th:fragment="script">
-<script th:inline="javascript">
-/*<![CDATA[*/
-    const HAS_REACT_CMS_WRITE = /*[[${userAuthorities != null && userAuthorities.contains('REACT-CMS:W')}]]*/ false;
-/*]]>*/
-</script>
-<script>
-    // ==================== ReactCmsDashboardPage ====================
+  <body>
+    <th:block th:fragment="script">
+      <script th:inline="javascript">
+        /*<![CDATA[*/
+        const HAS_REACT_CMS_WRITE = /*[[${userAuthorities != null && userAuthorities.contains('REACT_CMS:W')}]]*/ false;
+        /*]]>*/
+      </script>
+      <script>
+        // ==================== ReactCmsDashboardPage ====================
 
-    window.ReactCmsDashboardPage = {
-        currentPage: 1,
-        totalItems: 0,
-        itemsPerPage: 10,
-        sortBy: null,
-        sortDirection: null,
-        rowsByPageId: {},
+        window.ReactCmsDashboardPage = {
+          currentPage: 1,
+          totalItems: 0,
+          itemsPerPage: 10,
+          sortBy: null,
+          sortDirection: null,
+          rowsByPageId: {},
 
-        APPROVE_STATE_BADGE: {
-            WORK:     '<span class="badge bg-secondary">작업중</span>',
-            PENDING:  '<span class="badge bg-warning text-dark">승인대기</span>',
+          APPROVE_STATE_BADGE: {
+            WORK: '<span class="badge bg-secondary">작업중</span>',
+            PENDING: '<span class="badge bg-warning text-dark">승인대기</span>',
             APPROVED: '<span class="badge bg-success">승인완료</span>',
             REJECTED: '<span class="badge bg-danger">반려</span>',
-        },
+          },
 
-        load: function(page) {
+          load: function (page) {
             if (page !== undefined) this.currentPage = page;
             const params = new URLSearchParams({
-                page:         this.currentPage,
-                size:         this.itemsPerPage,
-                approveState: $('#filterApproveState').val(),
-                search:       $('#filterSearch').val().trim(),
+              page: this.currentPage,
+              size: this.itemsPerPage,
+              approveState: $("#filterApproveState").val(),
+              search: $("#filterSearch").val().trim(),
             });
             if (this.sortBy) {
-                params.append('sortBy', this.sortBy);
-                params.append('sortDirection', this.sortDirection);
+              params.append("sortBy", this.sortBy);
+              params.append("sortDirection", this.sortDirection);
             }
 
-            fetch('/api/react-cms-dashboard/pages?' + params)
-                .then(r => r.json())
-                .then(res => {
-                    if (!res.success) { Toast.error(res.message); return; }
-                    const pageData = res.data;
-                    this.totalItems = pageData.totalElements;
-                    this.renderTable(pageData.content);
-                    this.renderPagination();
-                    this.updateSortIndicators();
-                })
-                .catch(() => Toast.error('목록 조회 중 오류가 발생했습니다.'));
-        },
+            fetch("/api/react-cms-dashboard/pages?" + params)
+              .then((r) => r.json())
+              .then((res) => {
+                if (!res.success) {
+                  Toast.error(res.message);
+                  return;
+                }
+                const pageData = res.data;
+                this.totalItems = pageData.totalElements;
+                this.renderTable(pageData.content);
+                this.renderPagination();
+                this.updateSortIndicators();
+              })
+              .catch(() => Toast.error("목록 조회 중 오류가 발생했습니다."));
+          },
 
-        attachSortHandlers: function() {
+          attachSortHandlers: function () {
             $(document)
-                .off('click.reactCmsDashboardSort', '#reactCmsDashboardTable thead th[data-sort]')
-                .on('click.reactCmsDashboardSort', '#reactCmsDashboardTable thead th[data-sort]', function() {
-                    const sortKey = $(this).data('sort');
-                    if (!sortKey) return;
+              .off(
+                "click.reactCmsDashboardSort",
+                "#reactCmsDashboardTable thead th[data-sort]",
+              )
+              .on(
+                "click.reactCmsDashboardSort",
+                "#reactCmsDashboardTable thead th[data-sort]",
+                function () {
+                  const sortKey = $(this).data("sort");
+                  if (!sortKey) return;
 
-                    if (ReactCmsDashboardPage.sortBy === sortKey) {
-                        if (ReactCmsDashboardPage.sortDirection === 'ASC') {
-                            ReactCmsDashboardPage.sortDirection = 'DESC';
-                        } else {
-                            ReactCmsDashboardPage.sortBy = null;
-                            ReactCmsDashboardPage.sortDirection = null;
-                        }
+                  if (ReactCmsDashboardPage.sortBy === sortKey) {
+                    if (ReactCmsDashboardPage.sortDirection === "ASC") {
+                      ReactCmsDashboardPage.sortDirection = "DESC";
                     } else {
-                        ReactCmsDashboardPage.sortBy = sortKey;
-                        ReactCmsDashboardPage.sortDirection = 'ASC';
+                      ReactCmsDashboardPage.sortBy = null;
+                      ReactCmsDashboardPage.sortDirection = null;
                     }
+                  } else {
+                    ReactCmsDashboardPage.sortBy = sortKey;
+                    ReactCmsDashboardPage.sortDirection = "ASC";
+                  }
 
-                    ReactCmsDashboardPage.updateSortIndicators();
-                    ReactCmsDashboardPage.load(1);
-                });
-        },
+                  ReactCmsDashboardPage.updateSortIndicators();
+                  ReactCmsDashboardPage.load(1);
+                },
+              );
+          },
 
-        updateSortIndicators: function() {
-            const headers = $('#reactCmsDashboardTable thead th.sortable');
-            headers.removeClass('sort-asc sort-desc');
+          updateSortIndicators: function () {
+            const headers = $("#reactCmsDashboardTable thead th.sortable");
+            headers.removeClass("sort-asc sort-desc");
             if (!this.sortBy || !this.sortDirection) return;
-            headers.filter(`[data-sort="${this.sortBy}"]`)
-                .addClass(this.sortDirection === 'ASC' ? 'sort-asc' : 'sort-desc');
-        },
+            headers
+              .filter(`[data-sort="${this.sortBy}"]`)
+              .addClass(
+                this.sortDirection === "ASC" ? "sort-asc" : "sort-desc",
+              );
+          },
 
-        renderTable: function(rows) {
-            const $tbody = $('#reactCmsDashboardTableBody');
+          renderTable: function (rows) {
+            const $tbody = $("#reactCmsDashboardTableBody");
             if (!rows || rows.length === 0) {
-                this.rowsByPageId = {};
-                $tbody.html('<tr><td colspan="8" class="text-center py-4 text-body-secondary">조회된 데이터가 없습니다.</td></tr>');
-                return;
+              this.rowsByPageId = {};
+              $tbody.html(
+                '<tr><td colspan="8" class="text-center py-4 text-body-secondary">조회된 데이터가 없습니다.</td></tr>',
+              );
+              return;
             }
 
             this.rowsByPageId = rows.reduce((map, row) => {
-                if (row.pageId) map[row.pageId] = row;
-                return map;
+              if (row.pageId) map[row.pageId] = row;
+              return map;
             }, {});
 
-            const html = rows.map(row => {
-                const badge      = this.APPROVE_STATE_BADGE[row.approveState] || HtmlUtils.escape(row.approveState);
-                const expiredCls = row.isExpired === 'Y' ? 'text-danger fw-bold' : '';
+            const html = rows
+              .map((row) => {
+                const badge =
+                  this.APPROVE_STATE_BADGE[row.approveState] ||
+                  HtmlUtils.escape(row.approveState);
+                const expiredCls =
+                  row.isExpired === "Y" ? "text-danger fw-bold" : "";
                 // XSS 방지: pageId는 data-* 속성에만 저장하고 onclick 인라인 삽입 금지
-                const pid        = HtmlUtils.escape(row.pageId);
+                const pid = HtmlUtils.escape(row.pageId);
 
                 // 승인요청 버튼 — WORK: "승인요청", REJECTED/APPROVED: "재승인요청", PENDING: 버튼 없음
-                let tdApprove = '-';
+                let tdApprove = "-";
                 if (HAS_REACT_CMS_WRITE) {
-                    if (row.approveState === 'WORK') {
-                        tdApprove = `<button class="btn btn-primary btn-xs js-approve-request"
+                  if (row.approveState === "WORK") {
+                    tdApprove = `<button class="btn btn-primary btn-xs js-approve-request"
                             data-page-id="${pid}">승인요청</button>`;
-                    } else if (row.approveState === 'REJECTED' || row.approveState === 'APPROVED') {
-                        tdApprove = `<button class="btn btn-outline-primary btn-xs js-approve-request"
+                  } else if (
+                    row.approveState === "REJECTED" ||
+                    row.approveState === "APPROVED"
+                  ) {
+                    tdApprove = `<button class="btn btn-outline-primary btn-xs js-approve-request"
                             data-page-id="${pid}">재승인요청</button>`;
-                    }
+                  }
                 }
 
                 const tdDelete = HAS_REACT_CMS_WRITE
-                    ? `<button class="btn btn-outline-danger btn-xs js-delete-page"
+                  ? `<button class="btn btn-outline-danger btn-xs js-delete-page"
                            data-page-id="${pid}">삭제</button>`
-                    : '-';
+                  : "-";
 
                 // 반려 상태면 페이지명 옆에 반려 사유 확인 아이콘 표시
-                const rejectedLink = (row.approveState === 'REJECTED' && row.rejectedReason)
+                const rejectedLink =
+                  row.approveState === "REJECTED" && row.rejectedReason
                     ? ` <a href="#" class="text-danger small js-rejected-reason" title="반려 사유 확인"
                             data-page-id="${pid}">
                             <i class="bi bi-exclamation-circle"></i></a>`
-                    : '';
+                    : "";
 
                 return `<tr>
                     <td>
                         <span class="clickable-cell js-open-editor"
                               data-page-id="${pid}"
-                              title="React CMS 에디터로 이동">${HtmlUtils.escape(row.pageName || '')}</span>${rejectedLink}
+                              title="React CMS 에디터로 이동">${HtmlUtils.escape(row.pageName || "")}</span>${rejectedLink}
                     </td>
-                    <td class="text-center">${HtmlUtils.escape(row.viewMode || 'mobile')}</td>
                     <td class="text-center">${badge}</td>
-                    <td class="text-center">${HtmlUtils.escape(row.beginningDate || '-')}</td>
-                    <td class="text-center ${expiredCls}">${HtmlUtils.escape(row.expiredDate || '-')}</td>
-                    <td class="text-center small">${HtmlUtils.escape(row.lastModifiedDtime || '-')}</td>
+                    <td class="text-center">${HtmlUtils.escape(row.beginningDate || "-")}</td>
+                    <td class="text-center ${expiredCls}">${HtmlUtils.escape(row.expiredDate || "-")}</td>
+                    <td class="text-center small">${HtmlUtils.escape(row.lastModifiedDtime || "-")}</td>
                     <td class="text-center">${tdApprove}</td>
                     <td class="text-center">${tdDelete}</td>
                 </tr>`;
-            }).join('');
+              })
+              .join("");
 
             $tbody.html(html);
-        },
+          },
 
-        renderPagination: function() {
+          renderPagination: function () {
             const totalPages = Math.ceil(this.totalItems / this.itemsPerPage);
-            const pagination = $('#pagination');
+            const pagination = $("#pagination");
             pagination.empty();
 
             pagination.append(`
-                <li class="page-item ${this.currentPage === 1 ? 'disabled' : ''}">
+                <li class="page-item ${this.currentPage === 1 ? "disabled" : ""}">
                     <a class="page-link" href="#" onclick="ReactCmsDashboardPage.changePage(1); return false;"><i class="bi bi-chevron-double-left"></i></a>
                 </li>
-                <li class="page-item ${this.currentPage === 1 ? 'disabled' : ''}">
+                <li class="page-item ${this.currentPage === 1 ? "disabled" : ""}">
                     <a class="page-link" href="#" onclick="ReactCmsDashboardPage.changePage(${this.currentPage - 1}); return false;"><i class="bi bi-chevron-left"></i></a>
                 </li>
             `);
 
             const maxButtons = 5;
-            let startPage = Math.max(1, this.currentPage - Math.floor(maxButtons / 2));
-            let endPage   = Math.min(totalPages, startPage + maxButtons - 1);
+            let startPage = Math.max(
+              1,
+              this.currentPage - Math.floor(maxButtons / 2),
+            );
+            let endPage = Math.min(totalPages, startPage + maxButtons - 1);
             if (endPage - startPage + 1 < maxButtons) {
-                startPage = Math.max(1, endPage - maxButtons + 1);
+              startPage = Math.max(1, endPage - maxButtons + 1);
             }
 
             for (let i = startPage; i <= endPage; i++) {
-                pagination.append(`
-                    <li class="page-item ${i === this.currentPage ? 'active' : ''}">
+              pagination.append(`
+                    <li class="page-item ${i === this.currentPage ? "active" : ""}">
                         <a class="page-link" href="#" onclick="ReactCmsDashboardPage.changePage(${i}); return false;">${i}</a>
                     </li>
                 `);
             }
 
             pagination.append(`
-                <li class="page-item ${this.currentPage === totalPages || totalPages === 0 ? 'disabled' : ''}">
+                <li class="page-item ${this.currentPage === totalPages || totalPages === 0 ? "disabled" : ""}">
                     <a class="page-link" href="#" onclick="ReactCmsDashboardPage.changePage(${this.currentPage + 1}); return false;"><i class="bi bi-chevron-right"></i></a>
                 </li>
-                <li class="page-item ${this.currentPage === totalPages || totalPages === 0 ? 'disabled' : ''}">
+                <li class="page-item ${this.currentPage === totalPages || totalPages === 0 ? "disabled" : ""}">
                     <a class="page-link" href="#" onclick="ReactCmsDashboardPage.changePage(${totalPages}); return false;"><i class="bi bi-chevron-double-right"></i></a>
                 </li>
             `);
 
-            const start = this.totalItems === 0 ? 0 : (this.currentPage - 1) * this.itemsPerPage + 1;
-            const end   = Math.min(this.currentPage * this.itemsPerPage, this.totalItems);
-            $('#pageInfo').text(`${start} - ${end} of ${this.totalItems} items`);
-        },
+            const start =
+              this.totalItems === 0
+                ? 0
+                : (this.currentPage - 1) * this.itemsPerPage + 1;
+            const end = Math.min(
+              this.currentPage * this.itemsPerPage,
+              this.totalItems,
+            );
+            $("#pageInfo").text(
+              `${start} - ${end} of ${this.totalItems} items`,
+            );
+          },
 
-        changePage: function(page) {
+          changePage: function (page) {
             const totalPages = Math.ceil(this.totalItems / this.itemsPerPage);
             if (page < 1 || page > totalPages) return;
             this.currentPage = page;
             this.load();
-        },
+          },
 
-        reset: function() {
-            $('#filterApproveState').val('');
-            $('#filterSearch').val('');
+          reset: function () {
+            $("#filterApproveState").val("");
+            $("#filterSearch").val("");
             this.sortBy = null;
             this.sortDirection = null;
             this.updateSortIndicators();
-            this.itemsPerPage = parseInt($('#limitRows').val()) || 10;
+            this.itemsPerPage = parseInt($("#limitRows").val()) || 10;
             this.load(1);
-        },
+          },
 
-        // ── React CMS 에디터 — 팝업 창으로 열기 ──
-        openEditor: function(pageId) {
+          // ── React CMS 에디터 — 팝업 창으로 열기 ──
+          openEditor: function (pageId) {
             window.open(
-                '/react-cms/builder?pageId=' + encodeURIComponent(pageId),
-                'reactCmsEditor',
-                'width=1280,height=800,scrollbars=yes,resizable=yes'
+              "/react-cms/builder?pageId=" + encodeURIComponent(pageId),
+              "reactCmsEditor",
+              "width=1280,height=800,scrollbars=yes,resizable=yes",
             );
-        },
+          },
 
-        // 승인자 목록 캐시 — 변경 빈도가 낮으므로 페이지 세션 동안 재사용
-        _approversCache: null,
+          // 승인자 목록 캐시 — 변경 빈도가 낮으므로 페이지 세션 동안 재사용
+          _approversCache: null,
 
-        _loadApprovers: function() {
+          _loadApprovers: function () {
             if (this._approversCache) {
-                return Promise.resolve(this._approversCache);
+              return Promise.resolve(this._approversCache);
             }
-            return fetch('/api/auth/react-cms-approvers')
-                .then(r => r.json())
-                .then(res => {
-                    if (res.success) this._approversCache = res.data;
-                    return res.success ? res.data : [];
-                });
-        },
+            return fetch("/api/auth/react-cms-approvers")
+              .then((r) => r.json())
+              .then((res) => {
+                if (res.success) this._approversCache = res.data;
+                return res.success ? res.data : [];
+              });
+          },
 
-        // ── 승인 요청 모달 ──
-        openApproveRequestModal: function(pageId) {
+          // ── 승인 요청 모달 ──
+          openApproveRequestModal: function (pageId) {
             const row = this.rowsByPageId[pageId] || {};
-            const isReApprove = row.approveState === 'REJECTED' || row.approveState === 'APPROVED';
-            $('#approveRequestModalTitle').text(isReApprove ? '재승인요청' : '승인 요청');
-            $('#approveRequestPageId').val(pageId);
-            $('#approveRequestPageName').text(row.pageName || '-');
-            $('#approveRequestApproverId').html('<option value="">승인자 선택</option>');
-            $('#approveRequestBeginningDate').val(row.beginningDate || '');
-            $('#approveRequestExpiredDate').val(row.expiredDate || '');
+            const isReApprove =
+              row.approveState === "REJECTED" ||
+              row.approveState === "APPROVED";
+            $("#approveRequestModalTitle").text(
+              isReApprove ? "재승인요청" : "승인 요청",
+            );
+            $("#approveRequestPageId").val(pageId);
+            $("#approveRequestPageName").text(row.pageName || "-");
+            $("#approveRequestApproverId").html(
+              '<option value="">승인자 선택</option>',
+            );
+            $("#approveRequestBeginningDate").val(row.beginningDate || "");
+            $("#approveRequestExpiredDate").val(row.expiredDate || "");
 
-            this._loadApprovers().then(approvers => {
-                const options = approvers.map(a =>
+            this._loadApprovers().then((approvers) => {
+              const options = approvers
+                .map(
+                  (a) =>
                     `<option value="${HtmlUtils.escape(a.userId)}" data-name="${HtmlUtils.escape(a.userName)}">
                         ${HtmlUtils.escape(a.userName)}
-                    </option>`
-                ).join('');
-                $('#approveRequestApproverId').append(options);
+                    </option>`,
+                )
+                .join("");
+              $("#approveRequestApproverId").append(options);
             });
 
-            new bootstrap.Modal('#approveRequestModal').show();
-        },
+            new bootstrap.Modal("#approveRequestModal").show();
+          },
 
-        _isSubmittingApproval: false,
+          _isSubmittingApproval: false,
 
-        _submitApproveRequest: function() {
+          _submitApproveRequest: function () {
             if (this._isSubmittingApproval) return;
 
-            const pageId     = $('#approveRequestPageId').val();
-            const approverId = $('#approveRequestApproverId').val();
+            const pageId = $("#approveRequestPageId").val();
+            const approverId = $("#approveRequestApproverId").val();
 
-            if (!approverId) { Toast.warning('승인자를 선택하세요.'); return; }
+            if (!approverId) {
+              Toast.warning("승인자를 선택하세요.");
+              return;
+            }
 
-            const beginningDate = $('#approveRequestBeginningDate').val();
-            const expiredDate   = $('#approveRequestExpiredDate').val();
+            const beginningDate = $("#approveRequestBeginningDate").val();
+            const expiredDate = $("#approveRequestExpiredDate").val();
 
             this._isSubmittingApproval = true;
-            $('#btnApproveRequestConfirm').prop('disabled', true);
+            $("#btnApproveRequestConfirm").prop("disabled", true);
 
             // approverName은 서버에서 DB 조회 — 클라이언트에서 전달하지 않음 (위변조 방지)
             fetch(`/api/react-cms-dashboard/pages/${pageId}/approve-request`, {
-                method: 'PATCH',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ approverId, beginningDate, expiredDate }),
+              method: "PATCH",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ approverId, beginningDate, expiredDate }),
             })
-                .then(r => r.json())
-                .then(res => {
-                    bootstrap.Modal.getInstance('#approveRequestModal').hide();
-                    if (res.success) { Toast.success(res.message); this.load(); }
-                    else             { Toast.error(res.message); }
-                })
-                .catch(() => Toast.error('승인 요청 중 오류가 발생했습니다.'))
-                .finally(() => {
-                    this._isSubmittingApproval = false;
-                    $('#btnApproveRequestConfirm').prop('disabled', false);
-                });
-        },
+              .then((r) => r.json())
+              .then((res) => {
+                bootstrap.Modal.getInstance("#approveRequestModal").hide();
+                if (res.success) {
+                  Toast.success(res.message);
+                  this.load();
+                } else {
+                  Toast.error(res.message);
+                }
+              })
+              .catch(() => Toast.error("승인 요청 중 오류가 발생했습니다."))
+              .finally(() => {
+                this._isSubmittingApproval = false;
+                $("#btnApproveRequestConfirm").prop("disabled", false);
+              });
+          },
 
-        // ── 반려 사유 확인 ──
-        showRejectedReason: function(pageId) {
+          // ── 반려 사유 확인 ──
+          showRejectedReason: function (pageId) {
             const row = this.rowsByPageId[pageId] || {};
-            $('#rejectedReasonText').text(row.rejectedReason || '반려 사유가 없습니다.');
-            new bootstrap.Modal('#rejectedReasonModal').show();
-        },
+            $("#rejectedReasonText").text(
+              row.rejectedReason || "반려 사유가 없습니다.",
+            );
+            new bootstrap.Modal("#rejectedReasonModal").show();
+          },
 
-        // ── 삭제 ──
-        deletePage: function(pageId) {
+          // ── 삭제 ──
+          deletePage: function (pageId) {
             const row = this.rowsByPageId[pageId] || {};
-            if (!confirm(`'${row.pageName || pageId}' 페이지를 삭제하시겠습니까?`)) return;
+            if (
+              !confirm(`'${row.pageName || pageId}' 페이지를 삭제하시겠습니까?`)
+            )
+              return;
 
-            fetch(`/api/react-cms-dashboard/pages/${pageId}`, { method: 'DELETE' })
-                .then(r => r.json())
-                .then(res => {
-                    if (res.success) { Toast.success(res.message); this.load(); }
-                    else             { Toast.error(res.message); }
-                })
-                .catch(() => Toast.error('삭제 중 오류가 발생했습니다.'));
-        },
-    };
+            fetch(`/api/react-cms-dashboard/pages/${pageId}`, {
+              method: "DELETE",
+            })
+              .then((r) => r.json())
+              .then((res) => {
+                if (res.success) {
+                  Toast.success(res.message);
+                  this.load();
+                } else {
+                  Toast.error(res.message);
+                }
+              })
+              .catch(() => Toast.error("삭제 중 오류가 발생했습니다."));
+          },
+        };
 
-    // ==================== 이벤트 바인딩 ====================
+        // ==================== 이벤트 바인딩 ====================
 
-    $(document).ready(function() {
-        ReactCmsDashboardPage.itemsPerPage = parseInt($('#limitRows').val()) || 10;
-        ReactCmsDashboardPage.attachSortHandlers();
-        ReactCmsDashboardPage.load(1);
+        $(document).ready(function () {
+          ReactCmsDashboardPage.itemsPerPage =
+            parseInt($("#limitRows").val()) || 10;
+          ReactCmsDashboardPage.attachSortHandlers();
+          ReactCmsDashboardPage.load(1);
 
-        $('#limitRows').on('change', function() {
+          $("#limitRows").on("change", function () {
             ReactCmsDashboardPage.itemsPerPage = parseInt($(this).val()) || 10;
             ReactCmsDashboardPage.load(1);
-        });
+          });
 
-        // [새 페이지] 버튼 — 빌더 팝업 열기 (창 참조 보관)
-        $('#btnNewPage').on('click', function() {
+          // [새 페이지] 버튼 — 빌더 팝업 열기 (창 참조 보관)
+          $("#btnNewPage").on("click", function () {
             ReactCmsDashboardPage._editorWin = window.open(
-                '/react-cms/builder',
-                'reactCmsEditor',
-                'width=1280,height=800,scrollbars=yes,resizable=yes'
+              "/react-cms/builder",
+              "reactCmsEditor",
+              "width=1280,height=800,scrollbars=yes,resizable=yes",
             );
-        });
+          });
 
-        // 빌더에서 저장 완료 신호 수신 → 팝업 닫기 + 목록 새로고침
-        // Origin 검증으로 타 도메인 메시지 차단
-        window.addEventListener('message', function(e) {
+          // 빌더에서 저장 완료 신호 수신 → 팝업 닫기 + 목록 새로고침
+          // Origin 검증으로 타 도메인 메시지 차단
+          window.addEventListener("message", function (e) {
             if (e.origin !== window.location.origin) return;
-            if (e.data === 'reactCmsSaved') {
-                ReactCmsDashboardPage._editorWin?.close();
-                ReactCmsDashboardPage.load(1);
+            if (e.data === "reactCmsSaved") {
+              ReactCmsDashboardPage._editorWin?.close();
+              ReactCmsDashboardPage.load(1);
             }
-        });
+          });
 
-        // 이벤트 위임 — XSS 방지를 위해 onclick 인라인 대신 data-page-id로 pageId 전달
-        $(document)
-            .on('click', '.js-open-editor', function() {
-                ReactCmsDashboardPage.openEditor($(this).data('page-id'));
+          // 이벤트 위임 — XSS 방지를 위해 onclick 인라인 대신 data-page-id로 pageId 전달
+          $(document)
+            .on("click", ".js-open-editor", function () {
+              ReactCmsDashboardPage.openEditor($(this).data("page-id"));
             })
-            .on('click', '.js-approve-request', function() {
-                ReactCmsDashboardPage.openApproveRequestModal($(this).data('page-id'));
+            .on("click", ".js-approve-request", function () {
+              ReactCmsDashboardPage.openApproveRequestModal(
+                $(this).data("page-id"),
+              );
             })
-            .on('click', '.js-delete-page', function() {
-                ReactCmsDashboardPage.deletePage($(this).data('page-id'));
+            .on("click", ".js-delete-page", function () {
+              ReactCmsDashboardPage.deletePage($(this).data("page-id"));
             })
-            .on('click', '.js-rejected-reason', function(e) {
-                e.preventDefault();
-                ReactCmsDashboardPage.showRejectedReason($(this).data('page-id'));
+            .on("click", ".js-rejected-reason", function (e) {
+              e.preventDefault();
+              ReactCmsDashboardPage.showRejectedReason($(this).data("page-id"));
             });
 
-        $('#btnApproveRequestConfirm').on('click', function() { ReactCmsDashboardPage._submitApproveRequest(); });
-    });
-</script>
-</th:block>
-</body>
+          $("#btnApproveRequestConfirm").on("click", function () {
+            ReactCmsDashboardPage._submitApproveRequest();
+          });
+        });
+      </script>
+    </th:block>
+  </body>
 </html>

--- a/admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard-table.html
+++ b/admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard-table.html
@@ -1,29 +1,39 @@
-<!DOCTYPE html>
+<!doctype html>
 <html xmlns:th="http://www.thymeleaf.org">
-<body>
-<!-- React CMS 사용자 대시보드 테이블 프래그먼트 -->
-<div th:fragment="table" class="table-responsive">
-    <table class="table table-sm table-hover sp-data-grid" id="reactCmsDashboardTable" style="min-width: 840px;">
+  <body>
+    <!-- React CMS 사용자 대시보드 테이블 프래그먼트 -->
+    <div th:fragment="table" class="table-responsive">
+      <table
+        class="table table-sm table-hover sp-data-grid"
+        id="reactCmsDashboardTable"
+      >
         <thead class="table-light">
-            <tr>
-                <th class="sortable" data-sort="pageName">페이지명</th>
-                <th class="col-w-80">뷰모드</th>
-                <th class="col-w-100 sortable" data-sort="approveState">승인상태</th>
-                <th class="col-w-100 sortable" data-sort="beginningDate">노출시작일</th>
-                <th class="col-w-100 sortable" data-sort="expiredDate">노출종료일</th>
-                <th class="col-w-150 sortable" data-sort="lastModifiedDtime">최종수정일시</th>
-                <th class="col-w-90">승인요청</th>
-                <th class="col-w-80">삭제</th>
-            </tr>
+          <tr>
+            <th class="sortable" data-sort="pageName">페이지명</th>
+            <th class="col-w-120 sortable" data-sort="approveState">
+              승인상태
+            </th>
+            <th class="col-w-120 sortable" data-sort="beginningDate">
+              노출시작일
+            </th>
+            <th class="col-w-120 sortable" data-sort="expiredDate">
+              노출종료일
+            </th>
+            <th class="col-w-150 sortable" data-sort="lastModifiedDtime">
+              최종수정일시
+            </th>
+            <th class="col-w-120">승인요청</th>
+            <th class="col-w-80">삭제</th>
+          </tr>
         </thead>
         <tbody id="reactCmsDashboardTableBody">
-            <tr>
-                <td colspan="8" class="text-center py-4 text-body-secondary">
-                    조회 버튼을 클릭하여 데이터를 불러오세요.
-                </td>
-            </tr>
+          <tr>
+            <td colspan="7" class="text-center py-4 text-body-secondary">
+              조회 버튼을 클릭하여 데이터를 불러오세요.
+            </td>
+          </tr>
         </tbody>
-    </table>
-</div>
-</body>
+      </table>
+    </div>
+  </body>
 </html>

--- a/admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard.html
+++ b/admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard.html
@@ -1,112 +1,156 @@
-<!DOCTYPE html>
+<!doctype html>
 <html xmlns:th="http://www.thymeleaf.org">
-<body>
-<div th:fragment="content">
-
-    <!-- 검색조건 헤더 -->
-    <div class="page-header">
+  <body>
+    <div th:fragment="content">
+      <!-- 검색조건 헤더 -->
+      <div class="page-header">
         <h4 class="page-title">
-            <i class="bi bi-exclamation-circle-fill text-danger"></i>
-            검색조건
+          <i class="bi bi-exclamation-circle-fill text-danger"></i>
+          검색조건
         </h4>
-    </div>
+      </div>
 
-    <!-- 검색 영역 -->
-    <div th:replace="~{pages/react-cms-dashboard/react-cms-dashboard-search :: search}"></div>
+      <!-- 검색 영역 -->
+      <div
+        th:replace="~{pages/react-cms-dashboard/react-cms-dashboard-search :: search}"
+      ></div>
 
-    <!-- 리스트 헤더 + 툴바 -->
-    <div class="page-header mt-3">
+      <!-- 리스트 헤더 + 툴바 -->
+      <div class="page-header mt-3">
         <h4 class="page-title">
-            <i class="bi bi-exclamation-circle-fill text-danger"></i>
-            내 페이지 목록
+          <i class="bi bi-exclamation-circle-fill text-danger"></i>
+          내 페이지 목록
         </h4>
         <div class="page-header-actions">
-            <!-- react-cms 빌더를 새 창으로 열어 페이지를 생성 -->
-            <button class="btn btn-primary btn-sm" id="btnNewPage"
-                    th:if="${userAuthorities != null && userAuthorities.contains('REACT-CMS:W')}">
-                <i class="bi bi-plus-lg"></i> 새 페이지
-            </button>
+          <!-- react-cms 빌더를 새 창으로 열어 페이지를 생성 -->
+          <button
+            class="btn btn-primary btn-sm"
+            id="btnNewPage"
+            th:if="${userAuthorities != null && userAuthorities.contains('REACT_CMS:W')}"
+          >
+            <i class="bi bi-plus-lg"></i> 새 페이지
+          </button>
         </div>
-    </div>
+      </div>
 
-    <!-- 테이블 -->
-    <div th:replace="~{pages/react-cms-dashboard/react-cms-dashboard-table :: table}"></div>
+      <!-- 테이블 -->
+      <div
+        th:replace="~{pages/react-cms-dashboard/react-cms-dashboard-table :: table}"
+      ></div>
 
-    <!-- 페이지네이션 -->
-    <div th:replace="~{fragments/page-content-layout :: pagination}"></div>
+      <!-- 페이지네이션 -->
+      <div th:replace="~{fragments/page-content-layout :: pagination}"></div>
 
-    <!-- ==================== 승인 요청 모달 ==================== -->
-    <div class="modal fade" id="approveRequestModal" tabindex="-1">
+      <!-- ==================== 승인 요청 모달 ==================== -->
+      <div class="modal fade" id="approveRequestModal" tabindex="-1">
         <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="approveRequestModalTitle">승인 요청</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-                </div>
-                <div class="modal-body">
-                    <input type="hidden" id="approveRequestPageId"/>
-                    <div class="table-responsive">
-                        <table class="table table-sm mb-3">
-                            <tbody>
-                                <tr>
-                                    <th class="col-w-120">페이지명</th>
-                                    <td id="approveRequestPageName">-</td>
-                                </tr>
-                                <tr>
-                                    <th>승인자 <span class="text-danger">*</span></th>
-                                    <td>
-                                        <select id="approveRequestApproverId" class="form-select form-select-sm">
-                                            <option value="">승인자 선택</option>
-                                        </select>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>노출 시작일</th>
-                                    <td>
-                                        <input type="date" id="approveRequestBeginningDate"
-                                               class="form-control form-control-sm"/>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>노출 종료일</th>
-                                    <td>
-                                        <input type="date" id="approveRequestExpiredDate"
-                                               class="form-control form-control-sm"/>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
-                    <button type="button" id="btnApproveRequestConfirm" class="btn btn-primary">요청</button>
-                </div>
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="approveRequestModalTitle">
+                승인 요청
+              </h5>
+              <button
+                type="button"
+                class="btn-close"
+                data-bs-dismiss="modal"
+              ></button>
             </div>
+            <div class="modal-body">
+              <input type="hidden" id="approveRequestPageId" />
+              <div class="table-responsive">
+                <table class="table table-sm mb-3">
+                  <tbody>
+                    <tr>
+                      <th class="col-w-120">페이지명</th>
+                      <td id="approveRequestPageName">-</td>
+                    </tr>
+                    <tr>
+                      <th>승인자 <span class="text-danger">*</span></th>
+                      <td>
+                        <select
+                          id="approveRequestApproverId"
+                          class="form-select form-select-sm"
+                        >
+                          <option value="">승인자 선택</option>
+                        </select>
+                      </td>
+                    </tr>
+                    <tr>
+                      <th>노출 시작일</th>
+                      <td>
+                        <input
+                          type="date"
+                          id="approveRequestBeginningDate"
+                          class="form-control form-control-sm"
+                        />
+                      </td>
+                    </tr>
+                    <tr>
+                      <th>노출 종료일</th>
+                      <td>
+                        <input
+                          type="date"
+                          id="approveRequestExpiredDate"
+                          class="form-control form-control-sm"
+                        />
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button
+                type="button"
+                class="btn btn-secondary"
+                data-bs-dismiss="modal"
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                id="btnApproveRequestConfirm"
+                class="btn btn-primary"
+              >
+                요청
+              </button>
+            </div>
+          </div>
         </div>
-    </div>
+      </div>
 
-    <!-- ==================== 반려 사유 확인 모달 ==================== -->
-    <div class="modal fade" id="rejectedReasonModal" tabindex="-1">
+      <!-- ==================== 반려 사유 확인 모달 ==================== -->
+      <div class="modal fade" id="rejectedReasonModal" tabindex="-1">
         <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">반려 사유</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-                </div>
-                <div class="modal-body">
-                    <p id="rejectedReasonText" class="mb-0 text-break"></p>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
-                </div>
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title">반려 사유</h5>
+              <button
+                type="button"
+                class="btn-close"
+                data-bs-dismiss="modal"
+              ></button>
             </div>
+            <div class="modal-body">
+              <p id="rejectedReasonText" class="mb-0 text-break"></p>
+            </div>
+            <div class="modal-footer">
+              <button
+                type="button"
+                class="btn btn-secondary"
+                data-bs-dismiss="modal"
+              >
+                닫기
+              </button>
+            </div>
+          </div>
         </div>
+      </div>
+
+      <!-- 스크립트 -->
+      <th:block
+        th:replace="~{pages/react-cms-dashboard/react-cms-dashboard-script :: script}"
+      />
     </div>
-
-    <!-- 스크립트 -->
-    <th:block th:replace="~{pages/react-cms-dashboard/react-cms-dashboard-script :: script}"/>
-
-</div>
-</body>
+  </body>
 </html>

--- a/demo/front/src/App.tsx
+++ b/demo/front/src/App.tsx
@@ -38,7 +38,8 @@ function AppRoutes() {
   const isPublicPath =
     location.pathname === PATHS.LOGIN ||
     location.pathname.startsWith('/preview') ||
-    location.pathname.startsWith('/react/viewer')
+    location.pathname.startsWith('/react/viewer') ||
+    location.pathname.startsWith('/react-cms/viewer')
   if (!isLoggedIn && !isPublicPath) {
     return <Navigate to={PATHS.LOGIN} replace />
   }

--- a/demo/front/src/constants/paths.ts
+++ b/demo/front/src/constants/paths.ts
@@ -21,6 +21,8 @@ export const PATHS = {
   VIEWER: {
     /** 승인된 React 컴포넌트 뷰어. :codeId = FWK_RPS_CODE_HIS.CODE_ID */
     REACT: "/react/viewer/:codeId",
+    /** React CMS 배포 페이지 뷰어. :pageId = SPW_CMS_PAGE.PAGE_ID */
+    REACT_CMS: "/react-cms/viewer/:pageId",
   },
 
   CARD: {

--- a/demo/front/src/reactcms/containers/05c6b352-969f-4386-858b-5a8ad6021a2a.tsx
+++ b/demo/front/src/reactcms/containers/05c6b352-969f-4386-858b-5a8ad6021a2a.tsx
@@ -1,0 +1,2 @@
+// Auto-generated container for 05c6b352-969f-4386-858b-5a8ad6021a2a — do not edit manually
+export { default } from "@/reactcms/generated/05c6b352-969f-4386-858b-5a8ad6021a2a";

--- a/demo/front/src/reactcms/containers/2bf91543-2bb0-4ba7-b7fc-d4bdd1232988.tsx
+++ b/demo/front/src/reactcms/containers/2bf91543-2bb0-4ba7-b7fc-d4bdd1232988.tsx
@@ -1,0 +1,2 @@
+// Auto-generated container for 2bf91543-2bb0-4ba7-b7fc-d4bdd1232988 — do not edit manually
+export { default } from "@/reactcms/generated/2bf91543-2bb0-4ba7-b7fc-d4bdd1232988";

--- a/demo/front/src/reactcms/containers/e67024e8-462e-46cf-811c-2875f217fef7.tsx
+++ b/demo/front/src/reactcms/containers/e67024e8-462e-46cf-811c-2875f217fef7.tsx
@@ -1,0 +1,2 @@
+// Auto-generated container for e67024e8-462e-46cf-811c-2875f217fef7 — do not edit manually
+export { default } from "@/reactcms/generated/e67024e8-462e-46cf-811c-2875f217fef7";

--- a/demo/front/src/reactcms/generated/05c6b352-969f-4386-858b-5a8ad6021a2a.tsx
+++ b/demo/front/src/reactcms/generated/05c6b352-969f-4386-858b-5a8ad6021a2a.tsx
@@ -1,0 +1,14 @@
+// 레이아웃: blank
+
+import { BlankLayout, Stack, CardPaymentSummary, CardPerformanceBar } from "@cl";
+
+export default function NewPage() {
+  return (
+    <BlankLayout>
+      <Stack gap="lg">
+        <CardPaymentSummary dateFull="2026년 4월" dateYM="2026.04" dateMD="04.15" totalAmount={350000} revolving={0} cardLoan={0} cashAdvance={0} />
+        <CardPerformanceBar cardName="하나카드" currentAmount={350000} targetAmount={500000} benefitDescription="캐시백 1% 달성까지" />
+      </Stack>
+    </BlankLayout>
+  );
+}

--- a/demo/front/src/reactcms/generated/2bf91543-2bb0-4ba7-b7fc-d4bdd1232988.tsx
+++ b/demo/front/src/reactcms/generated/2bf91543-2bb0-4ba7-b7fc-d4bdd1232988.tsx
@@ -1,0 +1,25 @@
+// 레이아웃: page
+
+import { PageLayout, Stack, BrandBanner } from "@cl";
+
+export default function NewPage() {
+  return (
+    <PageLayout title="페이지 제목" showBack rightBtnType="close" bottomBtnCnt="0" bottomBtn1Label="확인" bottomBtn2Label="취소">
+      <Stack gap="xs">
+        <BrandBanner title="브랜드 타이틀" subtitle="서브 타이틀" />
+        <BrandBanner title="브랜드 타이틀" subtitle="서브 타이틀" />
+        <BrandBanner title="브랜드 타이틀" subtitle="서브 타이틀" />
+        <BrandBanner title="브랜드 타이틀" subtitle="서브 타이틀" />
+        <BrandBanner title="브랜드 타이틀" subtitle="서브 타이틀" />
+        <BrandBanner title="브랜드 타이틀" subtitle="서브 타이틀" />
+        <BrandBanner title="브랜드 타이틀" subtitle="서브 타이틀" />
+        <BrandBanner title="브랜드 타이틀" subtitle="서브 타이틀" />
+        <BrandBanner title="브랜드 타이틀" subtitle="서브 타이틀" />
+        <BrandBanner title="브랜드 타이틀" subtitle="서브 타이틀" />
+        <BrandBanner title="브랜드 타이틀" subtitle="서브 타이틀" />
+        <BrandBanner title="브랜드 타이틀" subtitle="서브 타이틀" />
+        <BrandBanner title="브랜드 타이틀" subtitle="서브 타이틀" />
+      </Stack>
+    </PageLayout>
+  );
+}

--- a/demo/front/src/reactcms/generated/e67024e8-462e-46cf-811c-2875f217fef7.tsx
+++ b/demo/front/src/reactcms/generated/e67024e8-462e-46cf-811c-2875f217fef7.tsx
@@ -1,0 +1,13 @@
+// 레이아웃: page
+
+import { PageLayout, Stack, Typography } from "@cl";
+
+export default function NewPage() {
+  return (
+    <PageLayout title="페이지 제목" showBack rightBtnType="close" bottomBtnCnt="0" bottomBtn1Label="확인" bottomBtn2Label="취소">
+      <Stack gap="md">
+        <div className="px-[16px]"><Typography variant="heading" weight="bold" color="primary" as="p" numeric={false}>테스트중입니다!!</Typography></div>
+      </Stack>
+    </PageLayout>
+  );
+}

--- a/demo/front/src/routes/RouteWrappers.tsx
+++ b/demo/front/src/routes/RouteWrappers.tsx
@@ -11,8 +11,19 @@
  * - 일반 페이지: XxxRoute (예: LoginRoute)
  * - 모달 오버레이: XxxModal (예: HanaCardMenuModal)
  */
-import { useState, useEffect, useRef, useMemo, type ComponentType } from "react";
-import { useNavigate, useLocation, useSearchParams, useParams } from "react-router-dom";
+import {
+  useState,
+  useEffect,
+  useRef,
+  useMemo,
+  type ComponentType,
+} from "react";
+import {
+  useNavigate,
+  useLocation,
+  useSearchParams,
+  useParams,
+} from "react-router-dom";
 import type { NoticePayload } from "@/hooks/useEmergencyNotice";
 import { useAuth } from "@/contexts/AuthContext";
 import { axiosInstance } from "@/api/axiosInstance";
@@ -205,7 +216,9 @@ export function CardDashboardRoute() {
     if (!user?.userId || user.lastLogin) return;
     axiosInstance
       .get<{ lastLogin: string }>("/auth/me")
-      .then(({ data }) => { if (data.lastLogin) setLastLogin(data.lastLogin); })
+      .then(({ data }) => {
+        if (data.lastLogin) setLastLogin(data.lastLogin);
+      })
       .catch(() => {}); // 실패해도 화면 진입은 허용
   }, [user?.userId, user?.lastLogin, setLastLogin]);
 
@@ -450,7 +463,6 @@ function isPaymentUpcoming(
   const day = paymentDay ? Number(paymentDay) : 1; // paymentDay 없으면 1일로 보수적 처리
   return new Date(y, m - 1, day) >= today;
 }
-
 
 /** YYMMDD or YYYYMMDD → { dateFull, dateYM, dateMD } */
 function parseDueDate(raw: string) {
@@ -772,7 +784,13 @@ export function ImmediatePayRequestRoute() {
   const storedCard = sessionStorage.getItem("immediatePaySelectedCard");
   const card: CardInfo = storedCard
     ? (JSON.parse(storedCard) as CardInfo)
-    : { id: "", name: "", maskedNumber: "", paymentBank: "", paymentAccount: "" };
+    : {
+        id: "",
+        name: "",
+        maskedNumber: "",
+        paymentBank: "",
+        paymentAccount: "",
+      };
 
   // POC_카드사용내역에서 누적결제금액 < 이용금액인 건의 미결제 잔액 합산을 조회한다.
   const [payableAmount, setPayableAmount] = useState<number>(0);
@@ -880,7 +898,13 @@ export function ImmediatePayMethodRoute() {
   const storedAmountInfo = sessionStorage.getItem("immediatePayAmountInfo");
   const card: CardInfo = storedCard
     ? (JSON.parse(storedCard) as CardInfo)
-    : { id: "", name: "", maskedNumber: "", paymentBank: "", paymentAccount: "" };
+    : {
+        id: "",
+        name: "",
+        maskedNumber: "",
+        paymentBank: "",
+        paymentAccount: "",
+      };
   const { usageType, payAmount } = storedRequest
     ? (JSON.parse(storedRequest) as { usageType: string; payAmount: number })
     : { usageType: "lump", payAmount: 0 };
@@ -1017,7 +1041,8 @@ export function ImmediatePayMethodRoute() {
               // PIN 오류 외의 예외는 완료 화면으로 이동해 오류 내용을 표시한다.
               // 4xx(비즈니스 오류): 서버가 보낸 구체적인 사유를 그대로 노출한다.
               // 5xx(시스템 오류): 내부 오류를 사용자에게 노출하지 않고 일반 메시지를 사용한다.
-              const isBusinessError = status !== undefined && status >= 400 && status < 500;
+              const isBusinessError =
+                status !== undefined && status >= 400 && status < 500;
               const errorMessage = isBusinessError
                 ? (data?.error ?? "결제 처리 중 오류가 발생했습니다.")
                 : "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.";
@@ -1379,7 +1404,9 @@ export function ReactViewerRoute() {
     // src/generated/*.tsx 파일 전체를 지연 로드(lazy) 맵으로 확보
     // import.meta.glob은 Vite가 빌드 타임에 glob 패턴을 해석하므로 동적 경로 조합 불가
     // → 전체 맵을 먼저 만든 뒤 codeId로 키를 선택한다
-    const modules = import.meta.glob<{ default: ComponentType }>("/src/generated/*.tsx");
+    const modules = import.meta.glob<{ default: ComponentType }>(
+      "/src/generated/*.tsx",
+    );
     const key = `/src/generated/${codeId}.tsx`;
 
     if (!modules[key]) {
@@ -1391,7 +1418,10 @@ export function ReactViewerRoute() {
       .then((mod) => setComponent(() => mod.default))
       .catch((err) => {
         // 네트워크 오류와 파일 미존재를 구분하기 위해 에러를 기록한다
-        console.error(`[ReactViewer] 컴포넌트 로드 실패 — codeId=${codeId}`, err);
+        console.error(
+          `[ReactViewer] 컴포넌트 로드 실패 — codeId=${codeId}`,
+          err,
+        );
         setNotFound(true);
       });
   }, [codeId]);
@@ -1408,6 +1438,77 @@ export function ReactViewerRoute() {
       {notFound && (
         <div className="flex items-center justify-center min-h-[80vh] text-sm text-text-muted">
           승인된 컴포넌트를 찾을 수 없습니다. (codeId: {codeId})
+        </div>
+      )}
+
+      {!notFound && !Component && (
+        <div className="flex items-center justify-center min-h-[80vh] text-sm text-text-muted">
+          로딩 중...
+        </div>
+      )}
+
+      {Component && <Component />}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* React CMS 배포 페이지 뷰어                                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Admin에서 배포한 React CMS 페이지 뷰어.
+ *
+ * /react-cms/viewer/:pageId 경로로 접근하며, 인증 없이 사용 가능하다.
+ * import.meta.glob으로 src/reactcms/containers/ 디렉토리의 .tsx 파일을 동적으로 탐색하여
+ * :pageId에 해당하는 컴포넌트를 렌더링한다.
+ *
+ * Vite HMR이 파일 추가를 감지하므로 Admin에서 배포 즉시 새 경로가 활성화된다.
+ */
+export function ReactCmsPageViewerRoute() {
+  const { pageId } = useParams<{ pageId: string }>();
+  const [Component, setComponent] = useState<ComponentType | null>(null);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    if (!pageId) {
+      setNotFound(true);
+      return;
+    }
+
+    // src/reactcms/containers/*.tsx 파일 전체를 지연 로드(lazy) 맵으로 확보
+    const modules = import.meta.glob<{ default: ComponentType }>(
+      "/src/reactcms/containers/*.tsx",
+    );
+    const key = `/src/reactcms/containers/${pageId}.tsx`;
+
+    if (!modules[key]) {
+      setNotFound(true);
+      return;
+    }
+
+    modules[key]()
+      .then((mod) => setComponent(() => mod.default))
+      .catch((err) => {
+        console.error(
+          `[ReactCmsViewer] 컴포넌트 로드 실패 — pageId=${pageId}`,
+          err,
+        );
+        setNotFound(true);
+      });
+  }, [pageId]);
+
+  return (
+    <div className="min-h-screen bg-bg-base">
+      {/* <div className="flex items-center justify-center py-1 bg-green-50 border-b border-green-200">
+        <span className="text-xs text-green-600 font-medium">
+          React CMS 배포 페이지 뷰어 — {pageId}
+        </span>
+      </div> */}
+
+      {notFound && (
+        <div className="flex items-center justify-center min-h-[80vh] text-sm text-text-muted">
+          배포된 CMS 페이지를 찾을 수 없습니다. (pageId: {pageId})
         </div>
       )}
 

--- a/demo/front/src/routes/index.tsx
+++ b/demo/front/src/routes/index.tsx
@@ -25,6 +25,7 @@ import {
   HanaCardMenuModal,
   NoticePreviewRoute,
   ReactViewerRoute,
+  ReactCmsPageViewerRoute,
 } from "./RouteWrappers";
 
 export interface RouteConfig {
@@ -36,6 +37,7 @@ export const pageRoutes: RouteConfig[] = [
   { path: PATHS.LOGIN,                element: <LoginRoute /> },
   { path: PATHS.PREVIEW.NOTICE,       element: <NoticePreviewRoute /> },
   { path: PATHS.VIEWER.REACT,          element: <ReactViewerRoute /> },
+  { path: PATHS.VIEWER.REACT_CMS,      element: <ReactCmsPageViewerRoute /> },
   { path: PATHS.CARD.DASHBOARD, element: <CardDashboardRoute /> },
   { path: PATHS.CARD.USAGE_HISTORY, element: <UsageHistoryRoute /> },
   { path: PATHS.CARD.PAYMENT_STATEMENT, element: <PaymentStatementRoute /> },

--- a/react-cms/.env.example
+++ b/react-cms/.env.example
@@ -33,8 +33,8 @@ ORACLE_CLIENT_DIR=
 
 # 개발용 인증 우회 모드.
 # true로 설정하면 Spider Admin API 호출 없이 쿠키(cms_bypass_role)로 역할을 분기한다.
-#   cms_bypass_role=react-adm  → 관리자 권한 (REACT-CMS:R, REACT-CMS:W)
-#   cms_bypass_role 미설정     → 일반 사용자 권한 (REACT-CMS:R, REACT-CMS:W)
+#   cms_bypass_role=react-adm  → 관리자 권한 (REACT_CMS:R, REACT_CMS:W)
+#   cms_bypass_role 미설정     → 일반 사용자 권한 (REACT_CMS:R, REACT_CMS:W)
 # 운영 환경에서는 반드시 false로 유지해야 한다.
 AUTH_BYPASS=false
 

--- a/react-cms/src/cms-admin/CmsAuthGuard.tsx
+++ b/react-cms/src/cms-admin/CmsAuthGuard.tsx
@@ -2,7 +2,7 @@
  * @file CmsAuthGuard.tsx
  * @description Spider Admin 권한 검증 레이아웃 가드.
  *
- * 마운트 시 `/__cms/api/me`를 호출해 REACT-CMS:R 권한을 확인한다.
+ * 마운트 시 `/__cms/api/me`를 호출해 REACT_CMS:R 권한을 확인한다.
  * - 로딩 중: 스피너 표시
  * - canRead=false: `/not-authorized`로 리다이렉트
  * - canRead=true: 자식 라우트 렌더링 (Outlet)
@@ -16,7 +16,7 @@ export default function CmsAuthGuard() {
 
   useEffect(() => {
     fetch(`${cmsBase}/api/me`, { credentials: "include" })
-      .then(r => r.json())
+      .then((r) => r.json())
       .then((data: { canRead?: boolean }) => {
         setAuthorized(data.canRead ?? false);
       })

--- a/react-cms/src/cms-admin/__tests__/current-user.test.ts
+++ b/react-cms/src/cms-admin/__tests__/current-user.test.ts
@@ -7,7 +7,7 @@
  *   - 비동기 함수: getCurrentUser (AUTH_BYPASS 분기, API 성공/실패, 폴백)
  *   - 권한 가드: requireCmsRead, requireCmsWrite
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   hasAuthority,
   canReadCms,
@@ -18,81 +18,81 @@ import {
   requireCmsWrite,
   UnauthorizedError,
   CMS_ROLE,
-} from '../current-user';
+} from "../current-user";
 
 // ── 픽스처 ────────────────────────────────────────────────────────────────────
 
-const userWithReadWrite = { authorities: ['REACT-CMS:R', 'REACT-CMS:W'] };
-const userWithReadOnly  = { authorities: ['REACT-CMS:R'] };
-const userWithWriteOnly = { authorities: ['REACT-CMS:W'] };
-const userWithNone      = { authorities: [] as string[] };
+const userWithReadWrite = { authorities: ["REACT_CMS:R", "REACT_CMS:W"] };
+const userWithReadOnly = { authorities: ["REACT_CMS:R"] };
+const userWithWriteOnly = { authorities: ["REACT_CMS:W"] };
+const userWithNone = { authorities: [] as string[] };
 
 // ── 순수 함수 ─────────────────────────────────────────────────────────────────
 
-describe('hasAuthority', () => {
-  it('권한 목록에 해당 권한이 있으면 true', () => {
-    expect(hasAuthority(userWithReadWrite, 'REACT-CMS:R')).toBe(true);
-    expect(hasAuthority(userWithReadWrite, 'REACT-CMS:W')).toBe(true);
+describe("hasAuthority", () => {
+  it("권한 목록에 해당 권한이 있으면 true", () => {
+    expect(hasAuthority(userWithReadWrite, "REACT_CMS:R")).toBe(true);
+    expect(hasAuthority(userWithReadWrite, "REACT_CMS:W")).toBe(true);
   });
 
-  it('권한 목록에 해당 권한이 없으면 false', () => {
-    expect(hasAuthority(userWithReadOnly, 'REACT-CMS:W')).toBe(false);
-    expect(hasAuthority(userWithNone, 'REACT-CMS:R')).toBe(false);
+  it("권한 목록에 해당 권한이 없으면 false", () => {
+    expect(hasAuthority(userWithReadOnly, "REACT_CMS:W")).toBe(false);
+    expect(hasAuthority(userWithNone, "REACT_CMS:R")).toBe(false);
   });
 });
 
-describe('canReadCms', () => {
-  it('REACT-CMS:R 권한이 있으면 true', () => {
+describe("canReadCms", () => {
+  it("REACT_CMS:R 권한이 있으면 true", () => {
     expect(canReadCms(userWithReadOnly)).toBe(true);
   });
 
-  it('REACT-CMS:W만 있어도 읽기 허용 (상위 권한 포함)', () => {
+  it("REACT_CMS:W만 있어도 읽기 허용 (상위 권한 포함)", () => {
     expect(canReadCms(userWithWriteOnly)).toBe(true);
   });
 
-  it('권한이 없으면 false', () => {
+  it("권한이 없으면 false", () => {
     expect(canReadCms(userWithNone)).toBe(false);
   });
 });
 
-describe('canWriteCms', () => {
-  it('REACT-CMS:W 권한이 있으면 true', () => {
+describe("canWriteCms", () => {
+  it("REACT_CMS:W 권한이 있으면 true", () => {
     expect(canWriteCms(userWithWriteOnly)).toBe(true);
     expect(canWriteCms(userWithReadWrite)).toBe(true);
   });
 
-  it('REACT-CMS:R만 있으면 false', () => {
+  it("REACT_CMS:R만 있으면 false", () => {
     expect(canWriteCms(userWithReadOnly)).toBe(false);
   });
 
-  it('권한이 없으면 false', () => {
+  it("권한이 없으면 false", () => {
     expect(canWriteCms(userWithNone)).toBe(false);
   });
 });
 
-describe('canAdminScreen', () => {
-  it('ADMIN 역할이면 true', () => {
+describe("canAdminScreen", () => {
+  it("ADMIN 역할이면 true", () => {
     expect(canAdminScreen({ roleId: CMS_ROLE.SPIDER_ADMIN })).toBe(true);
   });
 
-  it('react-adm 역할이면 true', () => {
+  it("react-adm 역할이면 true", () => {
     expect(canAdminScreen({ roleId: CMS_ROLE.CMS_ADMIN })).toBe(true);
   });
 
-  it('react-user 역할이면 false', () => {
+  it("react-user 역할이면 false", () => {
     expect(canAdminScreen({ roleId: CMS_ROLE.USER })).toBe(false);
   });
 
-  it('guest 역할이면 false', () => {
-    expect(canAdminScreen({ roleId: 'guest' })).toBe(false);
+  it("guest 역할이면 false", () => {
+    expect(canAdminScreen({ roleId: "guest" })).toBe(false);
   });
 });
 
 // ── getCurrentUser ────────────────────────────────────────────────────────────
 
-describe('getCurrentUser — AUTH_BYPASS=true', () => {
+describe("getCurrentUser — AUTH_BYPASS=true", () => {
   beforeEach(() => {
-    process.env.AUTH_BYPASS = 'true';
+    process.env.AUTH_BYPASS = "true";
     delete process.env.SPIDER_ADMIN_API_URL;
   });
 
@@ -100,32 +100,34 @@ describe('getCurrentUser — AUTH_BYPASS=true', () => {
     delete process.env.AUTH_BYPASS;
   });
 
-  it('cms_bypass_role=react-adm 쿠키가 있으면 관리자 반환', async () => {
-    const user = await getCurrentUser('cms_bypass_role=react-adm');
-    expect(user.roleId).toBe('react-adm');
-    expect(user.authorities).toContain('REACT-CMS:W');
+  it("cms_bypass_role=react-adm 쿠키가 있으면 관리자 반환", async () => {
+    const user = await getCurrentUser("cms_bypass_role=react-adm");
+    expect(user.roleId).toBe("react-adm");
+    expect(user.authorities).toContain("REACT_CMS:W");
   });
 
-  it('쿠키가 없으면 일반 사용자 반환', async () => {
-    const user = await getCurrentUser('');
-    expect(user.roleId).toBe('react-user');
-    expect(user.authorities).toContain('REACT-CMS:R');
+  it("쿠키가 없으면 일반 사용자 반환", async () => {
+    const user = await getCurrentUser("");
+    expect(user.roleId).toBe("react-user");
+    expect(user.authorities).toContain("REACT_CMS:R");
   });
 
-  it('다른 값의 쿠키가 있으면 일반 사용자 반환', async () => {
-    const user = await getCurrentUser('cms_bypass_role=other-role');
-    expect(user.roleId).toBe('react-user');
+  it("다른 값의 쿠키가 있으면 일반 사용자 반환", async () => {
+    const user = await getCurrentUser("cms_bypass_role=other-role");
+    expect(user.roleId).toBe("react-user");
   });
 
-  it('여러 쿠키 중 cms_bypass_role=react-adm이 있으면 관리자 반환', async () => {
-    const user = await getCurrentUser('session=abc; cms_bypass_role=react-adm; theme=dark');
-    expect(user.roleId).toBe('react-adm');
+  it("여러 쿠키 중 cms_bypass_role=react-adm이 있으면 관리자 반환", async () => {
+    const user = await getCurrentUser(
+      "session=abc; cms_bypass_role=react-adm; theme=dark",
+    );
+    expect(user.roleId).toBe("react-adm");
   });
 });
 
-describe('getCurrentUser — AUTH_BYPASS=false', () => {
+describe("getCurrentUser — AUTH_BYPASS=false", () => {
   beforeEach(() => {
-    process.env.AUTH_BYPASS = 'false';
+    process.env.AUTH_BYPASS = "false";
   });
 
   afterEach(() => {
@@ -134,149 +136,185 @@ describe('getCurrentUser — AUTH_BYPASS=false', () => {
     vi.unstubAllGlobals();
   });
 
-  it('SPIDER_ADMIN_API_URL 미설정 시 GUEST 반환', async () => {
+  it("SPIDER_ADMIN_API_URL 미설정 시 GUEST 반환", async () => {
     delete process.env.SPIDER_ADMIN_API_URL;
-    const user = await getCurrentUser('');
-    expect(user.roleId).toBe('guest');
+    const user = await getCurrentUser("");
+    expect(user.roleId).toBe("guest");
     expect(user.authorities).toHaveLength(0);
   });
 
-  it('Spider Admin API 정상 응답 시 사용자 정보 반환', async () => {
-    process.env.SPIDER_ADMIN_API_URL = 'http://localhost:8080';
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        success: true,
-        data: { userId: 'u1', userName: '홍길동', roleId: 'react-adm', authorities: ['REACT-CMS:R', 'REACT-CMS:W'] },
+  it("Spider Admin API 정상 응답 시 사용자 정보 반환", async () => {
+    process.env.SPIDER_ADMIN_API_URL = "http://localhost:8080";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          success: true,
+          data: {
+            userId: "u1",
+            userName: "홍길동",
+            roleId: "react-adm",
+            authorities: ["REACT_CMS:R", "REACT_CMS:W"],
+          },
+        }),
       }),
-    }));
+    );
 
-    const user = await getCurrentUser('session=token123');
-    expect(user.userId).toBe('u1');
-    expect(user.roleId).toBe('react-adm');
-    expect(user.authorities).toContain('REACT-CMS:W');
+    const user = await getCurrentUser("session=token123");
+    expect(user.userId).toBe("u1");
+    expect(user.roleId).toBe("react-adm");
+    expect(user.authorities).toContain("REACT_CMS:W");
   });
 
-  it('authorities 필드 없으면 빈 배열로 처리', async () => {
-    process.env.SPIDER_ADMIN_API_URL = 'http://localhost:8080';
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        success: true,
-        data: { userId: 'u2', userName: '테스트', roleId: 'react-user' },
+  it("authorities 필드 없으면 빈 배열로 처리", async () => {
+    process.env.SPIDER_ADMIN_API_URL = "http://localhost:8080";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          success: true,
+          data: { userId: "u2", userName: "테스트", roleId: "react-user" },
+        }),
       }),
-    }));
+    );
 
-    const user = await getCurrentUser('');
+    const user = await getCurrentUser("");
     expect(user.authorities).toEqual([]);
   });
 
-  it('API 응답이 ok=false이면 GUEST 반환', async () => {
-    process.env.SPIDER_ADMIN_API_URL = 'http://localhost:8080';
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+  it("API 응답이 ok=false이면 GUEST 반환", async () => {
+    process.env.SPIDER_ADMIN_API_URL = "http://localhost:8080";
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
 
-    const user = await getCurrentUser('');
-    expect(user.roleId).toBe('guest');
+    const user = await getCurrentUser("");
+    expect(user.roleId).toBe("guest");
   });
 
-  it('API 응답 success=false이면 GUEST 반환', async () => {
-    process.env.SPIDER_ADMIN_API_URL = 'http://localhost:8080';
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ success: false }),
-    }));
+  it("API 응답 success=false이면 GUEST 반환", async () => {
+    process.env.SPIDER_ADMIN_API_URL = "http://localhost:8080";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: false }),
+      }),
+    );
 
-    const user = await getCurrentUser('');
-    expect(user.roleId).toBe('guest');
+    const user = await getCurrentUser("");
+    expect(user.roleId).toBe("guest");
   });
 
-  it('네트워크 오류 발생 시 GUEST 반환', async () => {
-    process.env.SPIDER_ADMIN_API_URL = 'http://localhost:8080';
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
+  it("네트워크 오류 발생 시 GUEST 반환", async () => {
+    process.env.SPIDER_ADMIN_API_URL = "http://localhost:8080";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("Network error")),
+    );
 
-    const user = await getCurrentUser('');
-    expect(user.roleId).toBe('guest');
+    const user = await getCurrentUser("");
+    expect(user.roleId).toBe("guest");
   });
 
-  it('요청 시 Cookie 헤더를 Spider Admin으로 전달', async () => {
-    process.env.SPIDER_ADMIN_API_URL = 'http://localhost:8080';
+  it("요청 시 Cookie 헤더를 Spider Admin으로 전달", async () => {
+    process.env.SPIDER_ADMIN_API_URL = "http://localhost:8080";
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ success: true, data: { userId: 'u3', userName: '테스트', roleId: 'react-user', authorities: [] } }),
+      json: async () => ({
+        success: true,
+        data: {
+          userId: "u3",
+          userName: "테스트",
+          roleId: "react-user",
+          authorities: [],
+        },
+      }),
     });
-    vi.stubGlobal('fetch', mockFetch);
+    vi.stubGlobal("fetch", mockFetch);
 
-    await getCurrentUser('session=mysession');
+    await getCurrentUser("session=mysession");
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'http://localhost:8080/api/auth/me',
-      expect.objectContaining({ headers: { cookie: 'session=mysession' } }),
+      "http://localhost:8080/api/auth/me",
+      expect.objectContaining({ headers: { cookie: "session=mysession" } }),
     );
   });
 
-  it('SPIDER_ADMIN_API_URL 말미 슬래시를 제거하고 URL을 정규화', async () => {
-    process.env.SPIDER_ADMIN_API_URL = 'http://localhost:8080/';
+  it("SPIDER_ADMIN_API_URL 말미 슬래시를 제거하고 URL을 정규화", async () => {
+    process.env.SPIDER_ADMIN_API_URL = "http://localhost:8080/";
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ success: true, data: { userId: 'u4', userName: '테스트', roleId: 'react-user', authorities: [] } }),
+      json: async () => ({
+        success: true,
+        data: {
+          userId: "u4",
+          userName: "테스트",
+          roleId: "react-user",
+          authorities: [],
+        },
+      }),
     });
-    vi.stubGlobal('fetch', mockFetch);
+    vi.stubGlobal("fetch", mockFetch);
 
-    await getCurrentUser('');
+    await getCurrentUser("");
 
     // 말미 슬래시가 제거되어 이중 슬래시 없이 호출되어야 함
     expect(mockFetch).toHaveBeenCalledWith(
-      'http://localhost:8080/api/auth/me',
+      "http://localhost:8080/api/auth/me",
       expect.anything(),
     );
   });
 
-  it('타임아웃(AbortError) 발생 시 GUEST 반환', async () => {
-    process.env.SPIDER_ADMIN_API_URL = 'http://localhost:8080';
-    const abortError = new DOMException('The operation was aborted.', 'AbortError');
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abortError));
+  it("타임아웃(AbortError) 발생 시 GUEST 반환", async () => {
+    process.env.SPIDER_ADMIN_API_URL = "http://localhost:8080";
+    const abortError = new DOMException(
+      "The operation was aborted.",
+      "AbortError",
+    );
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(abortError));
 
-    const user = await getCurrentUser('');
-    expect(user.roleId).toBe('guest');
+    const user = await getCurrentUser("");
+    expect(user.roleId).toBe("guest");
   });
 });
 
 // ── requireCmsRead / requireCmsWrite ─────────────────────────────────────────
 
-describe('requireCmsWrite', () => {
+describe("requireCmsWrite", () => {
   afterEach(() => {
     delete process.env.AUTH_BYPASS;
     vi.unstubAllGlobals();
   });
 
-  it('REACT-CMS:W 권한이 있으면 CurrentUser 반환', async () => {
-    process.env.AUTH_BYPASS = 'true';
-    const user = await requireCmsWrite('cms_bypass_role=react-adm');
-    expect(user.roleId).toBe('react-adm');
+  it("REACT_CMS:W 권한이 있으면 CurrentUser 반환", async () => {
+    process.env.AUTH_BYPASS = "true";
+    const user = await requireCmsWrite("cms_bypass_role=react-adm");
+    expect(user.roleId).toBe("react-adm");
   });
 
-  it('권한이 없으면 UnauthorizedError throw', async () => {
-    process.env.AUTH_BYPASS = 'false';
+  it("권한이 없으면 UnauthorizedError throw", async () => {
+    process.env.AUTH_BYPASS = "false";
     delete process.env.SPIDER_ADMIN_API_URL; // → GUEST 반환
-    await expect(requireCmsWrite('')).rejects.toThrow(UnauthorizedError);
+    await expect(requireCmsWrite("")).rejects.toThrow(UnauthorizedError);
   });
 });
 
-describe('requireCmsRead', () => {
+describe("requireCmsRead", () => {
   afterEach(() => {
     delete process.env.AUTH_BYPASS;
     vi.unstubAllGlobals();
   });
 
-  it('REACT-CMS:R 권한이 있으면 CurrentUser 반환', async () => {
-    process.env.AUTH_BYPASS = 'true';
-    const user = await requireCmsRead('');
-    expect(user.authorities).toContain('REACT-CMS:R');
+  it("REACT_CMS:R 권한이 있으면 CurrentUser 반환", async () => {
+    process.env.AUTH_BYPASS = "true";
+    const user = await requireCmsRead("");
+    expect(user.authorities).toContain("REACT_CMS:R");
   });
 
-  it('권한이 없으면 UnauthorizedError throw', async () => {
-    process.env.AUTH_BYPASS = 'false';
+  it("권한이 없으면 UnauthorizedError throw", async () => {
+    process.env.AUTH_BYPASS = "false";
     delete process.env.SPIDER_ADMIN_API_URL; // → GUEST 반환
-    await expect(requireCmsRead('')).rejects.toThrow(UnauthorizedError);
+    await expect(requireCmsRead("")).rejects.toThrow(UnauthorizedError);
   });
 });

--- a/react-cms/src/cms-admin/current-user.ts
+++ b/react-cms/src/cms-admin/current-user.ts
@@ -15,7 +15,7 @@
  * if (!canWriteCms(user)) { jsonResponse(res, 403, { error: 'Forbidden' }); return; }
  */
 
-import { authEnv } from '../lib/env';
+import { authEnv } from "../lib/env";
 
 // ── 타입 정의 ────────────────────────────────────────────────────────────────
 
@@ -23,7 +23,7 @@ export interface CurrentUser {
   userId: string;
   userName: string;
   roleId: string;
-  /** Spider Admin이 부여한 권한 목록 (예: ['REACT-CMS:R', 'REACT-CMS:W']) */
+  /** Spider Admin이 부여한 권한 목록 (예: ['REACT_CMS:R', 'REACT_CMS:W']) */
   authorities: string[];
 }
 
@@ -44,40 +44,40 @@ interface SpiderAdminApiResponse<T> {
 
 /** 인증 실패·미인증 상태의 기본 사용자 */
 const GUEST_USER: CurrentUser = {
-  userId: 'guest',
-  userName: 'Guest',
-  roleId: 'guest',
+  userId: "guest",
+  userName: "Guest",
+  roleId: "guest",
   authorities: [],
 };
 
 /** AUTH_BYPASS 모드 — cms_bypass_role=react-adm 쿠키 보유 시 */
 const BYPASS_ADMIN: CurrentUser = {
-  userId: 'reactAdmin01',
-  userName: 'React CMS 관리자',
-  roleId: 'react-adm',
-  authorities: ['REACT-CMS:R', 'REACT-CMS:W'],
+  userId: "reactAdmin01",
+  userName: "React CMS 관리자",
+  roleId: "react-adm",
+  authorities: ["REACT_CMS:R", "REACT_CMS:W"],
 };
 
 /** AUTH_BYPASS 모드 — 기본값(쿠키 미설정 또는 react-user) */
 const BYPASS_USER: CurrentUser = {
-  userId: 'reactUser01',
-  userName: 'React CMS 제작자',
-  roleId: 'react-user',
-  authorities: ['REACT-CMS:R', 'REACT-CMS:W'],
+  userId: "reactUser01",
+  userName: "React CMS 제작자",
+  roleId: "react-user",
+  authorities: ["REACT_CMS:R", "REACT_CMS:W"],
 };
 
 export const CMS_ROLE = {
-  SPIDER_ADMIN: 'ADMIN',
-  CMS_ADMIN: 'react-adm',
-  USER: 'react-user',
+  SPIDER_ADMIN: "ADMIN",
+  CMS_ADMIN: "react-adm",
+  USER: "react-user",
 } as const;
 
 // ── 오류 ─────────────────────────────────────────────────────────────────────
 
 export class UnauthorizedError extends Error {
-  constructor(message = 'Permission denied.') {
+  constructor(message = "Permission denied.") {
     super(message);
-    this.name = 'UnauthorizedError';
+    this.name = "UnauthorizedError";
   }
 }
 
@@ -90,25 +90,32 @@ export class UnauthorizedError extends Error {
  */
 function parseCookie(cookieHeader: string, name: string): string | undefined {
   return cookieHeader
-    .split(';')
-    .map(c => c.trim())
-    .find(c => c.startsWith(`${name}=`))
-    ?.split('=')
+    .split(";")
+    .map((c) => c.trim())
+    .find((c) => c.startsWith(`${name}=`))
+    ?.split("=")
     .slice(1)
-    .join('=');
+    .join("=");
 }
 
 /**
  * AUTH_BYPASS 모드에서 쿠키 기반으로 역할을 분기한다.
- * cms_bypass_role=react-adm → BYPASS_ADMIN
- * 그 외 → BYPASS_USER
+ * cms_bypass_role=react-adm → BYPASS_ADMIN 기반
+ * 그 외                     → BYPASS_USER 기반
+ *
+ * cms_bypass_user_id 쿠키가 있으면 userId/userName을 해당 값으로 덮어씌운다.
+ * 개발 환경에서 실제 계정 ID로 저장·조회를 테스트할 때 사용한다.
+ * 예) document.cookie = "cms_bypass_user_id=cmsUser01"
  */
 function getBypassUser(cookieHeader: string): CurrentUser {
-  // cms_bypass_role 쿠키가 react-adm인 경우에만 관리자 권한 부여
-  if (parseCookie(cookieHeader, 'cms_bypass_role') === 'react-adm') {
-    return BYPASS_ADMIN;
-  }
-  return BYPASS_USER;
+  const base = parseCookie(cookieHeader, "cms_bypass_role") === "react-adm"
+    ? BYPASS_ADMIN
+    : BYPASS_USER;
+
+  const overrideUserId = parseCookie(cookieHeader, "cms_bypass_user_id");
+  if (!overrideUserId) return base;
+
+  return { ...base, userId: overrideUserId, userName: overrideUserId };
 }
 
 // ── 공개 API ─────────────────────────────────────────────────────────────────
@@ -120,20 +127,24 @@ function getBypassUser(cookieHeader: string): CurrentUser {
  * @param cookieHeader HTTP 요청의 Cookie 헤더 문자열 (req.headers.cookie ?? '')
  * @returns CurrentUser — 인증 실패 또는 예외 발생 시 GUEST_USER 반환
  */
-export async function getCurrentUser(cookieHeader: string): Promise<CurrentUser> {
+export async function getCurrentUser(
+  cookieHeader: string,
+): Promise<CurrentUser> {
   // 개발 우회 모드 — admin 미배포 환경 테스트용
-  if (authEnv.AUTH_BYPASS === 'true') {
+  if (authEnv.AUTH_BYPASS === "true") {
     return getBypassUser(cookieHeader);
   }
 
   if (!authEnv.SPIDER_ADMIN_API_URL) {
     // 환경변수 미설정 시 경고 후 GUEST 처리 (운영 환경에서는 반드시 설정해야 함)
-    console.warn('[react-cms] SPIDER_ADMIN_API_URL이 설정되지 않았습니다. GUEST로 처리합니다.');
+    console.warn(
+      "[react-cms] SPIDER_ADMIN_API_URL이 설정되지 않았습니다. GUEST로 처리합니다.",
+    );
     return GUEST_USER;
   }
 
   // 말미 슬래시 제거로 URL 이중 슬래시 방지
-  const baseUrl = authEnv.SPIDER_ADMIN_API_URL.replace(/\/$/, '');
+  const baseUrl = authEnv.SPIDER_ADMIN_API_URL.replace(/\/$/, "");
 
   // 5초 타임아웃 — Spider Admin 응답 지연 시 Vite 플러그인 전체가 블로킹되는 것을 방지
   const controller = new AbortController();
@@ -151,15 +162,16 @@ export async function getCurrentUser(cookieHeader: string): Promise<CurrentUser>
       return GUEST_USER;
     }
 
-    const body = (await response.json()) as SpiderAdminApiResponse<SpiderAdminCurrentUser>;
+    const body =
+      (await response.json()) as SpiderAdminApiResponse<SpiderAdminCurrentUser>;
     if (!body.success || !body.data) {
       return GUEST_USER;
     }
 
     return {
-      userId:      body.data.userId,
-      userName:    body.data.userName,
-      roleId:      body.data.roleId,
+      userId: body.data.userId,
+      userName: body.data.userName,
+      roleId: body.data.roleId,
       authorities: body.data.authorities ?? [],
     };
   } catch {
@@ -170,26 +182,28 @@ export async function getCurrentUser(cookieHeader: string): Promise<CurrentUser>
 
 /** 'CMS:R' 또는 'CMS:W' 권한 보유 여부 확인 */
 export function hasAuthority(
-  user: Pick<CurrentUser, 'authorities'>,
-  authority: 'REACT-CMS:R' | 'REACT-CMS:W',
+  user: Pick<CurrentUser, "authorities">,
+  authority: "REACT_CMS:R" | "REACT_CMS:W",
 ): boolean {
   return user.authorities.includes(authority);
 }
 
 /** React CMS 에디터/대시보드 읽기 접근 가능 여부 */
-export function canReadCms(user: Pick<CurrentUser, 'authorities'>): boolean {
-  // REACT-CMS:W를 가지면 읽기도 허용 (상위 권한)
-  return hasAuthority(user, 'REACT-CMS:R') || hasAuthority(user, 'REACT-CMS:W');
+export function canReadCms(user: Pick<CurrentUser, "authorities">): boolean {
+  // REACT_CMS:W를 가지면 읽기도 허용 (상위 권한)
+  return hasAuthority(user, "REACT_CMS:R") || hasAuthority(user, "REACT_CMS:W");
 }
 
 /** React CMS 페이지 저장·삭제 가능 여부 */
-export function canWriteCms(user: Pick<CurrentUser, 'authorities'>): boolean {
-  return hasAuthority(user, 'REACT-CMS:W');
+export function canWriteCms(user: Pick<CurrentUser, "authorities">): boolean {
+  return hasAuthority(user, "REACT_CMS:W");
 }
 
 /** 승인 관리 화면 접근 가능 여부 (cms_admin 또는 ADMIN 역할) */
-export function canAdminScreen(user: Pick<CurrentUser, 'roleId'>): boolean {
-  return user.roleId === CMS_ROLE.SPIDER_ADMIN || user.roleId === CMS_ROLE.CMS_ADMIN;
+export function canAdminScreen(user: Pick<CurrentUser, "roleId">): boolean {
+  return (
+    user.roleId === CMS_ROLE.SPIDER_ADMIN || user.roleId === CMS_ROLE.CMS_ADMIN
+  );
 }
 
 /**
@@ -200,10 +214,12 @@ export function canAdminScreen(user: Pick<CurrentUser, 'roleId'>): boolean {
  * @returns 권한이 있는 CurrentUser
  * @throws UnauthorizedError
  */
-export async function requireCmsWrite(cookieHeader: string): Promise<CurrentUser> {
+export async function requireCmsWrite(
+  cookieHeader: string,
+): Promise<CurrentUser> {
   const user = await getCurrentUser(cookieHeader);
   if (!canWriteCms(user)) {
-    throw new UnauthorizedError('Permission denied.');
+    throw new UnauthorizedError("Permission denied.");
   }
   return user;
 }
@@ -216,10 +232,12 @@ export async function requireCmsWrite(cookieHeader: string): Promise<CurrentUser
  * @returns 권한이 있는 CurrentUser
  * @throws UnauthorizedError
  */
-export async function requireCmsRead(cookieHeader: string): Promise<CurrentUser> {
+export async function requireCmsRead(
+  cookieHeader: string,
+): Promise<CurrentUser> {
   const user = await getCurrentUser(cookieHeader);
   if (!canReadCms(user)) {
-    throw new UnauthorizedError('Permission denied.');
+    throw new UnauthorizedError("Permission denied.");
   }
   return user;
 }

--- a/react-cms/src/cms-core/preview/PreviewPage.tsx
+++ b/react-cms/src/cms-core/preview/PreviewPage.tsx
@@ -1,27 +1,82 @@
 /**
  * @file PreviewPage.tsx
  * @description CMS 빌더 미리보기 페이지 컴포넌트.
- * CMS 빌더의 "미리보기" 버튼 클릭 시 새 탭(`/preview`)으로 열리며,
- * localStorage의 "cms_preview" 키에 저장된 CMSPage JSON을 읽어 PageRenderer로 렌더링합니다.
- * 미리보기 데이터가 없거나 파싱 실패 시 안내 메시지를 표시합니다.
+ *
+ * pageType 쿼리 파라미터로 데이터 소스를 구분한다.
+ *   - ?pageType=REACT&pageId=xxx : DB에서 pageId로 페이지 JSON 조회 (승인 관리 등 외부 진입)
+ *   - 파라미터 없음              : localStorage["cms_preview"] 읽기 (빌더 내부 미리보기 버튼)
  */
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
 import type { CMSPage } from "../types";
+import type { CmsPage } from "../../db/types";
 import PageRenderer from "../runtime/renderPage";
 import { UserScopeWrapper } from "../UserScopeWrapper";
+import { cmsBase } from "../../lib/client-env";
 
 const PREVIEW_KEY = "cms_preview";
 
 export default function PreviewPage() {
-  const [page] = useState<CMSPage | null>(() => {
-    const raw = localStorage.getItem(PREVIEW_KEY);
-    if (!raw) return null;
-    try {
-      return JSON.parse(raw) as CMSPage;
-    } catch {
-      return null;
+  const [searchParams] = useSearchParams();
+  const pageType = searchParams.get("pageType");
+  const pageId = searchParams.get("pageId");
+
+  const [page, setPage] = useState<CMSPage | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (pageType === "REACT" && pageId) {
+      // 외부 진입: DB에서 pageId로 조회
+      setLoading(true);
+      fetch(`${cmsBase}/api/load`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ pageId }),
+      })
+        .then((r) => r.json())
+        .then((data: { page?: CmsPage | null }) => {
+          if (!data.page || !data.page.PAGE_HTML) {
+            setError("페이지를 찾을 수 없습니다.");
+            return;
+          }
+          // PAGE_HTML 컬럼에 CMSPage JSON이 문자열로 저장되어 있음
+          try {
+            setPage(JSON.parse(data.page.PAGE_HTML) as CMSPage);
+          } catch {
+            setError("페이지 데이터를 파싱할 수 없습니다.");
+          }
+        })
+        .catch(() => setError("페이지 로드 중 오류가 발생했습니다."))
+        .finally(() => setLoading(false));
+    } else {
+      // 빌더 내부 미리보기: localStorage에서 읽기
+      const raw = localStorage.getItem(PREVIEW_KEY);
+      if (!raw) return;
+      try {
+        setPage(JSON.parse(raw) as CMSPage);
+      } catch {
+        setError("미리보기 데이터를 파싱할 수 없습니다.");
+      }
     }
-  });
+  }, [pageType, pageId]);
+
+  if (loading) {
+    return (
+      <div className="h-screen flex items-center justify-center bg-white">
+        <div className="w-8 h-8 border-4 border-[#0046A4] border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="h-screen flex items-center justify-center bg-white">
+        <p className="text-sm text-red-400">{error}</p>
+      </div>
+    );
+  }
 
   if (!page) {
     return (

--- a/react-cms/src/cms-core/runtime/renderPage.tsx
+++ b/react-cms/src/cms-core/runtime/renderPage.tsx
@@ -3,7 +3,7 @@
  * @description CMSPage 데이터를 런타임에 렌더링하는 컴포넌트.
  * BlockRegistryContext / LayoutRendererContext / OverlayTemplatesContext를 소비합니다.
  */
-import { useContext, useLayoutEffect, useRef, useState } from "react";
+import { useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { Action, CMSOverlay, CMSPage } from "../types";
 import { BlockRegistryContext, LayoutRendererContext, OverlayTemplatesContext } from "../context";
@@ -123,14 +123,10 @@ function PageContent({ page }: { page: CMSPage }) {
   const { layoutType, layoutProps, blocks, overlays } = page;
   const handleAction = useActionHandler();
   const layoutRenderer = useContext(LayoutRendererContext);
-  const containerRef = useRef<HTMLDivElement>(null);  // portal 타깃 — HTMLDivElement | null
-  const [containerReady, setContainerReady] = useState(false);
-
-  // OverlayCanvas와 동일한 패턴 — 브라우저 페인트 전 동기 실행으로
-  // containerRef.current가 확정된 뒤에 OverlayRenderer가 마운트되도록 함.
-  useLayoutEffect(() => {
-    setContainerReady(true);
-  }, []);
+  // ref callback 패턴 — React가 DOM 연결/해제 시 직접 state를 업데이트하므로
+  // useLayoutEffect + containerReady 조합보다 StrictMode에서 안전하다.
+  // mount: setContainer(div), unmount: setContainer(null)
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
 
   const blockGap = (layoutProps?.blockGap as string | undefined) ?? "none";
   const blockList = (
@@ -151,9 +147,9 @@ function PageContent({ page }: { page: CMSPage }) {
         {slots.footer}
       </div>
       {/* portal 타깃: UserScopeWrapper 안에 위치해 스코프 CSS가 적용되도록 함 */}
-      <div ref={containerRef} />
-      {containerReady && (
-        <OverlayRenderer overlays={overlays} handleAction={handleAction} container={containerRef.current} />
+      <div ref={setContainer} />
+      {container && (
+        <OverlayRenderer overlays={overlays} handleAction={handleAction} container={container} />
       )}
     </>
   );

--- a/react-cms/src/main.tsx
+++ b/react-cms/src/main.tsx
@@ -7,14 +7,20 @@
  *
  * 라우트 구성:
  *   - /not-authorized  : 권한 없는 사용자용 공개 페이지 (인증 가드 밖)
- *   - /                : admin 연동 모드 → CmsAuthGuard (REACT-CMS:R 검증)
+ *   - /                : admin 연동 모드 → CmsAuthGuard (REACT_CMS:R 검증)
  *                        단독 실행 모드 → 인증 없이 바로 자식 라우트 렌더링
  *   - /builder         : CMS 에디터
  *   - /preview         : 페이지 미리보기
  */
 import { StrictMode, useState, useEffect } from "react";
 import { createRoot } from "react-dom/client";
-import { createBrowserRouter, RouterProvider, Navigate, Outlet, useSearchParams } from "react-router-dom";
+import {
+  createBrowserRouter,
+  RouterProvider,
+  Navigate,
+  Outlet,
+  useSearchParams,
+} from "react-router-dom";
 import { CMSApp } from "@cms-core";
 import type { CMSPage } from "@cms-core/types";
 import { CMSBuilder } from "@cms-core/CMSBuilder";
@@ -45,9 +51,15 @@ function BuilderPage() {
   const [searchParams] = useSearchParams();
   const pageId = searchParams.get("pageId");
 
-  const [initialPage, setInitialPage] = useState<CMSPage | undefined>(undefined);
-  const [initialPageName, setInitialPageName] = useState<string | undefined>(undefined);
-  const [approveState, setApproveState] = useState<string | undefined>(undefined);
+  const [initialPage, setInitialPage] = useState<CMSPage | undefined>(
+    undefined,
+  );
+  const [initialPageName, setInitialPageName] = useState<string | undefined>(
+    undefined,
+  );
+  const [approveState, setApproveState] = useState<string | undefined>(
+    undefined,
+  );
   const [rejectedReason, setRejectedReason] = useState<string | null>(null);
   const [loading, setLoading] = useState(!!pageId);
   const [error, setError] = useState<string | null>(null);
@@ -70,32 +82,39 @@ function BuilderPage() {
       : Promise.resolve(null);
 
     Promise.all([pageLoad, approvalLoad])
-      .then(([data, approvalData]: [
-        { page?: { PAGE_HTML?: string | null; PAGE_NAME?: string } | null },
-        { data?: { approveState?: string; rejectedReason?: string | null } } | null,
-      ]) => {
-        const row = data.page;
-        if (!row) {
-          setError("페이지를 찾을 수 없습니다.");
-          return;
-        }
-        // 재편집을 위해 pageId를 localStorage에 캐싱 — savePage.ts의 UPDATE 분기를 타도록 함
-        if (row.PAGE_NAME) {
-          localStorage.setItem(`${PAGE_ID_KEY_PREFIX}${row.PAGE_NAME}`, pageId);
-          setInitialPageName(row.PAGE_NAME);
-        }
-        if (row.PAGE_HTML) {
-          try {
-            setInitialPage(JSON.parse(row.PAGE_HTML) as CMSPage);
-          } catch {
-            setError("페이지 데이터를 불러올 수 없습니다.");
+      .then(
+        ([data, approvalData]: [
+          { page?: { PAGE_HTML?: string | null; PAGE_NAME?: string } | null },
+          {
+            data?: { approveState?: string; rejectedReason?: string | null };
+          } | null,
+        ]) => {
+          const row = data.page;
+          if (!row) {
+            setError("페이지를 찾을 수 없습니다.");
+            return;
           }
-        }
-        if (approvalData?.data) {
-          setApproveState(approvalData.data.approveState);
-          setRejectedReason(approvalData.data.rejectedReason ?? null);
-        }
-      })
+          // 재편집을 위해 pageId를 localStorage에 캐싱 — savePage.ts의 UPDATE 분기를 타도록 함
+          if (row.PAGE_NAME) {
+            localStorage.setItem(
+              `${PAGE_ID_KEY_PREFIX}${row.PAGE_NAME}`,
+              pageId,
+            );
+            setInitialPageName(row.PAGE_NAME);
+          }
+          if (row.PAGE_HTML) {
+            try {
+              setInitialPage(JSON.parse(row.PAGE_HTML) as CMSPage);
+            } catch {
+              setError("페이지 데이터를 불러올 수 없습니다.");
+            }
+          }
+          if (approvalData?.data) {
+            setApproveState(approvalData.data.approveState);
+            setRejectedReason(approvalData.data.rejectedReason ?? null);
+          }
+        },
+      )
       .catch(() => setError("페이지 불러오기 중 오류가 발생했습니다."))
       .finally(() => setLoading(false));
   }, [pageId]);
@@ -115,7 +134,9 @@ function BuilderPage() {
         <div className="flex gap-2">
           <button
             className="px-4 py-2 text-xs rounded-lg bg-primary text-white hover:bg-primary-dark transition-colors"
-            onClick={() => { window.location.href = window.location.pathname; }}
+            onClick={() => {
+              window.location.href = window.location.pathname;
+            }}
           >
             새 페이지 생성
           </button>
@@ -145,9 +166,10 @@ function BuilderPage() {
 // BASE_URL은 Vite가 vite.config.ts의 base 설정값으로 주입한다.
 // VITE_BASE=/react-cms/ 로 실행 시 '/react-cms/' — nginx 프록시를 거쳐 admin과 연동되는 모드.
 // 단독 개발 시 기본값 '/' → admin 연동 없이 builder/preview 직접 접근 허용.
-const basename = import.meta.env.BASE_URL !== "/"
-  ? import.meta.env.BASE_URL.replace(/\/$/, "")
-  : undefined;
+const basename =
+  import.meta.env.BASE_URL !== "/"
+    ? import.meta.env.BASE_URL.replace(/\/$/, "")
+    : undefined;
 
 const router = createBrowserRouter(
   [
@@ -158,7 +180,7 @@ const router = createBrowserRouter(
     },
     {
       path: "/",
-      // admin 연동 모드: CmsAuthGuard로 REACT-CMS:R 권한 검증 후 자식 라우트 렌더링
+      // admin 연동 모드: CmsAuthGuard로 REACT_CMS:R 권한 검증 후 자식 라우트 렌더링
       // 단독 실행 모드: 인증 없이 Outlet으로 바로 자식 라우트 렌더링
       element: isAdminMode ? <CmsAuthGuard /> : <Outlet />,
       children: [

--- a/react-cms/src/user-scope.css
+++ b/react-cms/src/user-scope.css
@@ -8,4 +8,4 @@
  *   import userScopeCSS from "./user-scope.css?inline";
  *   <CMSApp stylesheetContent={userScopeCSS} />
  */
-@import "@cl/dist/styles.css";
+@import "@cl/styles.css";


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

Closes #264

## ✨ 변경 사항 (Changes)

- `ReactCmsAdminDeployService`: RestTemplate 제거, instanceId 기반 로컬/원격 배포 경로 분기 추가
- `ReactDeployLocalProperties` config 클래스 신규 추가
- `demo/front` 라우터에 `/react-cms/viewer/:pageId` Vite 뷰어 라우트 추가
- React CMS 권한 표기 `REACT-CMS` → `REACT_CMS` 통일
- 대시보드/배포 관리 화면 UI 업데이트
- `.env.example`, `application.yml`에 React CMS 로컬 배포 설정 추가

## 🛠 기술적 의사결정

로컬 인스턴스는 별도의 CMS push API 없이 TypeScript 파일을 직접 `demo/front/src/reactcms/` 경로에 저장하고 Vite 뷰어 라우트(`/react-cms/viewer/:pageId`)로 연결한다. instanceId로 로컬/원격을 구분하여 기존 원격 배포 흐름은 그대로 유지했다.

## ⚠️ 고려 및 주의 사항

- `admin/.env`에 `REACT_DEPLOY_LOCAL_INSTANCE_ID` 설정 필요 (미설정 시 로컬 분기 비활성)
- DB 쿼리 변경 포함 — `admin/docs/sql/oracle/03_insert_initial_data.sql` 참고하여 직접 수행 필요