### PR TITLE
🐛 fix/#268-application.yml multipart max-file-size 오타 수정

### DIFF
--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
   servlet:
     multipart:
       enabled: true
-      max-file-size: 50MBㅇ
+      max-file-size: 50MB
       max-request-size: 150MB
 
   # Thymeleaf Configuration


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

Closes #268

## ✨ 변경 사항 (Changes)

- `admin/src/main/resources/application.yml` line 26: `50MBㅇ` → `50MB`

## ⚠️ 고려 및 주의 사항

main 브랜치 전체에서 Playwright CI가 계속 실패 중이던 원인. 단순 오타 수정이므로 즉시 머지 권장.