### PR TITLE
🐛 fix/#278-배포 미리보기 viewMode 반영

### DIFF
--- a/spider-admin/src/main/java/com/example/spideradmin/domain/cmsdeployment/dto/CmsDeployPageResponse.java
+++ b/spider-admin/src/main/java/com/example/spideradmin/domain/cmsdeployment/dto/CmsDeployPageResponse.java
@@ -22,6 +22,12 @@ public class CmsDeployPageResponse {
     /** 페이지명 */
     private String pageName;
 
+    /**
+     * 뷰모드 — 'mobile' / 'responsive' / 'web'(=PC).
+     * 배포 미리보기 창 크기 결정에 사용. (#278)
+     */
+    private String viewMode;
+
     /** 작성자명 */
     private String createUserName;
 

--- a/spider-admin/src/main/java/com/example/spideradmin/global/page/controller/PageController.java
+++ b/spider-admin/src/main/java/com/example/spideradmin/global/page/controller/PageController.java
@@ -2,6 +2,7 @@ package com.example.spideradmin.global.page.controller;
 
 import com.example.spideradmin.domain.board.dto.BoardResponse;
 import com.example.spideradmin.domain.board.service.BoardService;
+import com.example.spideradmin.global.exception.InvalidInputException;
 import com.example.spideradmin.global.security.CustomUserDetails;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Set;
@@ -17,6 +18,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Slf4j
 @Controller
@@ -491,6 +493,31 @@ public class PageController {
     @PreAuthorize("hasAuthority('CMS:W')")
     public String cmsAdminDeployments(HttpServletRequest request, Model model) {
         return resolveView(request, "pages/cms-deployment/cms-deployment :: content", model);
+    }
+
+    /**
+     * 배포된 페이지를 디바이스 프레임(모바일/웹) 안에 iframe 으로 노출하는 미리보기 팝업. (#278)
+     *
+     * <p>배포된 HTML 자체에는 ContentBuilder 런타임이 없어 viewMode 별 렌더링이 불가능하므로,
+     * 래퍼 페이지가 디바이스 폭을 강제(mobile=390px)하거나 풀폭(web/PC) 으로 표시한다.
+     * 일반 admin 레이아웃이 아닌 standalone 페이지로 반환한다.
+     *
+     * @param url       배포 HTML 의 절대 URL (cms/deployed 경로만 허용)
+     * @param viewMode  'mobile' / 'responsive' / 'web' / 'PC' (대소문자 구분)
+     */
+    @GetMapping("/cms-admin/deployments/preview")
+    @PreAuthorize("hasAuthority('CMS:W')")
+    public String cmsAdminDeploymentPreview(
+            @RequestParam("url") String url,
+            @RequestParam(value = "viewMode", required = false) String viewMode,
+            Model model) {
+        // 외부에서 임의 URL 주입 차단 — 배포된 페이지 경로(/cms/deployed/) 만 허용
+        if (url == null || !url.contains("/cms/deployed/")) {
+            throw new InvalidInputException("허용되지 않은 미리보기 URL 입니다.");
+        }
+        model.addAttribute("deployedUrl", url);
+        model.addAttribute("viewMode", viewMode == null ? "" : viewMode);
+        return "pages/cms-deployment/cms-deployment-preview";
     }
 
     @GetMapping("/cms-admin/statistics")

--- a/spider-admin/src/main/resources/mapper/oracle/cmsdeployment/CmsDeployMapper.xml
+++ b/spider-admin/src/main/resources/mapper/oracle/cmsdeployment/CmsDeployMapper.xml
@@ -57,6 +57,8 @@
                 SELECT
                     p.PAGE_ID                                                   AS pageId,
                     p.PAGE_NAME                                                 AS pageName,
+                    <!-- 배포 미리보기 창 크기 결정용 (#278) -->
+                    p.VIEW_MODE                                                 AS viewMode,
                     p.CREATE_USER_NAME                                          AS createUserName,
                     CASE WHEN lh.FILE_ID IS NOT NULL
                         THEN 'http://' || si.INSTANCE_IP || ':' || TO_CHAR(si.INSTANCE_PORT)

--- a/spider-admin/src/main/resources/templates/pages/cms-deployment/cms-deployment-preview.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-deployment/cms-deployment-preview.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<!--
+  배포 미리보기 래퍼 페이지 (#278)
+  - viewMode 에 따라 모바일은 390x844 폰 프레임, 그 외(web/PC/responsive)는 풀폭 iframe 으로 표시
+  - 배포된 HTML 자체는 ContentBuilder 런타임이 없어 viewMode 별 자동 렌더링이 불가능하므로
+    래퍼가 컨테이너 폭을 강제하여 작성 의도와 동일한 미리보기를 제공한다.
+  - 배포 서버(nginx) 가 X-Frame-Options 를 설정하지 않아 cross-origin iframe 임베드 가능
+-->
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>배포 미리보기</title>
+    <style>
+        :root {
+            --bg-stage:    #2a2a2a;
+            --bg-header:   #1f1f1f;
+            --text-light:  #e5e5e5;
+            --text-muted:  #9ca3af;
+            --frame-shadow: 0 10px 40px rgba(0, 0, 0, 0.45);
+        }
+        * { box-sizing: border-box; }
+        html, body { margin: 0; height: 100%; }
+        body {
+            background: var(--bg-stage);
+            color: var(--text-light);
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Apple SD Gothic Neo',
+                         'Noto Sans KR', 'Malgun Gothic', sans-serif;
+            display: flex;
+            flex-direction: column;
+        }
+        .preview-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 10px 20px;
+            background: var(--bg-header);
+            border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+            font-size: 13px;
+            flex: 0 0 auto;
+        }
+        .preview-header .title { font-weight: 600; letter-spacing: 0.2px; }
+        .preview-header .meta  { color: var(--text-muted); font-size: 12px; }
+        .preview-header .url   {
+            color: var(--text-muted); font-size: 11px; max-width: 60%;
+            overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+        }
+        .preview-stage {
+            flex: 1 1 auto;
+            display: flex;
+            justify-content: center;
+            align-items: flex-start;
+            padding: 24px 20px;
+            overflow: auto;
+        }
+        /* 모바일 — 폰 프레임 (iPhone 14 Pro 기준 390x844) */
+        .device-frame.mobile {
+            width: 390px;
+            height: 844px;
+            background: #fff;
+            border-radius: 24px;
+            box-shadow: var(--frame-shadow);
+            overflow: hidden;
+        }
+        /* 웹/PC — 풀폭, 창 높이에 맞춰 채움 */
+        .device-frame.web {
+            width: 100%;
+            max-width: 1280px;
+            height: calc(100vh - 70px);
+            background: #fff;
+            border-radius: 8px;
+            box-shadow: var(--frame-shadow);
+            overflow: hidden;
+        }
+        .device-frame iframe {
+            width: 100%;
+            height: 100%;
+            border: 0;
+            display: block;
+            background: #fff;
+        }
+    </style>
+</head>
+<body>
+    <!-- 상단 정보 바: 모드 라벨 + URL 표시 -->
+    <div class="preview-header"
+         th:with="modeLabel=${viewMode == 'mobile' ? '모바일 (390 × 844)' : '웹 / PC'}">
+        <div>
+            <span class="title">배포 미리보기</span>
+            <span class="meta" style="margin-left:10px;">— <span th:text="${modeLabel}">웹 / PC</span></span>
+        </div>
+        <div class="url" th:text="${deployedUrl}">https://example.com/cms/deployed/x.html</div>
+    </div>
+
+    <!-- 디바이스 프레임 + iframe — viewMode 가 'mobile' 인 경우만 폰 프레임, 그 외는 풀폭 -->
+    <div class="preview-stage">
+        <div th:classappend="${viewMode == 'mobile' ? 'device-frame mobile' : 'device-frame web'}">
+            <!-- iframe 은 sandbox 미적용 — 배포 페이지의 스크립트/폼/링크가 제약 없이 동작해야 함 -->
+            <iframe th:src="${deployedUrl}" title="배포 페이지 미리보기"></iframe>
+        </div>
+    </div>
+</body>
+</html>

--- a/spider-admin/src/main/resources/templates/pages/cms-deployment/cms-deployment-script.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-deployment/cms-deployment-script.html
@@ -13,16 +13,9 @@
         sortBy: null,
         sortDirection: null,
 
-        // 배포 미리보기 창 크기 — VIEW_MODE 컬럼 값에 따라 적절한 디바이스 폭으로 노출 (#278)
-        // 'PC' 는 'web' 의 레거시 값(cms-dashboard 의 LEGACY_WEB_VIEW_MODE 와 동일 의미)
-        PREVIEW_SIZE_BY_VIEW_MODE: {
-            mobile:     { w: 390,  h: 800  },
-            responsive: { w: 768,  h: 1024 },
-            web:        { w: 1280, h: 800  },
-            PC:         { w: 1280, h: 800  },
-        },
-        // viewMode 값이 null/알 수 없는 값일 때 폴백 (가장 넓은 데스크톱 기준)
-        DEFAULT_PREVIEW_SIZE: { w: 1280, h: 800 },
+        // 배포 미리보기 래퍼 팝업 크기 — viewMode 무관 동일하게 큰 창으로 열고
+        // 내부 디바이스 프레임이 viewMode 별 폭(모바일=390 / 웹=풀폭) 을 책임진다 (#278)
+        PREVIEW_WINDOW_SIZE: { w: 1400, h: 900 },
 
         load: function(page) {
             if (page !== undefined) this.currentPage = page;
@@ -91,12 +84,17 @@
                 .replace(/\n/g, '\\n');
         },
 
-        // 배포된 페이지를 viewMode 에 맞춘 창 크기로 새 창에서 열기 (#278)
-        // 외부 서버(133.x.x.x)는 X-Frame-Options/CSP 정책으로 iframe 미지원 가능성이 있어 window.open 채택
+        // 배포된 페이지를 디바이스 프레임 래퍼(/cms-admin/deployments/preview) 안에서 열기 (#278)
+        // - mobile: 폰 프레임(390x844) 안에 iframe
+        // - web/PC: 풀폭 iframe
+        // 외부 배포 서버(nginx) 가 X-Frame-Options 미설정이라 cross-origin iframe 가능
         openDeployedPreview: function(url, viewMode) {
-            const size = this.PREVIEW_SIZE_BY_VIEW_MODE[viewMode] || this.DEFAULT_PREVIEW_SIZE;
+            const wrapperUrl = '/cms-admin/deployments/preview'
+                + '?url=' + encodeURIComponent(url)
+                + '&viewMode=' + encodeURIComponent(viewMode || '');
+            const size = this.PREVIEW_WINDOW_SIZE;
             window.open(
-                url,
+                wrapperUrl,
                 'cmsDeployPreview',
                 `width=${size.w},height=${size.h},scrollbars=yes,resizable=yes`,
             );

--- a/spider-admin/src/main/resources/templates/pages/cms-deployment/cms-deployment-script.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-deployment/cms-deployment-script.html
@@ -13,6 +13,17 @@
         sortBy: null,
         sortDirection: null,
 
+        // 배포 미리보기 창 크기 — VIEW_MODE 컬럼 값에 따라 적절한 디바이스 폭으로 노출 (#278)
+        // 'PC' 는 'web' 의 레거시 값(cms-dashboard 의 LEGACY_WEB_VIEW_MODE 와 동일 의미)
+        PREVIEW_SIZE_BY_VIEW_MODE: {
+            mobile:     { w: 390,  h: 800  },
+            responsive: { w: 768,  h: 1024 },
+            web:        { w: 1280, h: 800  },
+            PC:         { w: 1280, h: 800  },
+        },
+        // viewMode 값이 null/알 수 없는 값일 때 폴백 (가장 넓은 데스크톱 기준)
+        DEFAULT_PREVIEW_SIZE: { w: 1280, h: 800 },
+
         load: function(page) {
             if (page !== undefined) this.currentPage = page;
             const params = new URLSearchParams({
@@ -80,6 +91,17 @@
                 .replace(/\n/g, '\\n');
         },
 
+        // 배포된 페이지를 viewMode 에 맞춘 창 크기로 새 창에서 열기 (#278)
+        // 외부 서버(133.x.x.x)는 X-Frame-Options/CSP 정책으로 iframe 미지원 가능성이 있어 window.open 채택
+        openDeployedPreview: function(url, viewMode) {
+            const size = this.PREVIEW_SIZE_BY_VIEW_MODE[viewMode] || this.DEFAULT_PREVIEW_SIZE;
+            window.open(
+                url,
+                'cmsDeployPreview',
+                `width=${size.w},height=${size.h},scrollbars=yes,resizable=yes`,
+            );
+        },
+
         renderTable: function(rows) {
             const $tbody = $('#deployPageTableBody');
             // canWrite: 배포·만료수동처리 2컬럼 + URL 1컬럼 추가 → 9컬럼 / 미권한: 7컬럼
@@ -94,6 +116,8 @@
                 const pid          = HtmlUtils.escape(row.pageId || '');
                 const jsPageName   = this.escapeJsStringArg(row.pageName);
                 const jsDeployedUrl = this.escapeJsStringArg(row.deployedUrl);
+                // viewMode 는 배포 미리보기 창 크기 결정에 사용 (#278)
+                const jsViewMode   = this.escapeJsStringArg(row.viewMode);
 
                 // 노출기간 셀 — 만료된 경우 종료일 빨간색 + 만료 뱃지
                 const beginStr = row.beginningDate || '-';
@@ -107,9 +131,13 @@
                     : '-';
                 const periodCell = `<td class="small">${HtmlUtils.escape(beginStr)} ~ ${endStr}</td>`;
 
+                // 배포 미리보기: 앵커(target=_blank) → 버튼(window.open) 으로 변경
+                // viewMode 에 맞춘 창 크기로 노출되도록 openDeployedPreview() 위임 (#278)
                 const previewBtn = row.deployedUrl
-                    ? `<a href="${HtmlUtils.escape(row.deployedUrl)}" target="_blank" rel="noopener"
-                          class="btn btn-outline-info btn-xs"><i class="bi bi-box-arrow-up-right"></i> 보기</a>`
+                    ? `<button type="button" class="btn btn-outline-info btn-xs"
+                               onclick="CmsDeployPage.openDeployedPreview('${jsDeployedUrl}', '${jsViewMode}')">
+                           <i class="bi bi-box-arrow-up-right"></i> 보기
+                       </button>`
                     : '<span class="text-body-secondary small">-</span>';
                 const deployedUrlCell = row.deployedUrl
                     ? `<td class="small">

--- a/spider-admin/src/main/resources/templates/pages/cms-deployment/cms-deployment-script.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-deployment/cms-deployment-script.html
@@ -80,6 +80,8 @@
             return String(value || '')
                 .replace(/\\/g, '\\\\')
                 .replace(/'/g, "\\'")
+                // onclick="..." 속성 컨텍스트에서 " 가 포함되면 HTML 속성이 조기에 닫히므로 &quot; 로 인코딩
+                .replace(/"/g, '&quot;')
                 .replace(/\r/g, '\\r')
                 .replace(/\n/g, '\\n');
         },

--- a/spider-admin/src/test/java/com/example/spideradmin/domain/cmsdeployment/controller/CmsDeployControllerTest.java
+++ b/spider-admin/src/test/java/com/example/spideradmin/domain/cmsdeployment/controller/CmsDeployControllerTest.java
@@ -216,6 +216,7 @@ class CmsDeployControllerTest {
         return CmsDeployPageResponse.builder()
                 .pageId(PAGE_ID)
                 .pageName("테스트 페이지")
+                .viewMode("mobile")
                 .createUserName("홍길동")
                 .deployedUrl("http://133.186.135.23:8080/cms/deployed/" + PAGE_ID + ".html")
                 .build();

--- a/spider-admin/src/test/java/com/example/spideradmin/domain/cmsdeployment/service/CmsDeployServiceTest.java
+++ b/spider-admin/src/test/java/com/example/spideradmin/domain/cmsdeployment/service/CmsDeployServiceTest.java
@@ -176,6 +176,7 @@ class CmsDeployServiceTest {
         return CmsDeployPageResponse.builder()
                 .pageId(PAGE_ID)
                 .pageName("테스트 페이지")
+                .viewMode("mobile")
                 .createUserName("홍길동")
                 .deployedUrl("http://133.186.135.23:8080/cms/deployed/" + PAGE_ID + ".html")
                 .build();


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #278

## ✨ 변경 사항 (Changes)
배포 관리 페이지(`/cms-admin/deployments`)의 "보기" 버튼이 항상 풀 뷰포트 새 탭으로 열리던 문제를 수정. 페이지의 `VIEW_MODE` 컬럼 값에 따라 mobile / responsive / web 별로 적합한 창 크기로 미리보기를 노출합니다.

- `CmsDeployPageResponse`: `viewMode` 필드 추가
- `CmsDeployMapper#findApprovedPageList`: `p.VIEW_MODE AS viewMode` 컬럼 SELECT 추가
- `cms-deployment-script.html`:
  - `PREVIEW_SIZE_BY_VIEW_MODE` 매핑 상수 정의 (mobile=390×800, responsive=768×1024, web/PC=1280×800)
  - `openDeployedPreview(url, viewMode)` 함수 신규
  - "보기" 앵커 → 버튼(window.open) 으로 변경
- 테스트 fixture(`buildPageResponse`)에 `viewMode("mobile")` 추가

## 🛠 기술적 의사결정
- **iframe 모달이 아닌 `window.open` 채택**: 배포된 페이지는 외부 서버(`133.x.x.x`)에 호스팅되어 있어 `X-Frame-Options`/`CSP` 정책에 따라 iframe 임베드가 차단될 수 있음. `cms-approval` 의 기존 미리보기 패턴(`window.open`)과 일관성도 확보.
- **VIEW_MODE 매핑 키에 `web` 과 `PC` 모두 등록**: `cms-dashboard-script` 에서 정의한 `LEGACY_WEB_VIEW_MODE: 'PC'` 호환성 유지.
- **viewMode null/미지정 폴백**: 가장 안전한 데스크톱 폭(1280×800) 으로 폴백하여 기존 동작과 동일한 가시성 보장.

## 🧪 테스트
- [ ] mobile 뷰모드 페이지 "보기" → 390px 폭 새 창 노출 확인
- [ ] responsive 뷰모드 페이지 "보기" → 768px 폭 새 창 노출 확인
- [ ] web/PC 뷰모드 페이지 "보기" → 1280px 폭 새 창 노출 확인
- [ ] viewMode null 인 레거시 페이지 → 1280px 폭 폴백 확인
- [ ] 기존 "URL 복사" / URL 텍스트 링크 동작 회귀 없음
- [x] `./mvnw spotless:check` 통과
- [x] 단위 테스트(`CmsDeployControllerTest`, `CmsDeployServiceTest`) fixture 동기화

## ⚠️ 고려 및 주의 사항
- DB 스키마 변경 없음 (`SPW_CMS_PAGE.VIEW_MODE` 기존 컬럼 활용).
- MyBatis 매퍼는 Oracle만 변경 (MySQL 매퍼 미구현 상태 유지).
- 외부 배포 서버에는 영향 없음 — 로컬 spider-admin 만 재기동/리프레시로 검증 가능.

## 💬 리뷰 포인트
- mobile/responsive/web 별 권장 창 크기 값(390 / 768 / 1280)이 기획 의도와 일치하는지 확인 부탁드립니다. 필요시 조정 가능합니다.