### PR TITLE
feat #284: 통계 화면 배포 미리보기 버튼 추가

### DIFF
--- a/spider-admin/src/main/java/com/example/spideradmin/domain/cmsstatistics/dto/CmsStatisticsResponse.java
+++ b/spider-admin/src/main/java/com/example/spideradmin/domain/cmsstatistics/dto/CmsStatisticsResponse.java
@@ -20,6 +20,14 @@ public class CmsStatisticsResponse {
     /** 페이지명 */
     private String pageName;
 
+    /**
+     * 뷰모드 — 배포 미리보기 래퍼의 디바이스 프레임 폭 결정에 사용.
+     */
+    private String viewMode;
+
+    /** 최근 정상 배포 URL (배포 이력이 없으면 null) */
+    private String deployedUrl;
+
     /** 조회 수 (EVENT_TYPE='VIEW') */
     private Long viewCount;
 

--- a/spider-admin/src/main/resources/mapper/oracle/cmsstatistics/CmsStatisticsMapper.xml
+++ b/spider-admin/src/main/resources/mapper/oracle/cmsstatistics/CmsStatisticsMapper.xml
@@ -30,12 +30,31 @@
                 SELECT
                     p.PAGE_ID                                               AS pageId,
                     p.PAGE_NAME                                             AS pageName,
+                    p.VIEW_MODE                                             AS viewMode,
+                    CASE WHEN lh.FILE_ID IS NOT NULL
+                        THEN 'http://' || si.INSTANCE_IP || ':' || TO_CHAR(si.INSTANCE_PORT)
+                             || '/cms/deployed/' || p.PAGE_ID || '.html'
+                    END                                                     AS deployedUrl,
                     COUNT(CASE WHEN l.EVENT_TYPE = 'VIEW'  THEN 1 END)     AS viewCount,
                     COUNT(CASE WHEN l.EVENT_TYPE = 'CLICK' THEN 1 END)     AS clickCount
                 FROM SPW_CMS_PAGE_VIEW_LOG l
                 JOIN SPW_CMS_PAGE p ON l.PAGE_ID = p.PAGE_ID
+                LEFT JOIN (
+                    SELECT
+                        REGEXP_REPLACE(FILE_ID, '_v\d+\.html$', '') AS PAGE_ID,
+                        FILE_ID,
+                        INSTANCE_ID,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY REGEXP_REPLACE(FILE_ID, '_v\d+\.html$', '')
+                            ORDER BY LAST_MODIFIED_DTIME DESC
+                        ) AS RN
+                    FROM FWK_CMS_FILE_SEND_HIS
+                    WHERE FILE_ID LIKE '%_v%.html'
+                      AND FILE_ID NOT LIKE '%_expired.html'
+                ) lh ON lh.PAGE_ID = p.PAGE_ID AND lh.RN = 1
+                LEFT JOIN FWK_CMS_SERVER_INSTANCE si ON lh.INSTANCE_ID = si.INSTANCE_ID
                 <include refid="statConditions"/>
-                GROUP BY p.PAGE_ID, p.PAGE_NAME
+                GROUP BY p.PAGE_ID, p.PAGE_NAME, p.VIEW_MODE, lh.FILE_ID, si.INSTANCE_IP, si.INSTANCE_PORT
                 ORDER BY viewCount DESC, p.PAGE_NAME ASC
             ) INNER_QRY
             WHERE ROWNUM <![CDATA[<=]]> #{endRow}

