### PR TITLE
♻️ refactor/#274-AUTH_BYPASS 제거 및 React CMS 승인·대시보드 기능 수정

### DIFF
--- a/react-cms/.env.example
+++ b/react-cms/.env.example
@@ -29,16 +29,7 @@ ORACLE_SCHEMA=
 ORACLE_CLIENT_DIR=
 
 # ── CMS 인증 ──
-# Spider Admin API 기반 인증 구조. 자세한 내용은 src/admin/current-user.ts 참고.
-
-# 개발용 인증 우회 모드.
-# true로 설정하면 Spider Admin API 호출 없이 쿠키(cms_bypass_role)로 역할을 분기한다.
-#   cms_bypass_role=react-adm  → 관리자 권한 (REACT_CMS:R, REACT_CMS:W)
-#   cms_bypass_role 미설정     → 일반 사용자 권한 (REACT_CMS:R, REACT_CMS:W)
-# 운영 환경에서는 반드시 false로 유지해야 한다.
-AUTH_BYPASS=false
-
-# Spider Admin API 베이스 URL.
-# AUTH_BYPASS=false(운영) 환경에서 /api/auth/me 호출에 사용된다.
+# 어드민 모드(npm run dev:proxy)에서 spider-admin 세션을 통해 실제 사용자 확인.
+# nginx 프록시(포트 9000)를 통해 접근해야 세션 쿠키가 공유된다.
 # 예: SPIDER_ADMIN_API_URL=http://localhost:8080
 SPIDER_ADMIN_API_URL=

--- a/react-cms/README.md
+++ b/react-cms/README.md
@@ -158,6 +158,7 @@ cp .env.example .env
 |---|---|---|
 | `VITE_CMS_BRAND` | CMS 셸 브랜드 테마 색상 | `hana` |
 | `ORACLE_USER` / `ORACLE_PASSWORD` 등 | Oracle DB 접속 정보 | — |
+| `SPIDER_ADMIN_API_URL` | Spider Admin API 베이스 URL (어드민 모드에서 세션 인증에 사용) | — |
 
 **`VITE_CMS_BRAND`** 값에 따라 CMS 빌더 UI의 주요 색상(헤더, 버튼 등)이 변경된다.
 
@@ -167,17 +168,29 @@ VITE_CMS_BRAND=hana   # hana | kb | ibk | woori | shinhan | nh
 
 ### 실행
 
+#### 단독 실행 (파일시스템 저장)
+
 ```bash
 cd react-cms
 npm install
 npm run dev
 ```
 
-빌더 UI는 `http://localhost:5173/builder` 에서 접근한다.
+빌더 UI는 `http://localhost:5173/builder` 에서 접근한다. 페이지는 파일시스템(`demo/front`)에 저장된다.
 
 > `cmsBankPlugin`이 `react-cms` Vite 서버에 `/__cms/create-page` 엔드포인트를 등록하므로,
 > 저장 기능을 사용하려면 `demo/front`가 실행 중일 필요 없이 `react-cms` dev 서버만 실행하면 된다.
 > 단, 생성된 파일이 반영되려면 `demo/front` dev 서버도 함께 실행해야 한다.
+
+#### 어드민 모드 (spider-admin + Oracle DB 저장)
+
+```bash
+cd react-cms
+npm run dev:proxy
+```
+
+spider-admin(`:8080`)과 nginx 프록시(`:9000`)가 실행 중이어야 세션 쿠키가 공유되어 로그인 사용자로 저장된다.
+빌더 UI는 `http://localhost:9000/react-cms/builder` 에서 접근한다.
 
 ---
 
