### PR TITLE
🐛 fix/#280-A/B 라우팅 운영 서버 우선 선택

### DIFF
--- a/html-cms/src/app/api/ab/[groupId]/route.ts
+++ b/html-cms/src/app/api/ab/[groupId]/route.ts
@@ -63,14 +63,21 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ grou
         // 활성 서버 중 운영(localhost 가 아닌) 서버 우선 선택 — 시드 환경에 React 데모 서버
         // (localhost:5173/5174) 가 ALIVE_YN='Y' 로 함께 존재할 때 단순히 servers[0] 를 쓰면
         // 이름 가나다 정렬 영향으로 데모 서버가 잡히는 문제를 방어한다.
+        // IPv6 루프백(::1)도 제외하고, 폴백에서도 INSTANCE_IP 가 비어있는 서버를 걸러
+        // 'http:///...' 형태의 잘못된 redirect URL 생성을 막는다.
         const servers = await getServerList('Y');
         const operationServer =
-            servers.find((s) => !!s.INSTANCE_IP && !/^(localhost|127\.0\.0\.1)$/i.test(s.INSTANCE_IP)) ?? servers[0];
+            servers.find((s) => !!s.INSTANCE_IP && !/^(localhost|127\.0\.0\.1|::1)$/i.test(s.INSTANCE_IP)) ??
+            servers.find((s) => !!s.INSTANCE_IP);
         if (!operationServer) {
             return NextResponse.json({ ok: false, error: '활성화된 운영 서버가 없습니다.' }, { status: 503 });
         }
         const redirectUrl = new URL(
-            buildServerUrl(operationServer.INSTANCE_IP, operationServer.INSTANCE_PORT, `/cms/deployed/${targetPageId}.html`),
+            buildServerUrl(
+                operationServer.INSTANCE_IP,
+                operationServer.INSTANCE_PORT,
+                `/cms/deployed/${targetPageId}.html`,
+            ),
         );
 
         const res = NextResponse.redirect(redirectUrl, 302);

--- a/html-cms/src/app/api/ab/[groupId]/route.ts
+++ b/html-cms/src/app/api/ab/[groupId]/route.ts
@@ -60,14 +60,17 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ grou
             return NextResponse.json({ ok: false, error: '노출 가능한 페이지가 없습니다.' }, { status: 404 });
         }
 
-        // 활성 운영 서버 조회 — 첫 번째 서버의 배포 URL로 리다이렉트
+        // 활성 서버 중 운영(localhost 가 아닌) 서버 우선 선택 — 시드 환경에 React 데모 서버
+        // (localhost:5173/5174) 가 ALIVE_YN='Y' 로 함께 존재할 때 단순히 servers[0] 를 쓰면
+        // 이름 가나다 정렬 영향으로 데모 서버가 잡히는 문제를 방어한다.
         const servers = await getServerList('Y');
-        if (servers.length === 0) {
+        const operationServer =
+            servers.find((s) => !!s.INSTANCE_IP && !/^(localhost|127\.0\.0\.1)$/i.test(s.INSTANCE_IP)) ?? servers[0];
+        if (!operationServer) {
             return NextResponse.json({ ok: false, error: '활성화된 운영 서버가 없습니다.' }, { status: 503 });
         }
-        const server = servers[0];
         const redirectUrl = new URL(
-            buildServerUrl(server.INSTANCE_IP, server.INSTANCE_PORT, `/cms/deployed/${targetPageId}.html`),
+            buildServerUrl(operationServer.INSTANCE_IP, operationServer.INSTANCE_PORT, `/cms/deployed/${targetPageId}.html`),
         );
 
         const res = NextResponse.redirect(redirectUrl, 302);


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #280

## ✨ 변경 사항 (Changes)
- `html-cms/src/app/api/ab/[groupId]/route.ts` 의 서버 선택 로직을 변경
- 활성 서버 중 IP 가 `localhost`/`127.0.0.1` 이 아닌 서버를 우선 선택, 없으면 폴백으로 `servers[0]` 사용
- DB 시드 데이터(React 데모 서버)는 그대로 두고 코드 레벨에서만 해결

## 🛠 기술적 의사결정 (선택)
검토한 옵션:
1. **DB 시드 수정** — 다른 환경(개발자 로컬)에서 React 서버 필요할 수 있어 배제
2. **`SERVER_SELECT_LIST` SQL `ORDER BY` 변경** — `getServerList` 를 쓰는 다른 화면에 영향 가능 → 배제
3. **환경변수로 운영 서버 ID 지정** — 환경마다 설정 필요 + 운영 서버 변경 시 수동 동기화 부담 → 배제
4. **route.ts 단일 파일 수정** ✅ A/B 라우팅에만 영향, 변경 범위 최소

## 🧪 테스트 (선택)
- [ ] A/B 그룹의 "테스트" 버튼 클릭 시 `133.186.135.23:8080/cms/deployed/{pageId}.html` 로 리다이렉트되는지 확인
- [ ] 운영 서버 외 다른 활성 서버가 있어도 운영 서버가 선택되는지 확인
- [ ] 운영 서버가 비활성 상태면 폴백으로 첫 번째 서버 사용되는지 확인 (로컬 단독 환경 대응)

## ⚠️ 고려 및 주의 사항 (선택)
- 배포 후 운영 서버에 html-cms 재기동 필요 (Next.js 코드 변경)
- spider-admin 측 변경 없음 — html-cms 단독 배포로 충분

## 🔗 참고 사항 (선택)
근본 원인: `getServerList('Y')` 의 SQL 이 `ORDER BY INSTANCE_NAME` 이라 한글 가나다 정렬 시 "**데**모 로컬 리액트 서버"(localhost:5173)가 "**운**영 서버"(133.186.135.23:8080) 앞에 정렬되어 `servers[0]` 으로 잡히는 구조였음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)