### PR TITLE
🐛 fix/#291-MetaDrivenCommandHandler 컴파일 오류 및 전문 필드 검증 활성화

### DIFF
--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/handler/MetaDrivenCommandHandler.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/handler/MetaDrivenCommandHandler.java
@@ -101,6 +101,9 @@ public class MetaDrivenCommandHandler implements CommandHandler<JsonCommandReque
                 jsonMessageParser.maskForLog(command + "_REQ", payload));
 
         try {
+            // FWK_MESSAGE_FIELD REQUIRED_YN='Y' 기준 필수 필드 검증 — 미등록 전문은 통과
+            jsonMessageParser.validate(command + "_REQ", payload);
+
             String serviceId = metaRoutingMapper.selectServiceId(trxId, ORG_ID, IO_TYPE);
             if (serviceId == null) {
                 throw new IllegalStateException("서비스 미등록: trxId=" + trxId);


### PR DESCRIPTION
## 📌 개요
`MetaDrivenCommandHandler.java` 두 가지 문제 수정

## 🛠 변경 내용

| 구분 | 내용 |
|------|------|
| 버그 수정 | 124번 라인 for 블록 닫는 중괄호 뒤 불필요 문자 제거 → 컴파일 오류 해소 |
| 기능 활성화 | `jsonMessageParser.validate()` 호출 추가 — `FWK_MESSAGE_FIELD REQUIRED_YN='Y'` 기준 필수 필드 검증 |

## 🔄 처리 순서 변경

```
Before
  trxLogger.logRequest() → selectServiceId() → 스텝 실행

After
  trxLogger.logRequest() → validate() → selectServiceId() → 스텝 실행
```

## ✅ 검증
- `validate()`가 `IllegalArgumentException` throw 시 기존 `catch(Exception e)` 블록에서 처리 → `success: false` 자동 반환
- `FWK_MESSAGE_FIELD` 미등록 전문은 `validate()` 내부에서 즉시 return → 기존 동작 영향 없음
- spider-link, biz-auth, biz-transfer, biz-channel, mock-core 전 모듈 BUILD SUCCESS 확인

## 🔗 참고
- closes #291
- 참고소스 대응: `MessageValueSetter.checkMessageFieldValue()`