--- a/spider-admin/src/main/resources/mapper/oracle/cmsstatistics/CmsStatisticsMapper.xml
+++ b/spider-admin/src/main/resources/mapper/oracle/cmsstatistics/CmsStatisticsMapper.xml
@@ -28,34 +28,40 @@
         SELECT * FROM (
             SELECT INNER_QRY.*, ROWNUM AS RNUM FROM (
                 SELECT
-                    p.PAGE_ID                                               AS pageId,
-                    p.PAGE_NAME                                             AS pageName,
-                    p.VIEW_MODE                                             AS viewMode,
-                    CASE WHEN lh.FILE_ID IS NOT NULL
-                        THEN 'http://' || si.INSTANCE_IP || ':' || TO_CHAR(si.INSTANCE_PORT)
-                             || '/cms/deployed/' || p.PAGE_ID || '.html'
+                    s.PAGE_ID                                               AS pageId,
+                    s.PAGE_NAME                                             AS pageName,
+                    s.VIEW_MODE                                             AS viewMode,
+                    CASE WHEN MAX(h.FILE_ID) IS NOT NULL
+                        THEN 'http://'
+                             || MAX(si.INSTANCE_IP) KEEP (
+                                    DENSE_RANK LAST ORDER BY h.LAST_MODIFIED_DTIME, h.FILE_ID, h.INSTANCE_ID
+                                )
+                             || ':'
+                             || TRIM(TO_CHAR(MAX(si.INSTANCE_PORT) KEEP (
+                                    DENSE_RANK LAST ORDER BY h.LAST_MODIFIED_DTIME, h.FILE_ID, h.INSTANCE_ID
+                                )))
+                             || '/cms/deployed/' || s.PAGE_ID || '.html'
                     END                                                     AS deployedUrl,
-                    COUNT(CASE WHEN l.EVENT_TYPE = 'VIEW'  THEN 1 END)     AS viewCount,
-                    COUNT(CASE WHEN l.EVENT_TYPE = 'CLICK' THEN 1 END)     AS clickCount
-                FROM SPW_CMS_PAGE_VIEW_LOG l
-                JOIN SPW_CMS_PAGE p ON l.PAGE_ID = p.PAGE_ID
-                LEFT JOIN (
+                    s.VIEW_COUNT                                            AS viewCount,
+                    s.CLICK_COUNT                                           AS clickCount
+                FROM (
                     SELECT
-                        REGEXP_REPLACE(FILE_ID, '_v\d+\.html$', '') AS PAGE_ID,
-                        FILE_ID,
-                        INSTANCE_ID,
-                        ROW_NUMBER() OVER (
-                            PARTITION BY REGEXP_REPLACE(FILE_ID, '_v\d+\.html$', '')
-                            ORDER BY LAST_MODIFIED_DTIME DESC
-                        ) AS RN
-                    FROM FWK_CMS_FILE_SEND_HIS
-                    WHERE FILE_ID LIKE '%_v%.html'
-                      AND FILE_ID NOT LIKE '%_expired.html'
-                ) lh ON lh.PAGE_ID = p.PAGE_ID AND lh.RN = 1
-                LEFT JOIN FWK_CMS_SERVER_INSTANCE si ON lh.INSTANCE_ID = si.INSTANCE_ID
-                <include refid="statConditions"/>
-                GROUP BY p.PAGE_ID, p.PAGE_NAME, p.VIEW_MODE, lh.FILE_ID, si.INSTANCE_IP, si.INSTANCE_PORT
-                ORDER BY viewCount DESC, p.PAGE_NAME ASC
+                        p.PAGE_ID                                           AS PAGE_ID,
+                        p.PAGE_NAME                                         AS PAGE_NAME,
+                        p.VIEW_MODE                                         AS VIEW_MODE,
+                        COUNT(CASE WHEN l.EVENT_TYPE = 'VIEW'  THEN 1 END) AS VIEW_COUNT,
+                        COUNT(CASE WHEN l.EVENT_TYPE = 'CLICK' THEN 1 END) AS CLICK_COUNT
+                    FROM SPW_CMS_PAGE_VIEW_LOG l
+                    JOIN SPW_CMS_PAGE p ON l.PAGE_ID = p.PAGE_ID
+                    <include refid="statConditions"/>
+                    GROUP BY p.PAGE_ID, p.PAGE_NAME, p.VIEW_MODE
+                ) s
+                LEFT JOIN FWK_CMS_FILE_SEND_HIS h
+                    ON h.FILE_ID LIKE s.PAGE_ID || '\_v%.html' ESCAPE '\'
+                   AND h.FILE_ID NOT LIKE '%\_expired.html' ESCAPE '\'
+                LEFT JOIN FWK_CMS_SERVER_INSTANCE si ON h.INSTANCE_ID = si.INSTANCE_ID
+                GROUP BY s.PAGE_ID, s.PAGE_NAME, s.VIEW_MODE, s.VIEW_COUNT, s.CLICK_COUNT
+                ORDER BY s.VIEW_COUNT DESC, s.PAGE_NAME ASC
             ) INNER_QRY
             WHERE ROWNUM <![CDATA[<=]]> #{endRow}
         ) WHERE RNUM > #{offset}