@@ -402,8 +415,22 @@ export function App() {
 
 ```typescript
 interface CMSBuilderProps {
+  /** 페이지 저장 핸들러. 생략 시 defaultSave(파일시스템) 사용 */
   onSave?: (page: CMSPage, params: SavePageParams) => void | Promise<void>;
+  /** 초기 페이지 데이터. edit 모드에서 DB에서 불러온 CMSPage를 전달 */
   initialPage?: CMSPage;
+  /**
+   * 빌더 모드.
+   * 'create': 새 페이지 생성 (기본값) — 초기화 버튼이 빈 상태로 리셋.
+   * 'edit': 기존 페이지 수정 — 초기화 버튼이 initialPage 상태로 복원.
+   */
+  mode?: "create" | "edit";
+  /** 편집 모드에서 저장 모달의 초기 페이지명 */
+  initialPageName?: string;
+  /** 현재 페이지 승인 상태 (WORK / PENDING / APPROVED / REJECTED) */
+  approveState?: string;
+  /** 반려 사유 — REJECTED 상태일 때 배너에 표시 */
+  rejectedReason?: string | null;
 }
 ```
 

--- a/react-cms/src/cms-admin/__tests__/current-user.test.ts
+++ b/react-cms/src/cms-admin/__tests__/current-user.test.ts
@@ -4,7 +4,7 @@
  *
  * 테스트 대상:
  *   - 순수 함수: hasAuthority, canReadCms, canWriteCms, canAdminScreen
- *   - 비동기 함수: getCurrentUser (AUTH_BYPASS 분기, API 성공/실패, 폴백)
+ *   - 비동기 함수: getCurrentUser (SPIDER_ADMIN_API_URL 미설정, API 성공/실패, 폴백)
  *   - 권한 가드: requireCmsRead, requireCmsWrite
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
@@ -90,54 +90,18 @@ describe("canAdminScreen", () => {
 
 // ── getCurrentUser ────────────────────────────────────────────────────────────
 
-describe("getCurrentUser — AUTH_BYPASS=true", () => {
+describe("getCurrentUser", () => {
   beforeEach(() => {
-    process.env.AUTH_BYPASS = "true";
     delete process.env.SPIDER_ADMIN_API_URL;
+    vi.unstubAllGlobals();
   });
 
   afterEach(() => {
-    delete process.env.AUTH_BYPASS;
-  });
-
-  it("cms_bypass_role=react-adm 쿠키가 있으면 관리자 반환", async () => {
-    const user = await getCurrentUser("cms_bypass_role=react-adm");
-    expect(user.roleId).toBe("react-adm");
-    expect(user.authorities).toContain("REACT_CMS:W");
-  });
-
-  it("쿠키가 없으면 일반 사용자 반환", async () => {
-    const user = await getCurrentUser("");
-    expect(user.roleId).toBe("react-user");
-    expect(user.authorities).toContain("REACT_CMS:R");
-  });
-
-  it("다른 값의 쿠키가 있으면 일반 사용자 반환", async () => {
-    const user = await getCurrentUser("cms_bypass_role=other-role");
-    expect(user.roleId).toBe("react-user");
-  });
-
-  it("여러 쿠키 중 cms_bypass_role=react-adm이 있으면 관리자 반환", async () => {
-    const user = await getCurrentUser(
-      "session=abc; cms_bypass_role=react-adm; theme=dark",
-    );
-    expect(user.roleId).toBe("react-adm");
-  });
-});
-
-describe("getCurrentUser — AUTH_BYPASS=false", () => {
-  beforeEach(() => {
-    process.env.AUTH_BYPASS = "false";
-  });
-
-  afterEach(() => {
-    delete process.env.AUTH_BYPASS;
     delete process.env.SPIDER_ADMIN_API_URL;
     vi.unstubAllGlobals();
   });
 
   it("SPIDER_ADMIN_API_URL 미설정 시 GUEST 반환", async () => {
-    delete process.env.SPIDER_ADMIN_API_URL;
     const user = await getCurrentUser("");
     expect(user.roleId).toBe("guest");
     expect(user.authorities).toHaveLength(0);
@@ -283,18 +247,27 @@ describe("getCurrentUser — AUTH_BYPASS=false", () => {
 
 describe("requireCmsWrite", () => {
   afterEach(() => {
-    delete process.env.AUTH_BYPASS;
+    delete process.env.SPIDER_ADMIN_API_URL;
     vi.unstubAllGlobals();
   });
 
   it("REACT_CMS:W 권한이 있으면 CurrentUser 반환", async () => {
-    process.env.AUTH_BYPASS = "true";
-    const user = await requireCmsWrite("cms_bypass_role=react-adm");
+    process.env.SPIDER_ADMIN_API_URL = "http://localhost:8080";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          success: true,
+          data: { userId: "u1", userName: "테스트", roleId: "react-adm", authorities: ["REACT_CMS:R", "REACT_CMS:W"] },
+        }),
+      }),
+    );
+    const user = await requireCmsWrite("");
     expect(user.roleId).toBe("react-adm");
   });
 
   it("권한이 없으면 UnauthorizedError throw", async () => {
-    process.env.AUTH_BYPASS = "false";
     delete process.env.SPIDER_ADMIN_API_URL; // → GUEST 반환
     await expect(requireCmsWrite("")).rejects.toThrow(UnauthorizedError);
   });
@@ -302,18 +275,27 @@ describe("requireCmsWrite", () => {
 
 describe("requireCmsRead", () => {
   afterEach(() => {
-    delete process.env.AUTH_BYPASS;
+    delete process.env.SPIDER_ADMIN_API_URL;
     vi.unstubAllGlobals();
   });
 
   it("REACT_CMS:R 권한이 있으면 CurrentUser 반환", async () => {
-    process.env.AUTH_BYPASS = "true";
+    process.env.SPIDER_ADMIN_API_URL = "http://localhost:8080";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          success: true,
+          data: { userId: "u1", userName: "테스트", roleId: "react-user", authorities: ["REACT_CMS:R", "REACT_CMS:W"] },
+        }),
+      }),
+    );
     const user = await requireCmsRead("");
     expect(user.authorities).toContain("REACT_CMS:R");
   });
 
   it("권한이 없으면 UnauthorizedError throw", async () => {
-    process.env.AUTH_BYPASS = "false";
     delete process.env.SPIDER_ADMIN_API_URL; // → GUEST 반환
     await expect(requireCmsRead("")).rejects.toThrow(UnauthorizedError);
   });

--- a/react-cms/src/cms-admin/__tests__/current-user.test.ts
+++ b/react-cms/src/cms-admin/__tests__/current-user.test.ts
@@ -7,7 +7,7 @@
  *   - 비동기 함수: getCurrentUser (SPIDER_ADMIN_API_URL 미설정, API 성공/실패, 폴백)
  *   - 권한 가드: requireCmsRead, requireCmsWrite
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import {
   hasAuthority,
   canReadCms,
@@ -91,11 +91,6 @@ describe("canAdminScreen", () => {
 // ── getCurrentUser ────────────────────────────────────────────────────────────
 
 describe("getCurrentUser", () => {
-  beforeEach(() => {
-    delete process.env.SPIDER_ADMIN_API_URL;
-    vi.unstubAllGlobals();
-  });
-
   afterEach(() => {
     delete process.env.SPIDER_ADMIN_API_URL;
     vi.unstubAllGlobals();

--- a/react-cms/src/cms-admin/current-user.ts
+++ b/react-cms/src/cms-admin/current-user.ts
@@ -2,8 +2,9 @@
  * @file current-user.ts
  * @description Vite dev 서버(플러그인) 컨텍스트에서 현재 로그인 사용자를 조회하는 서버 사이드 모듈.
  *
- * 운영 환경에서는 Spider Admin API(`/api/auth/me`)를 호출해 사용자 정보를 파싱하고,
- * 개발 환경에서는 쿠키(`cms_bypass_role`) 값에 따라 역할을 고정 반환한다.
+ * Spider Admin API(`/api/auth/me`)를 호출해 사용자 정보를 파싱한다.
+ * 어드민 모드(npm run dev:proxy)에서만 동작하며, 단독 실행 모드(npm run dev)에서는
+ * 파일 시스템 저장을 사용하므로 이 모듈이 호출되지 않는다.
  *
  * 이 모듈은 Node.js(Vite 플러그인) 에서만 실행되므로 브라우저 API(`document.cookie` 등)를
  * 사용하지 않으며, HTTP 요청 헤더의 Cookie 문자열을 직접 파싱한다.
@@ -50,22 +51,6 @@ const GUEST_USER: CurrentUser = {
   authorities: [],
 };
 
-/** AUTH_BYPASS 모드 — cms_bypass_role=react-adm 쿠키 보유 시 */
-const BYPASS_ADMIN: CurrentUser = {
-  userId: "reactAdmin01",
-  userName: "React CMS 관리자",
-  roleId: "react-adm",
-  authorities: ["REACT_CMS:R", "REACT_CMS:W"],
-};
-
-/** AUTH_BYPASS 모드 — 기본값(쿠키 미설정 또는 react-user) */
-const BYPASS_USER: CurrentUser = {
-  userId: "reactUser01",
-  userName: "React CMS 제작자",
-  roleId: "react-user",
-  authorities: ["REACT_CMS:R", "REACT_CMS:W"],
-};
-
 export const CMS_ROLE = {
   SPIDER_ADMIN: "ADMIN",
   CMS_ADMIN: "react-adm",
@@ -81,48 +66,14 @@ export class UnauthorizedError extends Error {
   }
 }
 
-// ── 내부 헬퍼 ────────────────────────────────────────────────────────────────
-
-/**
- * Cookie 헤더 문자열에서 특정 쿠키 값을 파싱한다.
- * @param cookieHeader req.headers.cookie 문자열
- * @param name 쿠키 이름
- */
-function parseCookie(cookieHeader: string, name: string): string | undefined {
-  return cookieHeader
-    .split(";")
-    .map((c) => c.trim())
-    .find((c) => c.startsWith(`${name}=`))
-    ?.split("=")
-    .slice(1)
-    .join("=");
-}
-
-/**
- * AUTH_BYPASS 모드에서 쿠키 기반으로 역할을 분기한다.
- * cms_bypass_role=react-adm → BYPASS_ADMIN 기반
- * 그 외                     → BYPASS_USER 기반
- *
- * cms_bypass_user_id 쿠키가 있으면 userId/userName을 해당 값으로 덮어씌운다.
- * 개발 환경에서 실제 계정 ID로 저장·조회를 테스트할 때 사용한다.
- * 예) document.cookie = "cms_bypass_user_id=cmsUser01"
- */
-function getBypassUser(cookieHeader: string): CurrentUser {
-  const base = parseCookie(cookieHeader, "cms_bypass_role") === "react-adm"
-    ? BYPASS_ADMIN
-    : BYPASS_USER;
-
-  const overrideUserId = parseCookie(cookieHeader, "cms_bypass_user_id");
-  if (!overrideUserId) return base;
-
-  return { ...base, userId: overrideUserId, userName: overrideUserId };
-}
-
 // ── 공개 API ─────────────────────────────────────────────────────────────────
 
 /**
  * 현재 로그인 사용자를 조회한다.
  * Vite 플러그인(Node.js 서버) 컨텍스트에서만 호출되어야 한다.
+ *
+ * Spider Admin API(`/api/auth/me`)에 요청자의 쿠키를 전달해 사용자를 식별한다.
+ * SPIDER_ADMIN_API_URL 미설정 또는 인증 실패 시 GUEST_USER를 반환한다.
  *
  * @param cookieHeader HTTP 요청의 Cookie 헤더 문자열 (req.headers.cookie ?? '')
  * @returns CurrentUser — 인증 실패 또는 예외 발생 시 GUEST_USER 반환
@@ -130,11 +81,6 @@ function getBypassUser(cookieHeader: string): CurrentUser {
 export async function getCurrentUser(
   cookieHeader: string,
 ): Promise<CurrentUser> {
-  // 개발 우회 모드 — admin 미배포 환경 테스트용
-  if (authEnv.AUTH_BYPASS === "true") {
-    return getBypassUser(cookieHeader);
-  }
-
   if (!authEnv.SPIDER_ADMIN_API_URL) {
     // 환경변수 미설정 시 경고 후 GUEST 처리 (운영 환경에서는 반드시 설정해야 함)
     console.warn(
@@ -152,7 +98,7 @@ export async function getCurrentUser(
 
   try {
     const response = await fetch(`${baseUrl}/api/auth/me`, {
-      // 요청자의 쿠키(JWT 세션)를 Spider Admin에 그대로 전달해 사용자 식별
+      // 요청자의 쿠키(세션)를 Spider Admin에 그대로 전달해 사용자 식별
       headers: { cookie: cookieHeader },
       signal: controller.signal,
     });
@@ -175,7 +121,7 @@ export async function getCurrentUser(
       authorities: body.data.authorities ?? [],
     };
   } catch {
-    // 네트워크 오류·JSON 파싱 실패 등 예외 시 GUEST 처리
+    // 네트워크 오류·JSON 파싱 실패·타임아웃 등 예외 시 GUEST 처리
     return GUEST_USER;
   }
 }

--- a/react-cms/src/cms-core/CMSBuilder.tsx
+++ b/react-cms/src/cms-core/CMSBuilder.tsx
@@ -219,6 +219,16 @@ export function CMSBuilder({ onSave, initialPage, mode = "create", initialPageNa
     setSaveOpen(true);
   }
 
+  // 편집 모드: DB 저장 상태로 복원 / 생성 모드: 빈 상태로 초기화
+  const handleReset = useCallback(() => {
+    if (mode === "edit" && initialPage) {
+      if (!window.confirm("마지막 저장 상태로 되돌아가시겠습니까?\n현재 편집 내용은 사라집니다.")) return;
+      builder.loadPage(initialPage);
+    } else {
+      builder.clearBlocks();
+    }
+  }, [mode, initialPage, builder.loadPage, builder.clearBlocks]);
+
   // page 선언 이후에 위치해야 TDZ 에러가 발생하지 않음
   const handlePreview = useCallback(() => {
     localStorage.setItem("cms_preview", JSON.stringify(page));
@@ -254,7 +264,8 @@ export function CMSBuilder({ onSave, initialPage, mode = "create", initialPageNa
           onViewCode={() => setCodeOpen(true)}
           onSavePage={handleSavePageClick}
           onPreview={handlePreview}
-          onClear={builder.clearBlocks}
+          onClear={handleReset}
+          hasInitialPage={mode === "edit" && !!initialPage}
           approveState={approveState}
         />
 
@@ -362,6 +373,7 @@ function Toolbar({
   onSavePage,
   onPreview,
   onClear,
+  hasInitialPage,
   approveState,
 }: {
   blockCount: number;
@@ -375,6 +387,7 @@ function Toolbar({
   onSavePage: () => void;
   onPreview: () => void;
   onClear: () => void;
+  hasInitialPage: boolean;
   approveState?: string;
 }) {
   const isPending = approveState === "PENDING";
@@ -423,7 +436,7 @@ function Toolbar({
         <ToolbarButton onClick={onPreview} variant="primary" disabled={blockCount === 0}>
           미리보기
         </ToolbarButton>
-        {(blockCount > 0 || layoutType) && (
+        {(blockCount > 0 || layoutType || hasInitialPage) && (
           <ToolbarButton onClick={onClear} variant="danger">초기화</ToolbarButton>
         )}
       </div>

--- a/react-cms/src/cms-core/CMSBuilder.tsx
+++ b/react-cms/src/cms-core/CMSBuilder.tsx
@@ -220,14 +220,15 @@ export function CMSBuilder({ onSave, initialPage, mode = "create", initialPageNa
   }
 
   // 편집 모드: DB 저장 상태로 복원 / 생성 모드: 빈 상태로 초기화
+  const { loadPage, clearBlocks } = builder;
   const handleReset = useCallback(() => {
     if (mode === "edit" && initialPage) {
       if (!window.confirm("마지막 저장 상태로 되돌아가시겠습니까?\n현재 편집 내용은 사라집니다.")) return;
-      builder.loadPage(initialPage);
+      loadPage(initialPage);
     } else {
-      builder.clearBlocks();
+      clearBlocks();
     }
-  }, [mode, initialPage, builder.loadPage, builder.clearBlocks]);
+  }, [mode, initialPage, loadPage, clearBlocks]);
 
   // page 선언 이후에 위치해야 TDZ 에러가 발생하지 않음
   const handlePreview = useCallback(() => {

--- a/react-cms/src/lib/env.ts
+++ b/react-cms/src/lib/env.ts
@@ -32,14 +32,10 @@ export const oracleEnv = {
 // ── CMS 인증 ─────────────────────────────────────────────────────────────────
 
 /**
- * 개발용 인증 우회 모드.
- * 'true'로 설정하면 Spider Admin API 호출 없이 쿠키(`cms_bypass_role`) 값으로 역할을 분기한다.
- *
  * getter로 선언해 호출 시점에 process.env를 읽는다.
  * vite.config.ts의 static import 평가는 loadEnv 실행보다 앞서므로,
- * 모듈 로드 시 상수로 캡처하면 항상 fallback 값('false')이 된다.
+ * 모듈 로드 시 상수로 캡처하면 항상 fallback 값이 된다.
  */
 export const authEnv = {
-  get AUTH_BYPASS()          { return process.env.AUTH_BYPASS          ?? 'false'; },
-  get SPIDER_ADMIN_API_URL() { return process.env.SPIDER_ADMIN_API_URL ?? '';      },
+  get SPIDER_ADMIN_API_URL() { return process.env.SPIDER_ADMIN_API_URL ?? ''; },
 };

--- a/reactive-springware/.gitignore
+++ b/reactive-springware/.gitignore
@@ -5,6 +5,11 @@ node_modules/
 dist/
 storybook-static/
 
+# component-library/dist/styles.css는 소비자 프로젝트가 직접 참조하므로 버전 관리
+!component-library/dist/
+component-library/dist/*
+!component-library/dist/styles.css
+
 # 환경 변수
 .env
 .env.local

--- a/reactive-springware/component-library/dist/styles.css
+++ b/reactive-springware/component-library/dist/styles.css
@@ -1,0 +1,2805 @@
+/*! tailwindcss v4.2.4 | MIT License | https://tailwindcss.com */
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap');
+@layer properties;
+:root {
+  --bp-mobile: 390px;
+  --bp-tablet: 768px;
+  --bp-desktop: 1280px;
+}
+[data-domain='banking'] {
+  --domain-page-bg: #f5f8f8;
+}
+[data-domain='card'] {
+  --domain-page-bg: #f4f7ff;
+  --domain-card-accent: var(--brand-alt);
+  --domain-card-accent-text: var(--brand-text);
+}
+[data-brand='hana'][data-domain='card'] {
+  --domain-card-accent: #caee5d;
+  --domain-card-accent-text: #546b00;
+}
+[data-domain='giro'] {
+  --domain-page-bg: #f9f7ff;
+}
+[data-domain='insurance'] {
+  --domain-page-bg: #fff8f7;
+}
+:root {
+  --brand-primary: #008485;
+  --brand-alt: #14b8a6;
+  --brand-fg: #ffffff;
+  --brand-text: #008485;
+  --brand-dark: #006e6f;
+  --brand-darker: #005859;
+  --brand-5: rgba(0, 132, 133, 0.05);
+  --brand-10: rgba(0, 132, 133, 0.1);
+  --brand-20: rgba(0, 132, 133, 0.2);
+  --brand-shadow: rgba(0, 132, 133, 0.25);
+  --brand-bg: #f5f8f8;
+  --brand-name: '하나은행';
+  --shadow-primary: 0px 8px 20px -4px var(--brand-shadow);
+}
+[data-brand='hana'] {
+  --brand-primary: #008485;
+  --brand-alt: #14b8a6;
+  --brand-fg: #ffffff;
+  --brand-text: #008485;
+  --brand-dark: #006e6f;
+  --brand-darker: #005859;
+  --brand-5: rgba(0, 132, 133, 0.05);
+  --brand-10: rgba(0, 132, 133, 0.1);
+  --brand-20: rgba(0, 132, 133, 0.2);
+  --brand-shadow: rgba(0, 132, 133, 0.25);
+  --brand-bg: #f5f8f8;
+  --brand-name: '하나은행';
+  --shadow-primary: 0px 8px 20px -4px var(--brand-shadow);
+}
+[data-brand='ibk'] {
+  --brand-primary: #0068b7;
+  --brand-alt: #3b9ad9;
+  --brand-fg: #ffffff;
+  --brand-text: #0057a0;
+  --brand-dark: #0057a0;
+  --brand-darker: #004580;
+  --brand-5: rgba(0, 104, 183, 0.05);
+  --brand-10: rgba(0, 104, 183, 0.1);
+  --brand-20: rgba(0, 104, 183, 0.2);
+  --brand-shadow: rgba(0, 104, 183, 0.25);
+  --brand-bg: #f4f7fb;
+  --brand-name: 'IBK기업은행';
+  --shadow-primary: 0px 8px 20px -4px var(--brand-shadow);
+}
+[data-brand='kb'] {
+  --brand-primary: #ffbc00;
+  --brand-alt: #ffd740;
+  --brand-fg: #1a1200;
+  --brand-text: #7a4400;
+  --brand-dark: #e6aa00;
+  --brand-darker: #cc9600;
+  --brand-5: rgba(255, 188, 0, 0.05);
+  --brand-10: rgba(255, 188, 0, 0.1);
+  --brand-20: rgba(255, 188, 0, 0.2);
+  --brand-shadow: rgba(255, 188, 0, 0.25);
+  --brand-bg: #fffdf0;
+  --brand-name: 'KB국민은행';
+  --shadow-primary: 0px 8px 20px -4px var(--brand-shadow);
+}
+[data-brand='nh'] {
+  --brand-primary: #00a859;
+  --brand-alt: #eef300;
+  --brand-fg: #ffffff;
+  --brand-text: #007a40;
+  --brand-dark: #008a49;
+  --brand-darker: #006b38;
+  --brand-5: rgba(0, 168, 89, 0.05);
+  --brand-10: rgba(0, 168, 89, 0.1);
+  --brand-20: rgba(0, 168, 89, 0.2);
+  --brand-shadow: rgba(0, 168, 89, 0.25);
+  --brand-bg: #f4fbf7;
+  --brand-name: 'NH농협은행';
+  --shadow-primary: 0px 8px 20px -4px var(--brand-shadow);
+}
+[data-brand='shinhan'] {
+  --brand-primary: #0046ff;
+  --brand-alt: #4d7fff;
+  --brand-fg: #ffffff;
+  --brand-text: #0033cc;
+  --brand-dark: #0038cc;
+  --brand-darker: #002b99;
+  --brand-5: rgba(0, 70, 255, 0.05);
+  --brand-10: rgba(0, 70, 255, 0.1);
+  --brand-20: rgba(0, 70, 255, 0.2);
+  --brand-shadow: rgba(0, 70, 255, 0.25);
+  --brand-bg: #f4f6ff;
+  --brand-name: '신한은행';
+  --shadow-primary: 0px 8px 20px -4px var(--brand-shadow);
+}
+[data-brand='woori'] {
+  --brand-primary: #0067ac;
+  --brand-alt: #3395d4;
+  --brand-fg: #ffffff;
+  --brand-text: #005490;
+  --brand-dark: #005490;
+  --brand-darker: #00416e;
+  --brand-5: rgba(0, 103, 172, 0.05);
+  --brand-10: rgba(0, 103, 172, 0.1);
+  --brand-20: rgba(0, 103, 172, 0.2);
+  --brand-shadow: rgba(0, 103, 172, 0.25);
+  --brand-bg: #f4f8fc;
+  --brand-name: '우리은행';
+  --shadow-primary: 0px 8px 20px -4px var(--brand-shadow);
+}
+[data-brand] {
+  --color-brand: var(--brand-primary);
+  --color-brand-alt: var(--brand-alt);
+  --color-brand-fg: var(--brand-fg);
+  --color-brand-text: var(--brand-text);
+  --color-brand-dark: var(--brand-dark);
+  --color-brand-darker: var(--brand-darker);
+  --color-brand-5: var(--brand-5);
+  --color-brand-10: var(--brand-10);
+  --color-brand-20: var(--brand-20);
+  --color-brand-shadow: var(--brand-shadow);
+}
+:root, :host {
+  --color-brand: var(--brand-primary);
+  --color-brand-alt: var(--brand-alt);
+  --color-brand-fg: var(--brand-fg);
+  --color-brand-text: var(--brand-text);
+  --color-brand-dark: var(--brand-dark);
+  --color-brand-darker: var(--brand-darker);
+  --color-brand-5: var(--brand-5);
+  --color-brand-10: var(--brand-10);
+  --color-brand-20: var(--brand-20);
+  --color-brand-shadow: var(--brand-shadow);
+  --color-primary: #2563eb;
+  --color-primary-surface: #eff6ff;
+  --color-primary-border: #bfdbfe;
+  --color-primary-text: #1e40af;
+  --color-primary-dark: #1d4ed8;
+  --color-surface: #ffffff;
+  --color-surface-subtle: #f8fafc;
+  --color-surface-page: var(--brand-bg, var(--domain-page-bg, #f5f8f8));
+  --color-surface-raised: #f1f5f9;
+  --color-border: #e2e8f0;
+  --color-border-subtle: #f1f5f9;
+  --color-border-focus: var(--brand-primary);
+  --color-text-heading: #0f172a;
+  --color-text-base: #1e293b;
+  --color-text-label: #334155;
+  --color-text-secondary: #475569;
+  --color-text-muted: #64748b;
+  --color-text-placeholder: #94a3b8;
+  --color-text-disabled: #cbd5e1;
+  --color-danger: #e11d48;
+  --color-danger-dark: #c01742;
+  --color-danger-darker: #a8103a;
+  --color-danger-surface: #fff1f2;
+  --color-danger-border: #fda4af;
+  --color-danger-text: #be123c;
+  --color-danger-badge: #ef4444;
+  --color-success: #16a34a;
+  --color-success-surface: #f0fdf4;
+  --color-success-border: #86efac;
+  --color-success-text: #15803d;
+  --color-warning: #d97706;
+  --color-warning-surface: #fffbeb;
+  --color-warning-border: #fcd34d;
+  --color-warning-text: #b45309;
+  --color-info-surface: #eff6ff;
+  --font-sans: 'Noto Sans KR', system-ui, sans-serif;
+  --font-numeric: 'Manrope', 'Noto Sans KR', system-ui, sans-serif;
+  --font-icon: 'Material Symbols Outlined';
+  --text-xs: 12px;
+  --text-xs--line-height: 16px;
+  --text-xs--letter-spacing: 0px;
+  --text-sm: 14px;
+  --text-sm--line-height: 20px;
+  --text-sm--letter-spacing: 0px;
+  --text-base: 16px;
+  --text-base--line-height: 24px;
+  --text-base--letter-spacing: 0px;
+  --text-lg: 18px;
+  --text-lg--line-height: 28px;
+  --text-lg--letter-spacing: -0.45px;
+  --text-xl: 20px;
+  --text-xl--line-height: 28px;
+  --text-xl--letter-spacing: -0.5px;
+  --text-2xl: 24px;
+  --text-2xl--line-height: 32px;
+  --text-2xl--letter-spacing: -0.3px;
+  --text-3xl: 30px;
+  --text-3xl--line-height: 40px;
+  --text-3xl--letter-spacing: -0.75px;
+  --text-4xl: 36px;
+  --text-4xl--line-height: 44px;
+  --text-4xl--letter-spacing: -0.9px;
+  --spacing-px: 1px;
+  --spacing-0: 0px;
+  --spacing-xs: 4px;
+  --spacing-sm: 8px;
+  --spacing-md: 12px;
+  --spacing-standard: 16px;
+  --spacing-lg: 20px;
+  --spacing-xl: 24px;
+  --spacing-2xl: 32px;
+  --spacing-3xl: 40px;
+  --spacing-4xl: 48px;
+  --spacing-nav: 80px;
+  --radius-none: 0px;
+  --radius-xs: 4px;
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 24px;
+  --radius-full: 9999px;
+  --shadow-xs: 0px 1px 2px 0px rgba(0, 0, 0, 0.05);
+  --shadow-sm: 0px 1px 3px 0px rgba(0, 0, 0, 0.1), 0px 1px 2px -1px rgba(0, 0, 0, 0.1);
+  --shadow-md: 0px 4px 6px -1px rgba(0, 0, 0, 0.1), 0px 2px 4px -2px rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0px 10px 15px -3px rgba(0, 0, 0, 0.1), 0px 4px 6px -4px rgba(0, 0, 0, 0.1);
+  --shadow-xl: 0px 20px 25px -5px rgba(0, 0, 0, 0.1), 0px 8px 10px -6px rgba(0, 0, 0, 0.1);
+  --shadow-2xl: 0px 25px 50px -12px rgba(0, 0, 0, 0.25);
+  --transition-fast: 150ms ease-in-out;
+  --transition-base: 200ms ease-in-out;
+  --transition-slow: 300ms ease-in-out;
+  --transition-spring: 400ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  --breakpoint-sm: 640px;
+  --breakpoint-md: 768px;
+  --breakpoint-lg: 1024px;
+  --breakpoint-xl: 1280px;
+  --breakpoint-2xl: 1536px;
+  --breakpoint-mobile: 390px;
+  --breakpoint-tablet: 768px;
+  --breakpoint-desktop: 1280px;
+  --nav-top-height: 56px;
+  --nav-bottom-height: 60px;
+  --z-base: 0;
+  --z-raised: 1;
+  --z-overlay: 10;
+  --z-sticky: 20;
+  --z-modal: 50;
+  --z-toast: 100;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+      "Courier New", monospace;
+  --color-red-500: oklch(63.7% 0.237 25.331);
+  --color-black: #000;
+  --color-white: #fff;
+  --spacing: 0.25rem;
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-bold: 700;
+  --tracking-tight: -0.025em;
+  --tracking-wide: 0.025em;
+  --tracking-wider: 0.05em;
+  --tracking-widest: 0.1em;
+  --leading-tight: 1.25;
+  --leading-snug: 1.375;
+  --leading-relaxed: 1.625;
+  --radius-2xl: 1rem;
+  --radius-3xl: 1.5rem;
+  --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+  --animate-spin: spin 1s linear infinite;
+  --animate-pulse: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  --blur-sm: 8px;
+  --default-transition-duration: 150ms;
+  --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  --default-font-family: var(--font-sans);
+  --default-mono-font-family: var(--font-mono);
+}
+@layer base {
+  *, *::before, *::after {
+    box-sizing: border-box;
+    border-color: var(--color-border);
+  }
+  :root, [data-domain], [data-brand] {
+    transition: background-color var(--transition-base), color var(--transition-base);
+  }
+  html {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+  }
+  body {
+    margin: 0;
+    font-family: var(--font-sans);
+    background-color: var(--color-surface);
+    color: var(--color-text-base);
+    font-size: var(--text-base);
+    line-height: var(--text-base--line-height);
+  }
+  :focus-visible {
+    outline: 2px solid var(--brand-primary);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
+  }
+  ::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: var(--color-border);
+    border-radius: var(--radius-full);
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background: var(--color-text-placeholder);
+  }
+}
+@layer theme, base, components, utilities;
+@layer theme;
+@layer base {
+  *, ::after, ::before, ::backdrop, ::file-selector-button {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    border: 0 solid;
+  }
+  html, :host {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji");
+    font-feature-settings: var(--default-font-feature-settings, normal);
+    font-variation-settings: var(--default-font-variation-settings, normal);
+    -webkit-tap-highlight-color: transparent;
+  }
+  hr {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+  abbr:where([title]) {
+    -webkit-text-decoration: underline dotted;
+    text-decoration: underline dotted;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+  a {
+    color: inherit;
+    -webkit-text-decoration: inherit;
+    text-decoration: inherit;
+  }
+  b, strong {
+    font-weight: bolder;
+  }
+  code, kbd, samp, pre {
+    font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
+    font-feature-settings: var(--default-mono-font-feature-settings, normal);
+    font-variation-settings: var(--default-mono-font-variation-settings, normal);
+    font-size: 1em;
+  }
+  small {
+    font-size: 80%;
+  }
+  sub, sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+  sub {
+    bottom: -0.25em;
+  }
+  sup {
+    top: -0.5em;
+  }
+  table {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+  :-moz-focusring {
+    outline: auto;
+  }
+  progress {
+    vertical-align: baseline;
+  }
+  summary {
+    display: list-item;
+  }
+  ol, ul, menu {
+    list-style: none;
+  }
+  img, svg, video, canvas, audio, iframe, embed, object {
+    display: block;
+    vertical-align: middle;
+  }
+  img, video {
+    max-width: 100%;
+    height: auto;
+  }
+  button, input, select, optgroup, textarea, ::file-selector-button {
+    font: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    border-radius: 0;
+    background-color: transparent;
+    opacity: 1;
+  }
+  :where(select:is([multiple], [size])) optgroup {
+    font-weight: bolder;
+  }
+  :where(select:is([multiple], [size])) optgroup option {
+    padding-inline-start: 20px;
+  }
+  ::file-selector-button {
+    margin-inline-end: 4px;
+  }
+  ::placeholder {
+    opacity: 1;
+  }
+  @supports (not (-webkit-appearance: -apple-pay-button))  or (contain-intrinsic-size: 1px) {
+    ::placeholder {
+      color: currentcolor;
+      @supports (color: color-mix(in lab, red, red)) {
+        color: color-mix(in oklab, currentcolor 50%, transparent);
+      }
+    }
+  }
+  textarea {
+    resize: vertical;
+  }
+  ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+  ::-webkit-date-and-time-value {
+    min-height: 1lh;
+    text-align: inherit;
+  }
+  ::-webkit-datetime-edit {
+    display: inline-flex;
+  }
+  ::-webkit-datetime-edit-fields-wrapper {
+    padding: 0;
+  }
+  ::-webkit-datetime-edit, ::-webkit-datetime-edit-year-field, ::-webkit-datetime-edit-month-field, ::-webkit-datetime-edit-day-field, ::-webkit-datetime-edit-hour-field, ::-webkit-datetime-edit-minute-field, ::-webkit-datetime-edit-second-field, ::-webkit-datetime-edit-millisecond-field, ::-webkit-datetime-edit-meridiem-field {
+    padding-block: 0;
+  }
+  ::-webkit-calendar-picker-indicator {
+    line-height: 1;
+  }
+  :-moz-ui-invalid {
+    box-shadow: none;
+  }
+  button, input:where([type="button"], [type="reset"], [type="submit"]), ::file-selector-button {
+    appearance: button;
+  }
+  ::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
+    height: auto;
+  }
+  [hidden]:where(:not([hidden="until-found"])) {
+    display: none !important;
+  }
+}
+@layer utilities {
+  .pointer-events-none {
+    pointer-events: none;
+  }
+  .invisible {
+    visibility: hidden;
+  }
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border-width: 0;
+  }
+  .absolute {
+    position: absolute;
+  }
+  .fixed {
+    position: fixed;
+  }
+  .relative {
+    position: relative;
+  }
+  .sticky {
+    position: sticky;
+  }
+  .inset-0 {
+    inset: var(--spacing-0);
+  }
+  .inset-x-0 {
+    inset-inline: var(--spacing-0);
+  }
+  .start {
+    inset-inline-start: var(--spacing);
+  }
+  .end {
+    inset-inline-end: var(--spacing);
+  }
+  .-top-1 {
+    top: calc(var(--spacing) * -1);
+  }
+  .top-0 {
+    top: var(--spacing-0);
+  }
+  .top-1 {
+    top: calc(var(--spacing) * 1);
+  }
+  .top-1\.5 {
+    top: calc(var(--spacing) * 1.5);
+  }
+  .top-1\/4 {
+    top: calc(1 / 4 * 100%);
+  }
+  .top-14 {
+    top: calc(var(--spacing) * 14);
+  }
+  .top-\[-40px\] {
+    top: -40px;
+  }
+  .top-full {
+    top: 100%;
+  }
+  .top-sm {
+    top: var(--spacing-sm);
+  }
+  .-right-1 {
+    right: calc(var(--spacing) * -1);
+  }
+  .right-0 {
+    right: var(--spacing-0);
+  }
+  .right-1 {
+    right: calc(var(--spacing) * 1);
+  }
+  .right-1\.5 {
+    right: calc(var(--spacing) * 1.5);
+  }
+  .right-\[-40px\] {
+    right: -40px;
+  }
+  .right-sm {
+    right: var(--spacing-sm);
+  }
+  .right-xl {
+    right: var(--spacing-xl);
+  }
+  .-bottom-1 {
+    bottom: calc(var(--spacing) * -1);
+  }
+  .bottom-0 {
+    bottom: var(--spacing-0);
+  }
+  .bottom-1\/4 {
+    bottom: calc(1 / 4 * 100%);
+  }
+  .bottom-\[-1px\] {
+    bottom: -1px;
+  }
+  .left-0 {
+    left: var(--spacing-0);
+  }
+  .left-1\/2 {
+    left: calc(1 / 2 * 100%);
+  }
+  .z-10 {
+    z-index: 10;
+  }
+  .z-50 {
+    z-index: 50;
+  }
+  .z-\[10\] {
+    z-index: 10;
+  }
+  .container {
+    width: 100%;
+    @media (width >= 390px) {
+      max-width: 390px;
+    }
+    @media (width >= 640px) {
+      max-width: 640px;
+    }
+    @media (width >= 768px) {
+      max-width: 768px;
+    }
+    @media (width >= 768px) {
+      max-width: 768px;
+    }
+    @media (width >= 1024px) {
+      max-width: 1024px;
+    }
+    @media (width >= 1280px) {
+      max-width: 1280px;
+    }
+    @media (width >= 1280px) {
+      max-width: 1280px;
+    }
+    @media (width >= 1536px) {
+      max-width: 1536px;
+    }
+  }
+  .-m-xs {
+    margin: calc(var(--spacing-xs) * -1);
+  }
+  .-mx-standard {
+    margin-inline: calc(var(--spacing-standard) * -1);
+  }
+  .-mx-xs {
+    margin-inline: calc(var(--spacing-xs) * -1);
+  }
+  .mx-4 {
+    margin-inline: calc(var(--spacing) * 4);
+  }
+  .mx-auto {
+    margin-inline: auto;
+  }
+  .mx-lg {
+    margin-inline: var(--spacing-lg);
+  }
+  .mx-standard {
+    margin-inline: var(--spacing-standard);
+  }
+  .my-0 {
+    margin-block: var(--spacing-0);
+  }
+  .my-md {
+    margin-block: var(--spacing-md);
+  }
+  .my-xl {
+    margin-block: var(--spacing-xl);
+  }
+  .mt-0\.5 {
+    margin-top: calc(var(--spacing) * 0.5);
+  }
+  .mt-1 {
+    margin-top: calc(var(--spacing) * 1);
+  }
+  .mt-2 {
+    margin-top: calc(var(--spacing) * 2);
+  }
+  .mt-\[20px\] {
+    margin-top: 20px;
+  }
+  .mt-auto {
+    margin-top: auto;
+  }
+  .mt-lg {
+    margin-top: var(--spacing-lg);
+  }
+  .mt-md {
+    margin-top: var(--spacing-md);
+  }
+  .mt-px {
+    margin-top: 1px;
+  }
+  .mt-px {
+    margin-top: var(--spacing-px);
+  }
+  .mt-sm {
+    margin-top: var(--spacing-sm);
+  }
+  .mt-xs {
+    margin-top: var(--spacing-xs);
+  }
+  .-mr-xs {
+    margin-right: calc(var(--spacing-xs) * -1);
+  }
+  .mb-2xl {
+    margin-bottom: var(--spacing-2xl);
+  }
+  .mb-lg {
+    margin-bottom: var(--spacing-lg);
+  }
+  .mb-md {
+    margin-bottom: var(--spacing-md);
+  }
+  .mb-sm {
+    margin-bottom: var(--spacing-sm);
+  }
+  .mb-xl {
+    margin-bottom: var(--spacing-xl);
+  }
+  .mb-xs {
+    margin-bottom: var(--spacing-xs);
+  }
+  .-ml-sm {
+    margin-left: calc(var(--spacing-sm) * -1);
+  }
+  .ml-auto {
+    margin-left: auto;
+  }
+  .ml-md {
+    margin-left: var(--spacing-md);
+  }
+  .flex {
+    display: flex;
+  }
+  .grid {
+    display: grid;
+  }
+  .hidden {
+    display: none;
+  }
+  .inline {
+    display: inline;
+  }
+  .inline-block {
+    display: inline-block;
+  }
+  .inline-flex {
+    display: inline-flex;
+  }
+  .aspect-\[16\/10\] {
+    aspect-ratio: 16/10;
+  }
+  .aspect-square {
+    aspect-ratio: 1 / 1;
+  }
+  .size-1 {
+    width: calc(var(--spacing) * 1);
+    height: calc(var(--spacing) * 1);
+  }
+  .size-2 {
+    width: calc(var(--spacing) * 2);
+    height: calc(var(--spacing) * 2);
+  }
+  .size-2\.5 {
+    width: calc(var(--spacing) * 2.5);
+    height: calc(var(--spacing) * 2.5);
+  }
+  .size-3 {
+    width: calc(var(--spacing) * 3);
+    height: calc(var(--spacing) * 3);
+  }
+  .size-3\.5 {
+    width: calc(var(--spacing) * 3.5);
+    height: calc(var(--spacing) * 3.5);
+  }
+  .size-4 {
+    width: calc(var(--spacing) * 4);
+    height: calc(var(--spacing) * 4);
+  }
+  .size-5 {
+    width: calc(var(--spacing) * 5);
+    height: calc(var(--spacing) * 5);
+  }
+  .size-6 {
+    width: calc(var(--spacing) * 6);
+    height: calc(var(--spacing) * 6);
+  }
+  .size-7 {
+    width: calc(var(--spacing) * 7);
+    height: calc(var(--spacing) * 7);
+  }
+  .size-8 {
+    width: calc(var(--spacing) * 8);
+    height: calc(var(--spacing) * 8);
+  }
+  .size-9 {
+    width: calc(var(--spacing) * 9);
+    height: calc(var(--spacing) * 9);
+  }
+  .size-10 {
+    width: calc(var(--spacing) * 10);
+    height: calc(var(--spacing) * 10);
+  }
+  .size-12 {
+    width: calc(var(--spacing) * 12);
+    height: calc(var(--spacing) * 12);
+  }
+  .size-14 {
+    width: calc(var(--spacing) * 14);
+    height: calc(var(--spacing) * 14);
+  }
+  .size-16 {
+    width: calc(var(--spacing) * 16);
+    height: calc(var(--spacing) * 16);
+  }
+  .size-24 {
+    width: calc(var(--spacing) * 24);
+    height: calc(var(--spacing) * 24);
+  }
+  .size-\[18px\] {
+    width: 18px;
+    height: 18px;
+  }
+  .size-\[160px\] {
+    width: 160px;
+    height: 160px;
+  }
+  .h-0\.5 {
+    height: calc(var(--spacing) * 0.5);
+  }
+  .h-1 {
+    height: calc(var(--spacing) * 1);
+  }
+  .h-2 {
+    height: calc(var(--spacing) * 2);
+  }
+  .h-3 {
+    height: calc(var(--spacing) * 3);
+  }
+  .h-4 {
+    height: calc(var(--spacing) * 4);
+  }
+  .h-5 {
+    height: calc(var(--spacing) * 5);
+  }
+  .h-6 {
+    height: calc(var(--spacing) * 6);
+  }
+  .h-8 {
+    height: calc(var(--spacing) * 8);
+  }
+  .h-10 {
+    height: calc(var(--spacing) * 10);
+  }
+  .h-12 {
+    height: calc(var(--spacing) * 12);
+  }
+  .h-14 {
+    height: calc(var(--spacing) * 14);
+  }
+  .h-\[18px\] {
+    height: 18px;
+  }
+  .h-auto {
+    height: auto;
+  }
+  .h-dvh {
+    height: 100dvh;
+  }
+  .h-full {
+    height: 100%;
+  }
+  .h-px {
+    height: 1px;
+  }
+  .h-px {
+    height: var(--spacing-px);
+  }
+  .max-h-\[50dvh\] {
+    max-height: 50dvh;
+  }
+  .max-h-\[90dvh\] {
+    max-height: 90dvh;
+  }
+  .max-h-none {
+    max-height: none;
+  }
+  .min-h-0 {
+    min-height: var(--spacing-0);
+  }
+  .min-h-\[500px\] {
+    min-height: 500px;
+  }
+  .min-h-dvh {
+    min-height: 100dvh;
+  }
+  .w-1 {
+    width: calc(var(--spacing) * 1);
+  }
+  .w-1\/2 {
+    width: calc(1 / 2 * 100%);
+  }
+  .w-1\/3 {
+    width: calc(1 / 3 * 100%);
+  }
+  .w-1\/4 {
+    width: calc(1 / 4 * 100%);
+  }
+  .w-2 {
+    width: calc(var(--spacing) * 2);
+  }
+  .w-2\/5 {
+    width: calc(2 / 5 * 100%);
+  }
+  .w-4 {
+    width: calc(var(--spacing) * 4);
+  }
+  .w-10 {
+    width: calc(var(--spacing) * 10);
+  }
+  .w-12 {
+    width: calc(var(--spacing) * 12);
+  }
+  .w-16 {
+    width: calc(var(--spacing) * 16);
+  }
+  .w-20 {
+    width: calc(var(--spacing) * 20);
+  }
+  .w-24 {
+    width: calc(var(--spacing) * 24);
+  }
+  .w-28 {
+    width: calc(var(--spacing) * 28);
+  }
+  .w-36 {
+    width: calc(var(--spacing) * 36);
+  }
+  .w-40 {
+    width: calc(var(--spacing) * 40);
+  }
+  .w-48 {
+    width: calc(var(--spacing) * 48);
+  }
+  .w-72 {
+    width: calc(var(--spacing) * 72);
+  }
+  .w-\[117px\] {
+    width: 117px;
+  }
+  .w-full {
+    width: 100%;
+  }
+  .w-max {
+    width: max-content;
+  }
+  .w-px {
+    width: 1px;
+  }
+  .w-px {
+    width: var(--spacing-px);
+  }
+  .max-w-\[2\.75rem\] {
+    max-width: 2.75rem;
+  }
+  .max-w-\[260px\] {
+    max-width: 260px;
+  }
+  .max-w-\[320px\] {
+    max-width: 320px;
+  }
+  .max-w-\[360px\] {
+    max-width: 360px;
+  }
+  .max-w-\[390px\] {
+    max-width: 390px;
+  }
+  .max-w-none {
+    max-width: none;
+  }
+  .min-w-0 {
+    min-width: var(--spacing-0);
+  }
+  .min-w-35 {
+    min-width: calc(var(--spacing) * 35);
+  }
+  .min-w-\[18px\] {
+    min-width: 18px;
+  }
+  .min-w-\[50px\] {
+    min-width: 50px;
+  }
+  .min-w-\[80px\] {
+    min-width: 80px;
+  }
+  .min-w-max {
+    min-width: max-content;
+  }
+  .flex-1 {
+    flex: 1;
+  }
+  .shrink-0 {
+    flex-shrink: 0;
+  }
+  .-translate-x-1\/2 {
+    --tw-translate-x: calc(calc(1 / 2 * 100%) * -1);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+  .translate-x-0 {
+    --tw-translate-x: var(--spacing-0);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+  .translate-x-6 {
+    --tw-translate-x: calc(var(--spacing) * 6);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+  .rotate-180 {
+    rotate: 180deg;
+  }
+  .animate-pulse {
+    animation: var(--animate-pulse);
+  }
+  .animate-spin {
+    animation: var(--animate-spin);
+  }
+  .cursor-default {
+    cursor: default;
+  }
+  .cursor-grab {
+    cursor: grab;
+  }
+  .cursor-not-allowed {
+    cursor: not-allowed;
+  }
+  .cursor-pointer {
+    cursor: pointer;
+  }
+  .grid-cols-1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+  .grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .grid-cols-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+  .grid-cols-7 {
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+  }
+  .flex-col {
+    flex-direction: column;
+  }
+  .flex-wrap {
+    flex-wrap: wrap;
+  }
+  .items-baseline {
+    align-items: baseline;
+  }
+  .items-center {
+    align-items: center;
+  }
+  .items-end {
+    align-items: flex-end;
+  }
+  .items-start {
+    align-items: flex-start;
+  }
+  .items-stretch {
+    align-items: stretch;
+  }
+  .justify-around {
+    justify-content: space-around;
+  }
+  .justify-between {
+    justify-content: space-between;
+  }
+  .justify-center {
+    justify-content: center;
+  }
+  .justify-end {
+    justify-content: flex-end;
+  }
+  .justify-evenly {
+    justify-content: space-evenly;
+  }
+  .justify-start {
+    justify-content: flex-start;
+  }
+  .gap-0\.5 {
+    gap: calc(var(--spacing) * 0.5);
+  }
+  .gap-1 {
+    gap: calc(var(--spacing) * 1);
+  }
+  .gap-2xl {
+    gap: var(--spacing-2xl);
+  }
+  .gap-5 {
+    gap: calc(var(--spacing) * 5);
+  }
+  .gap-\[2px\] {
+    gap: 2px;
+  }
+  .gap-lg {
+    gap: var(--spacing-lg);
+  }
+  .gap-md {
+    gap: var(--spacing-md);
+  }
+  .gap-sm {
+    gap: var(--spacing-sm);
+  }
+  .gap-standard {
+    gap: var(--spacing-standard);
+  }
+  .gap-xl {
+    gap: var(--spacing-xl);
+  }
+  .gap-xs {
+    gap: var(--spacing-xs);
+  }
+  .divide-y {
+    :where(& > :not(:last-child)) {
+      --tw-divide-y-reverse: 0;
+      border-bottom-style: var(--tw-border-style);
+      border-top-style: var(--tw-border-style);
+      border-top-width: calc(1px * var(--tw-divide-y-reverse));
+      border-bottom-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
+    }
+  }
+  .divide-border-subtle {
+    :where(& > :not(:last-child)) {
+      border-color: var(--color-border-subtle);
+    }
+  }
+  .self-center {
+    align-self: center;
+  }
+  .truncate {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .overflow-auto {
+    overflow: auto;
+  }
+  .overflow-hidden {
+    overflow: hidden;
+  }
+  .overflow-x-auto {
+    overflow-x: auto;
+  }
+  .overflow-x-hidden {
+    overflow-x: hidden;
+  }
+  .overflow-y-auto {
+    overflow-y: auto;
+  }
+  .card {
+    background-color: var(--color-surface);
+    border-radius: var(--radius-xl);
+    border: 1px solid var(--color-border-subtle);
+    box-shadow: var(--shadow-xs);
+    padding: var(--spacing-lg);
+  }
+  .rounded {
+    border-radius: 0.25rem;
+  }
+  .rounded-2xl {
+    border-radius: var(--radius-2xl);
+  }
+  .rounded-3xl {
+    border-radius: var(--radius-3xl);
+  }
+  .rounded-\[6px\] {
+    border-radius: 6px;
+  }
+  .rounded-\[inherit\] {
+    border-radius: inherit;
+  }
+  .rounded-full {
+    border-radius: var(--radius-full);
+  }
+  .rounded-lg {
+    border-radius: var(--radius-lg);
+  }
+  .rounded-md {
+    border-radius: var(--radius-md);
+  }
+  .rounded-none {
+    border-radius: var(--radius-none);
+  }
+  .rounded-sm {
+    border-radius: var(--radius-sm);
+  }
+  .rounded-xl {
+    border-radius: var(--radius-xl);
+  }
+  .rounded-xs {
+    border-radius: var(--radius-xs);
+  }
+  .rounded-t-2xl {
+    border-top-left-radius: var(--radius-2xl);
+    border-top-right-radius: var(--radius-2xl);
+  }
+  .rounded-t-md {
+    border-top-left-radius: var(--radius-md);
+    border-top-right-radius: var(--radius-md);
+  }
+  .rounded-r {
+    border-top-right-radius: 0.25rem;
+    border-bottom-right-radius: 0.25rem;
+  }
+  .rounded-b-md {
+    border-bottom-right-radius: var(--radius-md);
+    border-bottom-left-radius: var(--radius-md);
+  }
+  .border {
+    border-style: var(--tw-border-style);
+    border-width: 1px;
+  }
+  .border-0 {
+    border-style: var(--tw-border-style);
+    border-width: 0px;
+  }
+  .border-2 {
+    border-style: var(--tw-border-style);
+    border-width: 2px;
+  }
+  .border-x {
+    border-inline-style: var(--tw-border-style);
+    border-inline-width: 1px;
+  }
+  .border-t {
+    border-top-style: var(--tw-border-style);
+    border-top-width: 1px;
+  }
+  .border-r {
+    border-right-style: var(--tw-border-style);
+    border-right-width: 1px;
+  }
+  .border-b {
+    border-bottom-style: var(--tw-border-style);
+    border-bottom-width: 1px;
+  }
+  .border-l {
+    border-left-style: var(--tw-border-style);
+    border-left-width: 1px;
+  }
+  .border-l-4 {
+    border-left-style: var(--tw-border-style);
+    border-left-width: 4px;
+  }
+  .border-dashed {
+    --tw-border-style: dashed;
+    border-style: dashed;
+  }
+  .border-none {
+    --tw-border-style: none;
+    border-style: none;
+  }
+  .border-border {
+    border-color: var(--color-border);
+  }
+  .border-border-subtle {
+    border-color: var(--color-border-subtle);
+  }
+  .border-brand {
+    border-color: var(--color-brand);
+  }
+  .border-brand-10 {
+    border-color: var(--color-brand-10);
+  }
+  .border-brand-20 {
+    border-color: var(--color-brand-20);
+  }
+  .border-brand-text {
+    border-color: var(--color-brand-text);
+  }
+  .border-brand\/20 {
+    border-color: var(--color-brand);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-brand) 20%, transparent);
+    }
+  }
+  .border-danger {
+    border-color: var(--color-danger);
+  }
+  .border-danger-border {
+    border-color: var(--color-danger-border);
+  }
+  .border-primary-border {
+    border-color: var(--color-primary-border);
+  }
+  .border-success {
+    border-color: var(--color-success);
+  }
+  .border-success-border {
+    border-color: var(--color-success-border);
+  }
+  .border-surface {
+    border-color: var(--color-surface);
+  }
+  .border-surface-subtle {
+    border-color: var(--color-surface-subtle);
+  }
+  .border-transparent {
+    border-color: transparent;
+  }
+  .border-warning-border {
+    border-color: var(--color-warning-border);
+  }
+  .border-white {
+    border-color: var(--color-white);
+  }
+  .border-l-\[var\(--domain-card-accent\)\] {
+    border-left-color: var(--domain-card-accent);
+  }
+  .bg-\[\#60a5fa\] {
+    background-color: #60a5fa;
+  }
+  .bg-\[\#dbeafe\] {
+    background-color: #dbeafe;
+  }
+  .bg-\[\#dcfce7\] {
+    background-color: #dcfce7;
+  }
+  .bg-\[\#ecfdf5\] {
+    background-color: #ecfdf5;
+  }
+  .bg-\[\#eff6ff\] {
+    background-color: #eff6ff;
+  }
+  .bg-\[\#f5f8f8\] {
+    background-color: #f5f8f8;
+  }
+  .bg-\[\#f472b6\] {
+    background-color: #f472b6;
+  }
+  .bg-\[\#facc15\] {
+    background-color: #facc15;
+  }
+  .bg-\[\#fee500\] {
+    background-color: #fee500;
+  }
+  .bg-\[\#fef9c3\] {
+    background-color: #fef9c3;
+  }
+  .bg-\[\#fff7ed\] {
+    background-color: #fff7ed;
+  }
+  .bg-\[var\(--domain-card-accent\)\] {
+    background-color: var(--domain-card-accent);
+  }
+  .bg-black\/40 {
+    background-color: color-mix(in srgb, #000 40%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-black) 40%, transparent);
+    }
+  }
+  .bg-black\/50 {
+    background-color: color-mix(in srgb, #000 50%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-black) 50%, transparent);
+    }
+  }
+  .bg-border {
+    background-color: var(--color-border);
+  }
+  .bg-border-subtle {
+    background-color: var(--color-border-subtle);
+  }
+  .bg-brand {
+    background-color: var(--color-brand);
+  }
+  .bg-brand-5 {
+    background-color: var(--color-brand-5);
+  }
+  .bg-brand-10 {
+    background-color: var(--color-brand-10);
+  }
+  .bg-brand-text {
+    background-color: var(--color-brand-text);
+  }
+  .bg-danger {
+    background-color: var(--color-danger);
+  }
+  .bg-danger-badge {
+    background-color: var(--color-danger-badge);
+  }
+  .bg-danger-surface {
+    background-color: var(--color-danger-surface);
+  }
+  .bg-info-surface {
+    background-color: var(--color-info-surface);
+  }
+  .bg-inherit {
+    background-color: inherit;
+  }
+  .bg-primary-surface {
+    background-color: var(--color-primary-surface);
+  }
+  .bg-success-surface {
+    background-color: var(--color-success-surface);
+  }
+  .bg-surface {
+    background-color: var(--color-surface);
+  }
+  .bg-surface-raised {
+    background-color: var(--color-surface-raised);
+  }
+  .bg-surface-subtle {
+    background-color: var(--color-surface-subtle);
+  }
+  .bg-surface\/80 {
+    background-color: color-mix(in srgb, #ffffff 80%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-surface) 80%, transparent);
+    }
+  }
+  .bg-surface\/95 {
+    background-color: color-mix(in srgb, #ffffff 95%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-surface) 95%, transparent);
+    }
+  }
+  .bg-transparent {
+    background-color: transparent;
+  }
+  .bg-warning-surface {
+    background-color: var(--color-warning-surface);
+  }
+  .bg-white {
+    background-color: var(--color-white);
+  }
+  .bg-white\/10 {
+    background-color: color-mix(in srgb, #fff 10%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 10%, transparent);
+    }
+  }
+  .bg-white\/20 {
+    background-color: color-mix(in srgb, #fff 20%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 20%, transparent);
+    }
+  }
+  .bg-white\/80 {
+    background-color: color-mix(in srgb, #fff 80%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 80%, transparent);
+    }
+  }
+  .bg-linear-to-br {
+    --tw-gradient-position: to bottom right;
+    @supports (background-image: linear-gradient(in lab, red, red)) {
+      --tw-gradient-position: to bottom right in oklab;
+    }
+    background-image: linear-gradient(var(--tw-gradient-stops));
+  }
+  .bg-gradient-to-r {
+    --tw-gradient-position: to right in oklab;
+    background-image: linear-gradient(var(--tw-gradient-stops));
+  }
+  .from-brand {
+    --tw-gradient-from: var(--color-brand);
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .to-brand-alt {
+    --tw-gradient-to: var(--color-brand-alt);
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .to-brand-dark {
+    --tw-gradient-to: var(--color-brand-dark);
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .p-0 {
+    padding: var(--spacing-0);
+  }
+  .p-1 {
+    padding: calc(var(--spacing) * 1);
+  }
+  .p-2xl {
+    padding: var(--spacing-2xl);
+  }
+  .p-\[5px\] {
+    padding: 5px;
+  }
+  .p-lg {
+    padding: var(--spacing-lg);
+  }
+  .p-md {
+    padding: var(--spacing-md);
+  }
+  .p-standard {
+    padding: var(--spacing-standard);
+  }
+  .p-xl {
+    padding: var(--spacing-xl);
+  }
+  .p-xs {
+    padding: var(--spacing-xs);
+  }
+  .px-0 {
+    padding-inline: var(--spacing-0);
+  }
+  .px-0\! {
+    padding-inline: var(--spacing-0) !important;
+  }
+  .px-14 {
+    padding-inline: calc(var(--spacing) * 14);
+  }
+  .px-\[13px\] {
+    padding-inline: 13px;
+  }
+  .px-lg {
+    padding-inline: var(--spacing-lg);
+  }
+  .px-md {
+    padding-inline: var(--spacing-md);
+  }
+  .px-sm {
+    padding-inline: var(--spacing-sm);
+  }
+  .px-standard {
+    padding-inline: var(--spacing-standard);
+  }
+  .px-xl {
+    padding-inline: var(--spacing-xl);
+  }
+  .px-xs {
+    padding-inline: var(--spacing-xs);
+  }
+  .py-0\.5 {
+    padding-block: calc(var(--spacing) * 0.5);
+  }
+  .py-1\! {
+    padding-block: calc(var(--spacing) * 1) !important;
+  }
+  .py-2xl {
+    padding-block: var(--spacing-2xl);
+  }
+  .py-3xl {
+    padding-block: var(--spacing-3xl);
+  }
+  .py-\[9px\] {
+    padding-block: 9px;
+  }
+  .py-\[10px\] {
+    padding-block: 10px;
+  }
+  .py-\[21px\] {
+    padding-block: 21px;
+  }
+  .py-lg {
+    padding-block: var(--spacing-lg);
+  }
+  .py-md {
+    padding-block: var(--spacing-md);
+  }
+  .py-sm {
+    padding-block: var(--spacing-sm);
+  }
+  .py-standard {
+    padding-block: var(--spacing-standard);
+  }
+  .py-xl {
+    padding-block: var(--spacing-xl);
+  }
+  .py-xs {
+    padding-block: var(--spacing-xs);
+  }
+  .pt-3 {
+    padding-top: calc(var(--spacing) * 3);
+  }
+  .pt-lg {
+    padding-top: var(--spacing-lg);
+  }
+  .pt-md {
+    padding-top: var(--spacing-md);
+  }
+  .pt-sm {
+    padding-top: var(--spacing-sm);
+  }
+  .pt-standard {
+    padding-top: var(--spacing-standard);
+  }
+  .pt-xl {
+    padding-top: var(--spacing-xl);
+  }
+  .pt-xs {
+    padding-top: var(--spacing-xs);
+  }
+  .pr-md {
+    padding-right: var(--spacing-md);
+  }
+  .pr-sm {
+    padding-right: var(--spacing-sm);
+  }
+  .pr-standard {
+    padding-right: var(--spacing-standard);
+  }
+  .pb-1 {
+    padding-bottom: calc(var(--spacing) * 1);
+  }
+  .pb-2 {
+    padding-bottom: calc(var(--spacing) * 2);
+  }
+  .pb-2xl {
+    padding-bottom: var(--spacing-2xl);
+  }
+  .pb-3 {
+    padding-bottom: calc(var(--spacing) * 3);
+  }
+  .pb-\[21px\] {
+    padding-bottom: 21px;
+  }
+  .pb-\[calc\(env\(safe-area-inset-bottom\,0px\)\+theme\(spacing\.xl\)\)\] {
+    padding-bottom: calc(env(safe-area-inset-bottom,0px) + 24px);
+  }
+  .pb-lg {
+    padding-bottom: var(--spacing-lg);
+  }
+  .pb-md {
+    padding-bottom: var(--spacing-md);
+  }
+  .pb-nav {
+    padding-bottom: calc(var(--nav-bottom-height) + env(safe-area-inset-bottom, 0px));
+  }
+  .pb-nav {
+    padding-bottom: var(--spacing-nav);
+  }
+  .pb-safe {
+    padding-bottom: max(var(--spacing-sm), env(safe-area-inset-bottom));
+  }
+  .pb-sm {
+    padding-bottom: var(--spacing-sm);
+  }
+  .pb-standard {
+    padding-bottom: var(--spacing-standard);
+  }
+  .pb-xl {
+    padding-bottom: var(--spacing-xl);
+  }
+  .pb-xs {
+    padding-bottom: var(--spacing-xs);
+  }
+  .pl-md {
+    padding-left: var(--spacing-md);
+  }
+  .pl-sm {
+    padding-left: var(--spacing-sm);
+  }
+  .text-center {
+    text-align: center;
+  }
+  .text-left {
+    text-align: left;
+  }
+  .text-right {
+    text-align: right;
+  }
+  .font-numeric {
+    font-family: var(--font-numeric);
+  }
+  .font-numeric {
+    font-family: var(--font-numeric);
+  }
+  .text-2xl {
+    font-size: var(--text-2xl);
+    line-height: var(--tw-leading, var(--text-2xl--line-height));
+    letter-spacing: var(--tw-tracking, var(--text-2xl--letter-spacing));
+  }
+  .text-3xl {
+    font-size: var(--text-3xl);
+    line-height: var(--tw-leading, var(--text-3xl--line-height));
+    letter-spacing: var(--tw-tracking, var(--text-3xl--letter-spacing));
+  }
+  .text-4xl {
+    font-size: var(--text-4xl);
+    line-height: var(--tw-leading, var(--text-4xl--line-height));
+    letter-spacing: var(--tw-tracking, var(--text-4xl--letter-spacing));
+  }
+  .text-base {
+    font-size: var(--text-base);
+    line-height: var(--tw-leading, var(--text-base--line-height));
+    letter-spacing: var(--tw-tracking, var(--text-base--letter-spacing));
+  }
+  .text-lg {
+    font-size: var(--text-lg);
+    line-height: var(--tw-leading, var(--text-lg--line-height));
+    letter-spacing: var(--tw-tracking, var(--text-lg--letter-spacing));
+  }
+  .text-sm {
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+    letter-spacing: var(--tw-tracking, var(--text-sm--letter-spacing));
+  }
+  .text-xl {
+    font-size: var(--text-xl);
+    line-height: var(--tw-leading, var(--text-xl--line-height));
+    letter-spacing: var(--tw-tracking, var(--text-xl--letter-spacing));
+  }
+  .text-xs {
+    font-size: var(--text-xs);
+    line-height: var(--tw-leading, var(--text-xs--line-height));
+    letter-spacing: var(--tw-tracking, var(--text-xs--letter-spacing));
+  }
+  .text-\[10px\] {
+    font-size: 10px;
+  }
+  .text-\[11px\] {
+    font-size: 11px;
+  }
+  .leading-none {
+    --tw-leading: 1;
+    line-height: 1;
+  }
+  .leading-relaxed {
+    --tw-leading: var(--leading-relaxed);
+    line-height: var(--leading-relaxed);
+  }
+  .leading-snug {
+    --tw-leading: var(--leading-snug);
+    line-height: var(--leading-snug);
+  }
+  .leading-tight {
+    --tw-leading: var(--leading-tight);
+    line-height: var(--leading-tight);
+  }
+  .font-bold {
+    --tw-font-weight: var(--font-weight-bold);
+    font-weight: var(--font-weight-bold);
+  }
+  .font-medium {
+    --tw-font-weight: var(--font-weight-medium);
+    font-weight: var(--font-weight-medium);
+  }
+  .font-normal {
+    --tw-font-weight: var(--font-weight-normal);
+    font-weight: var(--font-weight-normal);
+  }
+  .tracking-tight {
+    --tw-tracking: var(--tracking-tight);
+    letter-spacing: var(--tracking-tight);
+  }
+  .tracking-wide {
+    --tw-tracking: var(--tracking-wide);
+    letter-spacing: var(--tracking-wide);
+  }
+  .tracking-wider {
+    --tw-tracking: var(--tracking-wider);
+    letter-spacing: var(--tracking-wider);
+  }
+  .tracking-widest {
+    --tw-tracking: var(--tracking-widest);
+    letter-spacing: var(--tracking-widest);
+  }
+  .break-keep {
+    word-break: keep-all;
+  }
+  .whitespace-normal {
+    white-space: normal;
+  }
+  .whitespace-nowrap {
+    white-space: nowrap;
+  }
+  .whitespace-pre-line {
+    white-space: pre-line;
+  }
+  .whitespace-pre-wrap {
+    white-space: pre-wrap;
+  }
+  .text-\[\#1d4ed8\] {
+    color: #1d4ed8;
+  }
+  .text-\[\#1e40af\] {
+    color: #1e40af;
+  }
+  .text-\[\#3c1e1e\] {
+    color: #3c1e1e;
+  }
+  .text-\[\#333\] {
+    color: #333;
+  }
+  .text-\[\#854d0e\] {
+    color: #854d0e;
+  }
+  .text-\[\#166534\] {
+    color: #166534;
+  }
+  .text-\[\#c2410c\] {
+    color: #c2410c;
+  }
+  .text-\[var\(--domain-card-accent-text\)\] {
+    color: var(--domain-card-accent-text);
+  }
+  .text-brand {
+    color: var(--color-brand);
+  }
+  .text-brand-fg {
+    color: var(--color-brand-fg);
+  }
+  .text-brand-fg\/80 {
+    color: var(--color-brand-fg);
+    @supports (color: color-mix(in lab, red, red)) {
+      color: color-mix(in oklab, var(--color-brand-fg) 80%, transparent);
+    }
+  }
+  .text-brand-text {
+    color: var(--color-brand-text);
+  }
+  .text-danger {
+    color: var(--color-danger);
+  }
+  .text-danger-text {
+    color: var(--color-danger-text);
+  }
+  .text-primary-text {
+    color: var(--color-primary-text);
+  }
+  .text-red-500 {
+    color: var(--color-red-500);
+  }
+  .text-success-text {
+    color: var(--color-success-text);
+  }
+  .text-text-base {
+    color: var(--color-text-base);
+  }
+  .text-text-heading {
+    color: var(--color-text-heading);
+  }
+  .text-text-label {
+    color: var(--color-text-label);
+  }
+  .text-text-muted {
+    color: var(--color-text-muted);
+  }
+  .text-text-placeholder {
+    color: var(--color-text-placeholder);
+  }
+  .text-text-secondary {
+    color: var(--color-text-secondary);
+  }
+  .text-warning-text {
+    color: var(--color-warning-text);
+  }
+  .text-white {
+    color: var(--color-white);
+  }
+  .uppercase {
+    text-transform: uppercase;
+  }
+  .tabular-nums {
+    --tw-numeric-spacing: tabular-nums;
+    font-variant-numeric: var(--tw-ordinal,) var(--tw-slashed-zero,) var(--tw-numeric-figure,) var(--tw-numeric-spacing,) var(--tw-numeric-fraction,);
+  }
+  .underline {
+    text-decoration-line: underline;
+  }
+  .opacity-30 {
+    opacity: 30%;
+  }
+  .opacity-40 {
+    opacity: 40%;
+  }
+  .opacity-50 {
+    opacity: 50%;
+  }
+  .opacity-60 {
+    opacity: 60%;
+  }
+  .opacity-70 {
+    opacity: 70%;
+  }
+  .opacity-80 {
+    opacity: 80%;
+  }
+  .shadow-2xl {
+    --tw-shadow: 0px 25px 50px -12px var(--tw-shadow-color, rgba(0, 0, 0, 0.25));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-\[0px_4px_14px_-4px_rgba\(225\,29\,72\,0\.4\)\] {
+    --tw-shadow: 0px 4px 14px -4px var(--tw-shadow-color, rgba(225,29,72,0.4));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-\[0px_8px_24px_0px_var\(--color-brand-shadow\)\] {
+    --tw-shadow: 0px 8px 24px 0px var(--tw-shadow-color, var(--color-brand-shadow));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-lg {
+    --tw-shadow: 0px 10px 15px -3px var(--tw-shadow-color, rgba(0, 0, 0, 0.1)), 0px 4px 6px -4px var(--tw-shadow-color, rgba(0, 0, 0, 0.1));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-md {
+    --tw-shadow: 0px 4px 6px -1px var(--tw-shadow-color, rgba(0, 0, 0, 0.1)), 0px 2px 4px -2px var(--tw-shadow-color, rgba(0, 0, 0, 0.1));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-none {
+    --tw-shadow: 0 0 #0000;
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-sm {
+    --tw-shadow: 0px 1px 3px 0px var(--tw-shadow-color, rgba(0, 0, 0, 0.1)), 0px 1px 2px -1px var(--tw-shadow-color, rgba(0, 0, 0, 0.1));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-xs {
+    --tw-shadow: 0px 1px 2px 0px var(--tw-shadow-color, rgba(0, 0, 0, 0.05));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .ring-1 {
+    --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-brand {
+    box-shadow: var(--shadow-primary);
+  }
+  .shadow-brand {
+    --tw-shadow-color: var(--color-brand);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-shadow-color: color-mix(in oklab, var(--color-brand) var(--tw-shadow-alpha), transparent);
+    }
+  }
+  .ring-danger-border {
+    --tw-ring-color: var(--color-danger-border);
+  }
+  .outline {
+    outline-style: var(--tw-outline-style);
+    outline-width: 1px;
+  }
+  .blur {
+    --tw-blur: blur(8px);
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .blur-\[32px\] {
+    --tw-blur: blur(32px);
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .filter {
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .backdrop-blur {
+    --tw-backdrop-blur: blur(8px);
+    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+  }
+  .backdrop-blur-sm {
+    --tw-backdrop-blur: blur(var(--blur-sm));
+    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+  }
+  .transition-all {
+    transition-property: all;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .transition-colors {
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .transition-opacity {
+    transition-property: opacity;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .transition-transform {
+    transition-property: transform, translate, scale, rotate;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .duration-100 {
+    --tw-duration: 100ms;
+    transition-duration: 100ms;
+  }
+  .duration-150 {
+    --tw-duration: 150ms;
+    transition-duration: 150ms;
+  }
+  .duration-200 {
+    --tw-duration: 200ms;
+    transition-duration: 200ms;
+  }
+  .duration-500 {
+    --tw-duration: 500ms;
+    transition-duration: 500ms;
+  }
+  .ease-in-out {
+    --tw-ease: var(--ease-in-out);
+    transition-timing-function: var(--ease-in-out);
+  }
+  .outline-none {
+    --tw-outline-style: none;
+    outline-style: none;
+  }
+  .select-none {
+    -webkit-user-select: none;
+    user-select: none;
+  }
+  .group-hover\:text-brand {
+    &:is(:where(.group):hover *) {
+      @media (hover: hover) {
+        color: var(--color-brand);
+      }
+    }
+  }
+  .placeholder\:font-sans {
+    &::placeholder {
+      font-family: var(--font-sans);
+    }
+  }
+  .placeholder\:font-normal {
+    &::placeholder {
+      --tw-font-weight: var(--font-weight-normal);
+      font-weight: var(--font-weight-normal);
+    }
+  }
+  .placeholder\:text-text-placeholder {
+    &::placeholder {
+      color: var(--color-text-placeholder);
+    }
+  }
+  .last\:mb-0 {
+    &:last-child {
+      margin-bottom: var(--spacing-0);
+    }
+  }
+  .last\:border-b-0 {
+    &:last-child {
+      border-bottom-style: var(--tw-border-style);
+      border-bottom-width: 0px;
+    }
+  }
+  .focus-within\:border-brand-text {
+    &:focus-within {
+      border-color: var(--color-brand-text);
+    }
+  }
+  .hover\:border-brand {
+    &:hover {
+      @media (hover: hover) {
+        border-color: var(--color-brand);
+      }
+    }
+  }
+  .hover\:border-brand-text {
+    &:hover {
+      @media (hover: hover) {
+        border-color: var(--color-brand-text);
+      }
+    }
+  }
+  .hover\:bg-brand-5 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-brand-5);
+      }
+    }
+  }
+  .hover\:bg-brand-10 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-brand-10);
+      }
+    }
+  }
+  .hover\:bg-brand-20 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-brand-20);
+      }
+    }
+  }
+  .hover\:bg-brand-dark {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-brand-dark);
+      }
+    }
+  }
+  .hover\:bg-danger-dark {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-danger-dark);
+      }
+    }
+  }
+  .hover\:bg-surface {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-surface);
+      }
+    }
+  }
+  .hover\:bg-surface-raised {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-surface-raised);
+      }
+    }
+  }
+  .hover\:bg-surface-subtle {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-surface-subtle);
+      }
+    }
+  }
+  .hover\:text-brand-fg {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-brand-fg);
+      }
+    }
+  }
+  .hover\:text-brand-text {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-brand-text);
+      }
+    }
+  }
+  .hover\:text-text-heading {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-text-heading);
+      }
+    }
+  }
+  .hover\:underline {
+    &:hover {
+      @media (hover: hover) {
+        text-decoration-line: underline;
+      }
+    }
+  }
+  .hover\:opacity-80 {
+    &:hover {
+      @media (hover: hover) {
+        opacity: 80%;
+      }
+    }
+  }
+  .hover\:opacity-90 {
+    &:hover {
+      @media (hover: hover) {
+        opacity: 90%;
+      }
+    }
+  }
+  .hover\:opacity-100 {
+    &:hover {
+      @media (hover: hover) {
+        opacity: 100%;
+      }
+    }
+  }
+  .hover\:shadow-md {
+    &:hover {
+      @media (hover: hover) {
+        --tw-shadow: 0px 4px 6px -1px var(--tw-shadow-color, rgba(0, 0, 0, 0.1)), 0px 2px 4px -2px var(--tw-shadow-color, rgba(0, 0, 0, 0.1));
+        box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+      }
+    }
+  }
+  .hover\:shadow-sm {
+    &:hover {
+      @media (hover: hover) {
+        --tw-shadow: 0px 1px 3px 0px var(--tw-shadow-color, rgba(0, 0, 0, 0.1)), 0px 1px 2px -1px var(--tw-shadow-color, rgba(0, 0, 0, 0.1));
+        box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+      }
+    }
+  }
+  .hover\:shadow-brand {
+    &:hover {
+      @media (hover: hover) {
+        box-shadow: var(--shadow-primary);
+      }
+    }
+  }
+  .hover\:shadow-brand {
+    &:hover {
+      @media (hover: hover) {
+        --tw-shadow-color: var(--color-brand);
+        @supports (color: color-mix(in lab, red, red)) {
+          --tw-shadow-color: color-mix(in oklab, var(--color-brand) var(--tw-shadow-alpha), transparent);
+        }
+      }
+    }
+  }
+  .focus\:border-border-focus {
+    &:focus {
+      border-color: var(--color-border-focus);
+    }
+  }
+  .focus\:border-brand-text {
+    &:focus {
+      border-color: var(--color-brand-text);
+    }
+  }
+  .focus\:bg-surface {
+    &:focus {
+      background-color: var(--color-surface);
+    }
+  }
+  .focus\:ring-2 {
+    &:focus {
+      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
+  .focus\:ring-brand-10 {
+    &:focus {
+      --tw-ring-color: var(--color-brand-10);
+    }
+  }
+  .focus\:ring-danger-border {
+    &:focus {
+      --tw-ring-color: var(--color-danger-border);
+    }
+  }
+  .focus-visible\:ring-2 {
+    &:focus-visible {
+      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
+  .focus-visible\:ring-brand {
+    &:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 3px var(--color-surface), 0 0 0 5px var(--brand-primary);
+    }
+  }
+  .focus-visible\:ring-brand {
+    &:focus-visible {
+      --tw-ring-color: var(--color-brand);
+    }
+  }
+  .focus-visible\:ring-brand-20 {
+    &:focus-visible {
+      --tw-ring-color: var(--color-brand-20);
+    }
+  }
+  .focus-visible\:outline-none {
+    &:focus-visible {
+      --tw-outline-style: none;
+      outline-style: none;
+    }
+  }
+  .active\:scale-\[0\.96\] {
+    &:active {
+      scale: 0.96;
+    }
+  }
+  .active\:scale-\[0\.97\] {
+    &:active {
+      scale: 0.97;
+    }
+  }
+  .active\:scale-\[0\.98\] {
+    &:active {
+      scale: 0.98;
+    }
+  }
+  .active\:scale-\[0\.99\] {
+    &:active {
+      scale: 0.99;
+    }
+  }
+  .active\:cursor-grabbing {
+    &:active {
+      cursor: grabbing;
+    }
+  }
+  .active\:bg-brand-10 {
+    &:active {
+      background-color: var(--color-brand-10);
+    }
+  }
+  .active\:bg-brand-darker {
+    &:active {
+      background-color: var(--color-brand-darker);
+    }
+  }
+  .active\:bg-danger-darker {
+    &:active {
+      background-color: var(--color-danger-darker);
+    }
+  }
+  .active\:bg-surface-raised {
+    &:active {
+      background-color: var(--color-surface-raised);
+    }
+  }
+  .active\:bg-surface-subtle {
+    &:active {
+      background-color: var(--color-surface-subtle);
+    }
+  }
+  .active\:opacity-60 {
+    &:active {
+      opacity: 60%;
+    }
+  }
+  .active\:opacity-75 {
+    &:active {
+      opacity: 75%;
+    }
+  }
+  .active\:opacity-80 {
+    &:active {
+      opacity: 80%;
+    }
+  }
+  .disabled\:cursor-default {
+    &:disabled {
+      cursor: default;
+    }
+  }
+  .disabled\:cursor-not-allowed {
+    &:disabled {
+      cursor: not-allowed;
+    }
+  }
+  .disabled\:border-border {
+    &:disabled {
+      border-color: var(--color-border);
+    }
+  }
+  .disabled\:bg-text-disabled {
+    &:disabled {
+      background-color: var(--color-text-disabled);
+    }
+  }
+  .disabled\:text-surface {
+    &:disabled {
+      color: var(--color-surface);
+    }
+  }
+  .disabled\:text-text-disabled {
+    &:disabled {
+      color: var(--color-text-disabled);
+    }
+  }
+  .disabled\:opacity-40 {
+    &:disabled {
+      opacity: 40%;
+    }
+  }
+  .disabled\:opacity-50 {
+    &:disabled {
+      opacity: 50%;
+    }
+  }
+  .disabled\:shadow-none {
+    &:disabled {
+      --tw-shadow: 0 0 #0000;
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
+  .sm\:max-w-\[320px\] {
+    @media (width >= 640px) {
+      max-width: 320px;
+    }
+  }
+  .sm\:gap-lg {
+    @media (width >= 640px) {
+      gap: var(--spacing-lg);
+    }
+  }
+  .sm\:gap-sm {
+    @media (width >= 640px) {
+      gap: var(--spacing-sm);
+    }
+  }
+  .sm\:px-md {
+    @media (width >= 640px) {
+      padding-inline: var(--spacing-md);
+    }
+  }
+  .sm\:py-lg {
+    @media (width >= 640px) {
+      padding-block: var(--spacing-lg);
+    }
+  }
+  .sm\:py-md {
+    @media (width >= 640px) {
+      padding-block: var(--spacing-md);
+    }
+  }
+  .sm\:py-sm {
+    @media (width >= 640px) {
+      padding-block: var(--spacing-sm);
+    }
+  }
+  .sm\:text-2xl {
+    @media (width >= 640px) {
+      font-size: var(--text-2xl);
+      line-height: var(--tw-leading, var(--text-2xl--line-height));
+      letter-spacing: var(--tw-tracking, var(--text-2xl--letter-spacing));
+    }
+  }
+  .sm\:text-base {
+    @media (width >= 640px) {
+      font-size: var(--text-base);
+      line-height: var(--tw-leading, var(--text-base--line-height));
+      letter-spacing: var(--tw-tracking, var(--text-base--letter-spacing));
+    }
+  }
+  .sm\:text-lg {
+    @media (width >= 640px) {
+      font-size: var(--text-lg);
+      line-height: var(--tw-leading, var(--text-lg--line-height));
+      letter-spacing: var(--tw-tracking, var(--text-lg--letter-spacing));
+    }
+  }
+  .sm\:text-sm {
+    @media (width >= 640px) {
+      font-size: var(--text-sm);
+      line-height: var(--tw-leading, var(--text-sm--line-height));
+      letter-spacing: var(--tw-tracking, var(--text-sm--letter-spacing));
+    }
+  }
+  .sm\:text-xl {
+    @media (width >= 640px) {
+      font-size: var(--text-xl);
+      line-height: var(--tw-leading, var(--text-xl--line-height));
+      letter-spacing: var(--tw-tracking, var(--text-xl--letter-spacing));
+    }
+  }
+  .md\:max-w-\[400px\] {
+    @media (width >= 768px) {
+      max-width: 400px;
+    }
+  }
+  .md\:grid-cols-2 {
+    @media (width >= 768px) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+  .md\:grid-cols-3 {
+    @media (width >= 768px) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+  .md\:grid-cols-4 {
+    @media (width >= 768px) {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+  }
+  .md\:items-center {
+    @media (width >= 768px) {
+      align-items: center;
+    }
+  }
+  .md\:py-md {
+    @media (width >= 768px) {
+      padding-block: var(--spacing-md);
+    }
+  }
+  .\[\&\:\:-webkit-scrollbar\]\:hidden {
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+  .\[\&\>\*\]\:flex-1 {
+    &>* {
+      flex: 1;
+    }
+  }
+}
+@property --tw-translate-x {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-translate-y {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-translate-z {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-divide-y-reverse {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-border-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
+@property --tw-gradient-position {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-gradient-from {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #0000;
+}
+@property --tw-gradient-via {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #0000;
+}
+@property --tw-gradient-to {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #0000;
+}
+@property --tw-gradient-stops {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-gradient-via-stops {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-gradient-from-position {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 0%;
+}
+@property --tw-gradient-via-position {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 50%;
+}
+@property --tw-gradient-to-position {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+@property --tw-leading {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-font-weight {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-tracking {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-ordinal {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-slashed-zero {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-numeric-figure {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-numeric-spacing {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-numeric-fraction {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-shadow-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+@property --tw-inset-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-inset-shadow-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-inset-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+@property --tw-ring-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-ring-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-inset-ring-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-inset-ring-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-ring-inset {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-ring-offset-width {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+@property --tw-ring-offset-color {
+  syntax: "*";
+  inherits: false;
+  initial-value: #fff;
+}
+@property --tw-ring-offset-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-outline-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
+@property --tw-blur {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-brightness {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-contrast {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-grayscale {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-hue-rotate {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-invert {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-opacity {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-saturate {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-sepia {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-drop-shadow {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-drop-shadow-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-drop-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+@property --tw-drop-shadow-size {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-blur {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-brightness {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-contrast {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-grayscale {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-hue-rotate {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-invert {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-opacity {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-saturate {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-sepia {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-duration {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-ease {
+  syntax: "*";
+  inherits: false;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@keyframes pulse {
+  50% {
+    opacity: 0.5;
+  }
+}
+@layer properties {
+  @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
+    *, ::before, ::after, ::backdrop {
+      --tw-translate-x: 0;
+      --tw-translate-y: 0;
+      --tw-translate-z: 0;
+      --tw-divide-y-reverse: 0;
+      --tw-border-style: solid;
+      --tw-gradient-position: initial;
+      --tw-gradient-from: #0000;
+      --tw-gradient-via: #0000;
+      --tw-gradient-to: #0000;
+      --tw-gradient-stops: initial;
+      --tw-gradient-via-stops: initial;
+      --tw-gradient-from-position: 0%;
+      --tw-gradient-via-position: 50%;
+      --tw-gradient-to-position: 100%;
+      --tw-leading: initial;
+      --tw-font-weight: initial;
+      --tw-tracking: initial;
+      --tw-ordinal: initial;
+      --tw-slashed-zero: initial;
+      --tw-numeric-figure: initial;
+      --tw-numeric-spacing: initial;
+      --tw-numeric-fraction: initial;
+      --tw-shadow: 0 0 #0000;
+      --tw-shadow-color: initial;
+      --tw-shadow-alpha: 100%;
+      --tw-inset-shadow: 0 0 #0000;
+      --tw-inset-shadow-color: initial;
+      --tw-inset-shadow-alpha: 100%;
+      --tw-ring-color: initial;
+      --tw-ring-shadow: 0 0 #0000;
+      --tw-inset-ring-color: initial;
+      --tw-inset-ring-shadow: 0 0 #0000;
+      --tw-ring-inset: initial;
+      --tw-ring-offset-width: 0px;
+      --tw-ring-offset-color: #fff;
+      --tw-ring-offset-shadow: 0 0 #0000;
+      --tw-outline-style: solid;
+      --tw-blur: initial;
+      --tw-brightness: initial;
+      --tw-contrast: initial;
+      --tw-grayscale: initial;
+      --tw-hue-rotate: initial;
+      --tw-invert: initial;
+      --tw-opacity: initial;
+      --tw-saturate: initial;
+      --tw-sepia: initial;
+      --tw-drop-shadow: initial;
+      --tw-drop-shadow-color: initial;
+      --tw-drop-shadow-alpha: 100%;
+      --tw-drop-shadow-size: initial;
+      --tw-backdrop-blur: initial;
+      --tw-backdrop-brightness: initial;
+      --tw-backdrop-contrast: initial;
+      --tw-backdrop-grayscale: initial;
+      --tw-backdrop-hue-rotate: initial;
+      --tw-backdrop-invert: initial;
+      --tw-backdrop-opacity: initial;
+      --tw-backdrop-saturate: initial;
+      --tw-backdrop-sepia: initial;
+      --tw-duration: initial;
+      --tw-ease: initial;
+    }
+  }
+}

--- a/spider-admin/src/main/resources/mapper/oracle/user/UserMapper.xml
+++ b/spider-admin/src/main/resources/mapper/oracle/user/UserMapper.xml
@@ -322,7 +322,7 @@
         ORDER BY u.USER_NAME ASC, u.USER_ID ASC
     </select>
 
-    <!-- React CMS 결재자 목록 조회 (v3_react_cms_admin_approvals 쓰기 권한 보유 활성 사용자) -->
+    <!-- React CMS 결재자 목록 조회 (v3_react_cms_admin_approval 쓰기 권한 보유 활성 사용자) -->
     <select id="findReactCmsApprovers"
             resultType="com.example.spideradmin.global.auth.dto.CmsApproverResponse">
         SELECT DISTINCT
@@ -335,14 +335,14 @@
                   SELECT 1
                   FROM FWK_USER_MENU um
                   WHERE um.USER_ID = u.USER_ID
-                    AND um.MENU_ID = 'v3_react_cms_admin_approvals'
+                    AND um.MENU_ID = 'v3_react_cms_admin_approval'
                     AND um.AUTH_CODE = 'W'
               )
               OR EXISTS (
                   SELECT 1
                   FROM FWK_ROLE_MENU rm
                   WHERE rm.ROLE_ID = u.ROLE_ID
-                    AND rm.MENU_ID = 'v3_react_cms_admin_approvals'
+                    AND rm.MENU_ID = 'v3_react_cms_admin_approval'
                     AND rm.AUTH_CODE = 'W'
               )
           )

--- a/spider-admin/src/main/resources/templates/pages/react-cms-admin-approval/react-cms-admin-approval-script.html
+++ b/spider-admin/src/main/resources/templates/pages/react-cms-admin-approval/react-cms-admin-approval-script.html
@@ -107,20 +107,20 @@
                 const expiredCls = this._isExpired(row.expiredDate) ? 'text-danger fw-bold' : '';
                 const pid        = HtmlUtils.escape(row.pageId);
 
-                // 공개여부 — 현재 상태 라벨 + 클릭 시 토글 (쓰기 권한자에게만 노출)
+                // 공개여부 — XSS 방지: pageId·isPublic을 data-* 속성에만 저장
                 const isPublicBtn = HAS_REACT_CMS_WRITE
-                    ? `<button class="btn btn-xs ${row.isPublic === 'Y' ? 'btn-primary' : 'btn-outline-secondary'}"
+                    ? `<button class="btn btn-xs js-approval-toggle-public ${row.isPublic === 'Y' ? 'btn-primary' : 'btn-outline-secondary'}"
                                title="${row.isPublic === 'Y' ? '클릭하여 비공개 전환' : '클릭하여 공개 전환'}"
-                               onclick="ReactCmsAdminApprovalPage.togglePublicState('${pid}', '${HtmlUtils.escape(row.isPublic)}')">
+                               data-page-id="${pid}" data-current-state="${HtmlUtils.escape(row.isPublic)}">
                                ${row.isPublic === 'Y' ? '공개' : '비공개'}
                        </button>`
                     : `<span class="badge ${row.isPublic === 'Y' ? 'bg-primary' : 'bg-secondary'}">${row.isPublic === 'Y' ? '공개' : '비공개'}</span>`;
 
-                // 결재 컬럼 — PENDING 상태 + 쓰기 권한일 때만 노출
+                // 결재 컬럼 — XSS 방지: pageId를 data-* 속성에만 저장
                 const tdApproval = (HAS_REACT_CMS_WRITE && row.approveState === 'PENDING')
                     ? `<div class="d-flex flex-column gap-1">
-                           <button class="btn btn-success btn-xs" onclick="ReactCmsAdminApprovalPage.openApproveModal('${pid}')">승인</button>
-                           <button class="btn btn-danger btn-xs"  onclick="ReactCmsAdminApprovalPage.openRejectModal('${pid}')">반려</button>
+                           <button class="btn btn-success btn-xs js-approval-approve" data-page-id="${pid}">승인</button>
+                           <button class="btn btn-danger btn-xs js-approval-reject"   data-page-id="${pid}">반려</button>
                        </div>`
                     : '-';
 
@@ -400,6 +400,18 @@
 
         $(document).on('click', '.js-approval-history', function() {
             ReactCmsAdminApprovalPage.openHistoryModal($(this).data('page-id'));
+        });
+
+        $(document).on('click', '.js-approval-toggle-public', function() {
+            ReactCmsAdminApprovalPage.togglePublicState($(this).data('page-id'), $(this).data('current-state'));
+        });
+
+        $(document).on('click', '.js-approval-approve', function() {
+            ReactCmsAdminApprovalPage.openApproveModal($(this).data('page-id'));
+        });
+
+        $(document).on('click', '.js-approval-reject', function() {
+            ReactCmsAdminApprovalPage.openRejectModal($(this).data('page-id'));
         });
 
         $('#btnRefresh').off('click').on('click', function() { ReactCmsAdminApprovalPage.load(); });

--- a/spider-admin/src/main/resources/templates/pages/react-cms-admin-approval/react-cms-admin-approval-script.html
+++ b/spider-admin/src/main/resources/templates/pages/react-cms-admin-approval/react-cms-admin-approval-script.html
@@ -128,9 +128,9 @@
                 const previewBtn = `<button class="btn btn-outline-info btn-xs js-approval-preview"
                     data-page-id="${pid}"><i class="bi bi-box-arrow-up-right"></i> 보기</button>`;
 
-                // 이력 컬럼
-                const tdHistory = `<button class="btn btn-outline-dark btn-xs"
-                    onclick="ReactCmsAdminApprovalPage.openHistoryModal('${pid}')">이력</button>`;
+                // 이력 컬럼 — XSS 방지: pageId를 data-* 속성에만 저장
+                const tdHistory = `<button class="btn btn-outline-dark btn-xs js-approval-history"
+                    data-page-id="${pid}">이력</button>`;
 
                 return `<tr>
                     <td>${HtmlUtils.escape(row.pageName)}</td>
@@ -396,6 +396,10 @@
 
         $(document).on('click', '.js-approval-preview', function() {
             ReactCmsAdminApprovalPage.openReactPreview($(this).data('page-id'));
+        });
+
+        $(document).on('click', '.js-approval-history', function() {
+            ReactCmsAdminApprovalPage.openHistoryModal($(this).data('page-id'));
         });
 
         $('#btnRefresh').off('click').on('click', function() { ReactCmsAdminApprovalPage.load(); });

--- a/spider-admin/src/main/resources/templates/pages/react-cms-admin-approval/react-cms-admin-approval-script.html
+++ b/spider-admin/src/main/resources/templates/pages/react-cms-admin-approval/react-cms-admin-approval-script.html
@@ -93,7 +93,7 @@
             const $tbody = $('#reactCmsAdminApprovalTableBody');
             if (!rows || rows.length === 0) {
                 this.rowsByPageId = {};
-                $tbody.html('<tr><td colspan="10" class="text-center py-4 text-body-secondary">조회된 데이터가 없습니다.</td></tr>');
+                $tbody.html('<tr><td colspan="11" class="text-center py-4 text-body-secondary">조회된 데이터가 없습니다.</td></tr>');
                 return;
             }
 
@@ -124,16 +124,16 @@
                        </div>`
                     : '-';
 
+                // 미리보기 버튼 — XSS 방지: pageId를 data-* 속성에만 저장
+                const previewBtn = `<button class="btn btn-outline-info btn-xs js-approval-preview"
+                    data-page-id="${pid}"><i class="bi bi-box-arrow-up-right"></i> 보기</button>`;
+
                 // 이력 컬럼
                 const tdHistory = `<button class="btn btn-outline-dark btn-xs"
                     onclick="ReactCmsAdminApprovalPage.openHistoryModal('${pid}')">이력</button>`;
 
                 return `<tr>
-                    <td>
-                        <span class="clickable-cell"
-                              onclick="ReactCmsAdminApprovalPage.openReactPreview('${pid}')"
-                              title="미리보기">${HtmlUtils.escape(row.pageName)}</span>
-                    </td>
+                    <td>${HtmlUtils.escape(row.pageName)}</td>
                     <td class="text-center">${HtmlUtils.escape(row.viewMode || '')}</td>
                     <td>${HtmlUtils.escape(row.createUserName || '')}</td>
                     <td class="text-center">${badge}</td>
@@ -141,6 +141,7 @@
                     <td class="text-center">${HtmlUtils.escape(row.beginningDate || '-')}</td>
                     <td class="text-center ${expiredCls}">${HtmlUtils.escape(row.expiredDate || '-')}</td>
                     <td class="text-center small">${HtmlUtils.escape(row.lastModifiedDtime || '-')}</td>
+                    <td class="text-center">${previewBtn}</td>
                     <td class="text-center">${tdApproval}</td>
                     <td class="text-center">${tdHistory}</td>
                 </tr>`;
@@ -218,7 +219,7 @@
         // ── React CMS 페이지 프리뷰 (/react-cms/preview?pageType=REACT&pageId=xxx) ──
         openReactPreview: function(pageId) {
             const url = '/react-cms/preview?pageType=REACT&pageId=' + encodeURIComponent(pageId);
-            window.open(url, 'reactCmsBuilderPreview', 'width=1280,height=800,scrollbars=yes,resizable=yes');
+            window.open(url, 'reactCmsBuilderPreview', 'width=430,height=860,scrollbars=yes,resizable=yes');
         },
 
         // ── 승인 모달 ──
@@ -392,6 +393,10 @@
 
         $('#btnApproveConfirm').on('click', function() { ReactCmsAdminApprovalPage._submitApprove(); });
         $('#btnRejectConfirm').on('click',  function() { ReactCmsAdminApprovalPage._submitReject(); });
+
+        $(document).on('click', '.js-approval-preview', function() {
+            ReactCmsAdminApprovalPage.openReactPreview($(this).data('page-id'));
+        });
 
         $('#btnRefresh').off('click').on('click', function() { ReactCmsAdminApprovalPage.load(); });
         $('#btnExcel').off('click').on('click', function() { Toast.warning('엑셀 내보내기는 지원되지 않습니다.'); });

--- a/spider-admin/src/main/resources/templates/pages/react-cms-admin-approval/react-cms-admin-approval-table.html
+++ b/spider-admin/src/main/resources/templates/pages/react-cms-admin-approval/react-cms-admin-approval-table.html
@@ -25,13 +25,14 @@
             <th class="col-w-150 sortable" data-sort="lastModifiedDtime">
               최종수정일시
             </th>
+            <th class="col-w-70">미리보기</th>
             <th class="col-w-70">결재</th>
             <th class="col-w-70">이력</th>
           </tr>
         </thead>
         <tbody id="reactCmsAdminApprovalTableBody">
           <tr>
-            <td colspan="10" class="text-center py-4 text-body-secondary">
+            <td colspan="11" class="text-center py-4 text-body-secondary">
               조회 버튼을 클릭하여 데이터를 불러오세요.
             </td>
           </tr>

--- a/spider-admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard-table.html
+++ b/spider-admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard-table.html
@@ -6,6 +6,7 @@
       <table
         class="table table-sm table-hover sp-data-grid"
         id="reactCmsDashboardTable"
+        style="min-width: 900px"
       >
         <thead class="table-light">
           <tr>


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

Closes #274

## ✨ 변경 사항 (Changes)

- **AUTH_BYPASS 완전 제거** — 어드민 모드에서 반드시 실 spider-admin 세션으로 사용자 인증 (hardcoded userId로 저장되던 문제 해결)
- **작업자 대시보드 테이블 가로 스크롤** — `min-width: 900px` 추가로 컬럼 잘림 해소
- **빌더 초기화 버튼 동작 개선** — 편집 모드에서 빈 상태가 아닌 DB 저장 상태로 복원
- **승인자 목록 빈 문제 수정** — `UserMapper.xml` MENU_ID 오타 수정 (`v3_react_cms_admin_approvals` → `v3_react_cms_admin_approval`)
- **승인 관리 미리보기 컬럼 추가** — 배포 관리와 동일한 창 크기(430×860)로 미리보기 지원
- **코드 리뷰 반영** — `useCallback` 의존성 명시, tdHistory XSS 방지(이벤트 위임), 테스트 중복 제거
- **README 최신화** — `SPIDER_ADMIN_API_URL`, `npm run dev:proxy`, `CMSBuilderProps` 신규 항목 반영
- **`styles.css` 버전 관리 추가** — `reactive-springware/component-library/dist/styles.css` gitignore 예외 처리

## 🛠 기술적 의사결정

**AUTH_BYPASS 제거 방향**
단순 flag 분기 → 실 API 인증으로 전환. `SPIDER_ADMIN_API_URL` 미설정 또는 인증 실패 시 `GUEST_USER`로 graceful fallback 처리하여 단독 실행 환경도 안전하게 지원.

**tdHistory XSS 개선**
기존 inline `onclick="...('${pid}')"` 패턴은 pageId 값에 따라 XSS 가능성이 있어, 미리보기 버튼과 동일하게 `data-page-id` + jQuery 이벤트 위임 방식으로 통일.

## 🧪 테스트

- [x] `current-user.test.ts` — AUTH_BYPASS 관련 테스트 제거, fetch 모킹 기반으로 재작성 (25개 통과)
- [x] ESLint — 신규 오류 없음 (기존 대비 warning 1개 감소)
- [x] Spotless — 통과 (Java 파일 변경 없음)

## ⚠️ 고려 및 주의 사항

- `npm run dev:proxy` 실행 시 spider-admin(`:8080`)과 nginx 프록시(`:9000`)가 반드시 실행 중이어야 세션 쿠키가 공유됨
- 승인자 목록 조회는 `FWK_USER_MENU` / `FWK_ROLE_MENU` 테이블의 `MENU_ID = 'v3_react_cms_admin_approval'` 데이터가 있어야 정상 노출됨

## 💬 리뷰 포인트

- `CMSBuilder.tsx` `handleReset`: `loadPage`·`clearBlocks`가 `useBuilderState`에서 `useCallback`으로 메모화되어 있어 안정적 의존성 보장
- 승인 관리 script의 `tdApproval`(승인/반려 버튼)은 UUID인 `pid`를 inline onclick에 유지 중 — 동일한 방식으로 추후 통일 가능