--- a/spider-admin/src/main/resources/templates/pages/cms-statistics/cms-statistics-script.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-statistics/cms-statistics-script.html
@@ -13,6 +13,7 @@
         _detailChart: null,
         /** afterDraw 레이블 계산 시 total 접근용 — _renderDetailChart 실행 시 갱신 */
         _chartTotal: 0,
+        PREVIEW_WINDOW_SIZE: { w: 1400, h: 900 },
 
         /**
          * 비율(%) 계산 헬퍼 — afterDraw·tooltip·요약 테이블에서 공통 사용
@@ -74,7 +75,7 @@
         renderTable: function(rows) {
             const $tbody = $('#statisticsTableBody');
             if (!rows || rows.length === 0) {
-                $tbody.html('<tr><td colspan="5" class="text-center py-4 text-body-secondary">아직 수집된 데이터가 없습니다.</td></tr>');
+                $tbody.html('<tr><td colspan="6" class="text-center py-4 text-body-secondary">아직 수집된 데이터가 없습니다.</td></tr>');
                 return;
             }
 
@@ -88,12 +89,20 @@
                     ? `<button class="btn btn-outline-primary btn-xs"
                            onclick="CmsStatisticsPage.openDetailModal('${pid}', '${escapedName}', '${HtmlUtils.escape(startDate)}', '${HtmlUtils.escape(endDate)}')">상세</button>`
                     : '-';
+                const previewBtn = row.deployedUrl
+                    ? `<button type="button" class="btn btn-outline-info btn-xs js-stat-preview"
+                           data-deployed-url="${HtmlUtils.escape(row.deployedUrl)}"
+                           data-view-mode="${HtmlUtils.escape(row.viewMode || '')}">
+                           <i class="bi bi-box-arrow-up-right"></i> 보기
+                       </button>`
+                    : '<span class="text-body-secondary small">-</span>';
 
                 return `<tr>
                     <td>${HtmlUtils.escape(row.pageName || '')}</td>
                     <td class="text-monospace small">${pid}</td>
                     <td class="text-end">${(row.viewCount || 0).toLocaleString()}</td>
                     <td class="text-end">${(row.clickCount || 0).toLocaleString()}</td>
+                    <td class="text-center">${previewBtn}</td>
                     <td class="text-center">${detailBtn}</td>
                 </tr>`;
             }).join('');
@@ -159,6 +168,19 @@
             $('#filterPageId').val('');
             this.itemsPerPage = parseInt($('#limitRows').val()) || 10;
             this.load(1);
+        },
+
+        // ── CMS 페이지 미리보기 ──
+        openPreview: function(deployedUrl, viewMode) {
+            const wrapperUrl = '/cms-admin/deployments/preview'
+                + '?url=' + encodeURIComponent(deployedUrl)
+                + '&viewMode=' + encodeURIComponent(viewMode || '');
+            const size = this.PREVIEW_WINDOW_SIZE;
+            window.open(
+                wrapperUrl,
+                'cmsStatisticsPreview',
+                `width=${size.w},height=${size.h},scrollbars=yes,resizable=yes`,
+            );
         },
 
         openDetailModal: function(pageId, pageName, startDate, endDate) {
@@ -323,6 +345,10 @@
         $('#limitRows').on('change', function() {
             CmsStatisticsPage.itemsPerPage = parseInt($(this).val()) || 10;
             CmsStatisticsPage.load(1);
+        });
+
+        $(document).on('click', '.js-stat-preview', function() {
+            CmsStatisticsPage.openPreview($(this).data('deployed-url'), $(this).data('view-mode'));
         });
 
         $('#btnRefresh').off('click').on('click', function() { CmsStatisticsPage.load(); });

--- a/spider-admin/src/main/resources/templates/pages/cms-statistics/cms-statistics-table.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-statistics/cms-statistics-table.html
@@ -10,12 +10,13 @@
                 <th class="col-w-160">페이지 ID</th>
                 <th class="col-w-100 text-end">조회 수</th>
                 <th class="col-w-100 text-end">클릭 수</th>
+                <th class="col-w-90">미리보기</th>
                 <th class="col-w-80">상세</th>
             </tr>
         </thead>
         <tbody id="statisticsTableBody">
             <tr>
-                <td colspan="5" class="text-center py-4 text-body-secondary">
+                <td colspan="6" class="text-center py-4 text-body-secondary">
                     조회 버튼을 클릭하여 데이터를 불러오세요.
                 </td>
             </tr>


### PR DESCRIPTION
##  관련 이슈 (Related Issues)
  > 머지 시 자동으로 닫을 이슈는 `Closes #이슈번호` 형식으로 적어주세요.
  > 참조만 할 경우 `- #이슈번호` 형식을 사용하세요.
  >
  > Closes #284

  ## ✨ 변경 사항 (Changes)
  > 무엇이 바뀌었는지 핵심 내용을 설명해 주세요.

  - `/cms-admin/statistics` 통계 목록에 `미리보기` 컬럼을 추가했습니다.
  - 통계 목록 API 응답에 `viewMode`, `deployedUrl`을 추가했습니다.
  - `FWK_CMS_FILE_SEND_HIS`의 최신 정상 배포 이력과 `FWK_CMS_SERVER_INSTANCE` 정보를 조합해 배포 페이지 URL을 생성하도록 했습니다.
  - 미리보기 버튼 클릭 시 배포 관리 화면과 동일하게 `/cms-admin/deployments/preview` 래퍼를 통해 배포된 페이지를 확인하도록 구현했습니다.
  - 배포 이력이 없는 페이지는 미리보기 버튼 대신 `-`로 표시됩니다.

  ##  변경 사항 확인 (선택)
  > UI 변경이 있거나 결과물을 시각적으로 보여줄 수 있다면 첨부해 주세요.

  | 변경 전 (Before) | 변경 후 (After) |
  | :--- | :--- |
  | CMS 통계 목록에서 페이지별 배포 화면을 바로 확인할 수 없음 | CMS 통계 목록에 `미리보기` 버튼이 추가되어 배포된 페이지를 새 창으로 확인 가능 |

  ## ⚠️ 고려 및 주의 사항 (선택)
  > 배포 시 유의점이나 기술적 부채, 향후 영향도를 적어주세요.

  - 미리보기 URL은 최신 정상 배포 이력(`*_v*.html`) 기준으로 생성됩니다.
  - 만료 전용 이력(`*_expired.html`)은 미리보기 대상에서 제외했습니다.
  - 배포 이력이 없는 페이지는 미리보기 버튼이 노출되지 않습니다.
  - Maven wrapper 실행 오류로 로컬 Maven 테스트는 수행하지 못했습니다.

  ##  리뷰 포인트 (선택)
  > 특별히 신경 써서 봐주었으면 하는 부분이나 의견이 필요한 곳을 적어주세요.

  - 통계 화면의 미리보기 기준이 편집 미리보기(`/cms/view?preview=1`)가 아니라 배포 미리보기(`/cms/deployed/{pageId}.html`)인 것이 맞는지 확인 부탁
  드립니다.
  - `FWK_CMS_FILE_SEND_HIS` 최신 배포 이력 기준 URL 생성 방식이 배포 관리 화면과 일관적인지 확인 부탁드립니다.

  ##  참고 사항 (선택)
  > 참고 자료 혹은 추가로 전달할 사항을 적어주세요.

  - 변경 파일:
    - `CmsStatisticsResponse.java`
    - `CmsStatisticsMapper.xml`
    - `cms-statistics-script.html`
    - `cms-statistics-table.html`