### PR TITLE
✨ feat/#292-MessageEngineContext 라우팅 데이터 메모리 캐싱

### DIFF
--- a/spider-link/src/main/java/com/example/spiderlink/domain/meta/context/MessageEngineContext.java
+++ b/spider-link/src/main/java/com/example/spiderlink/domain/meta/context/MessageEngineContext.java
@@ -1,0 +1,100 @@
+package com.example.spiderlink.domain.meta.context;
+
+import com.example.spiderlink.domain.meta.dto.TrxMappingEntry;
+import com.example.spiderlink.domain.meta.mapper.MetaRoutingMapper;
+import jakarta.annotation.PostConstruct;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 기동 시 FWK_LISTENER_TRX_MESSAGE 전체를 메모리에 캐싱하는 라우팅 컨텍스트.
+ *
+ * <p>참고소스(spiderLink_Admin)의 {@code MessageEngineContext.initialize()} 역할에 해당한다.
+ * 거래 수신마다 DB를 재조회하는 대신, 이 컨텍스트에서 TRX_ID · ORG_ID를 반환한다.</p>
+ *
+ * <p>캐시 구조:
+ * <pre>
+ *   Map key : gwId + ":" + reqIdCode  (ex. "DEMO_GW:LOGIN")
+ *   Map value: TrxMappingEntry (gwId, reqIdCode, orgId, trxId)
+ * </pre>
+ * </p>
+ *
+ * <p>Admin에서 FWK_LISTENER_TRX_MESSAGE 변경 후 재기동 없이 반영하려면 {@link #reload()}를 호출한다.</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MessageEngineContext {
+
+    private final MetaRoutingMapper metaRoutingMapper;
+
+    /**
+     * gwId + ":" + reqIdCode → TrxMappingEntry.
+     * volatile: reload()는 관리 스레드에서, 조회는 TCP 워커 스레드에서 실행될 수 있으므로 가시성 보장 필요.
+     */
+    private volatile Map<String, TrxMappingEntry> trxMappings = new HashMap<>();
+
+    @PostConstruct
+    void init() {
+        reload();
+    }
+
+    /**
+     * FWK_LISTENER_TRX_MESSAGE 전체를 DB에서 다시 읽어 캐시를 교체한다.
+     *
+     * <p>Admin에서 커맨드·기관 매핑을 변경한 뒤 재기동 없이 반영할 때 호출한다.</p>
+     */
+    public void reload() {
+        List<TrxMappingEntry> all = metaRoutingMapper.selectAllTrxMappings();
+        Map<String, TrxMappingEntry> map = new HashMap<>(all.size() * 2);
+        for (TrxMappingEntry e : all) {
+            map.put(buildKey(e.getGwId(), e.getReqIdCode()), e);
+        }
+        // 참조를 atomic하게 교체 — 진행 중인 거래는 이전 맵을 계속 사용하므로 안전
+        this.trxMappings = map;
+        log.info("[MessageEngineContext] FWK_LISTENER_TRX_MESSAGE {}건 로드 완료", map.size());
+    }
+
+    /**
+     * GW_ID + 커맨드(REQ_ID_CODE)에 해당하는 TRX_ID를 반환한다.
+     *
+     * @return 미등록 커맨드이면 {@code null}
+     */
+    public String getTrxId(String gwId, String command) {
+        TrxMappingEntry entry = trxMappings.get(buildKey(gwId, command));
+        return entry != null ? entry.getTrxId() : null;
+    }
+
+    /**
+     * GW_ID + 커맨드(REQ_ID_CODE)에 해당하는 ORG_ID를 반환한다.
+     *
+     * @return 미등록 커맨드이면 {@code null}
+     */
+    public String getOrgId(String gwId, String command) {
+        TrxMappingEntry entry = trxMappings.get(buildKey(gwId, command));
+        return entry != null ? entry.getOrgId() : null;
+    }
+
+    /**
+     * GW_ID에 등록된 커맨드(REQ_ID_CODE) 전체를 반환한다.
+     *
+     * <p>{@code MetaDrivenCommandHandler.supports()} 판별용 커맨드 셋 초기화에 사용한다.</p>
+     */
+    public Set<String> getRegisteredCommands(String gwId) {
+        String prefix = gwId + ":";
+        return trxMappings.entrySet().stream()
+                .filter(e -> e.getKey().startsWith(prefix))
+                .map(e -> e.getValue().getReqIdCode())
+                .collect(Collectors.toSet());
+    }
+
+    private static String buildKey(String gwId, String reqIdCode) {
+        return gwId + ":" + reqIdCode;
+    }
+}

--- a/spider-link/src/main/java/com/example/spiderlink/domain/meta/dto/TrxMappingEntry.java
+++ b/spider-link/src/main/java/com/example/spiderlink/domain/meta/dto/TrxMappingEntry.java
@@ -1,0 +1,23 @@
+package com.example.spiderlink.domain.meta.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * FWK_LISTENER_TRX_MESSAGE 1건 — 게이트웨이·커맨드 → 기관·거래 매핑 정보.
+ *
+ * <p>기동 시 {@code MessageEngineContext}가 전체 행을 메모리에 적재하고,
+ * 거래 수신마다 DB 조회 대신 이 객체로 TRX_ID·ORG_ID를 반환한다.</p>
+ */
+@Data
+@NoArgsConstructor
+public class TrxMappingEntry {
+
+    private String gwId;
+    /** FWK_LISTENER_TRX_MESSAGE.REQ_ID_CODE — 커맨드(전문 ID) */
+    private String reqIdCode;
+    /** 기관 식별자 */
+    private String orgId;
+    /** 거래 ID — FWK_SERVICE 조회 키 */
+    private String trxId;
+}

--- a/spider-link/src/main/java/com/example/spiderlink/domain/meta/mapper/MetaRoutingMapper.java
+++ b/spider-link/src/main/java/com/example/spiderlink/domain/meta/mapper/MetaRoutingMapper.java
@@ -3,6 +3,7 @@ package com.example.spiderlink.domain.meta.mapper;
 import com.example.spiderlink.domain.meta.dto.ComponentInfo;
 import com.example.spiderlink.domain.meta.dto.RelationParam;
 import com.example.spiderlink.domain.meta.dto.ServiceStep;
+import com.example.spiderlink.domain.meta.dto.TrxMappingEntry;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -20,9 +21,19 @@ import org.apache.ibatis.annotations.Param;
 public interface MetaRoutingMapper {
 
     /**
+     * FWK_LISTENER_TRX_MESSAGE 전체 행을 반환한다.
+     *
+     * <p>기동 시 {@code MessageEngineContext}가 일괄 로딩하여 메모리 맵을 구성한다.
+     * 이후 거래 수신 시 DB 재조회 없이 메모리에서 TRX_ID·ORG_ID를 반환한다.</p>
+     */
+    List<TrxMappingEntry> selectAllTrxMappings();
+
+    /**
      * 게이트웨이에 등록된 커맨드(REQ_ID_CODE) 목록을 반환한다.
      * 시작 시 지원 커맨드 캐시를 초기화하는 데 사용한다.
+     * @deprecated {@link #selectAllTrxMappings()} 일괄 로딩으로 대체 — MessageEngineContext 사용 권장
      */
+    @Deprecated
     List<String> selectRegisteredCommands(@Param("gwId") String gwId);
 
     /** FWK_LISTENER_TRX_MESSAGE에서 커맨드에 해당하는 TRX_ID를 반환한다. */

--- a/spider-link/src/main/java/com/example/spiderlink/infra/tcp/handler/MetaDrivenCommandHandler.java
+++ b/spider-link/src/main/java/com/example/spiderlink/infra/tcp/handler/MetaDrivenCommandHandler.java
@@ -1,5 +1,6 @@
 package com.example.spiderlink.infra.tcp.handler;
 
+import com.example.spiderlink.domain.meta.context.MessageEngineContext;
 import com.example.spiderlink.domain.meta.dto.ComponentInfo;
 import com.example.spiderlink.domain.meta.dto.RelationParam;
 import com.example.spiderlink.domain.meta.dto.ServiceStep;
@@ -49,7 +50,6 @@ import org.springframework.stereotype.Component;
 public class MetaDrivenCommandHandler implements CommandHandler<JsonCommandRequest, JsonCommandResponse> {
 
     private static final String GW_ID   = "DEMO_GW";
-    private static final String ORG_ID  = "DEMO";
     private static final String IO_TYPE = "I";
 
     private final MetaRoutingMapper metaRoutingMapper;
@@ -60,27 +60,34 @@ public class MetaDrivenCommandHandler implements CommandHandler<JsonCommandReque
     private final JsonMessageParser jsonMessageParser;
     /** Biz 타입 컴포넌트 리플렉션 호출 시 스프링 빈 조회용 */
     private final ApplicationContext applicationContext;
+    /**
+     * 기동 시 FWK_LISTENER_TRX_MESSAGE를 일괄 메모리 캐싱 — 거래 수신마다 DB 재조회 제거.
+     * 참고소스의 MessageEngineContext.initialize()에 해당한다.
+     */
+    private final MessageEngineContext messageEngineContext;
 
     /**
-     * 시작 시 FWK_LISTENER_TRX_MESSAGE에서 등록된 커맨드 목록 캐싱 — DB 조회 최소화.
-     * volatile: refreshCommands()가 TCP 워커 스레드와 다른 스레드에서 참조를 교체하므로 가시성 보장 필요
+     * 지원 커맨드 셋 — MessageEngineContext에서 파생.
+     * volatile: refreshCommands()가 TCP 워커 스레드와 다른 스레드에서 참조를 교체하므로 가시성 보장 필요.
      */
     private volatile Set<String> supportedCommands = new HashSet<>();
 
     @PostConstruct
     void init() {
-        supportedCommands = new HashSet<>(metaRoutingMapper.selectRegisteredCommands(GW_ID));
+        // MessageEngineContext가 먼저 @PostConstruct로 초기화되므로 즉시 사용 가능
+        supportedCommands = messageEngineContext.getRegisteredCommands(GW_ID);
         log.info("[MetaDrivenCommandHandler] 등록된 커맨드 {}개 로드: {}", supportedCommands.size(), supportedCommands);
     }
 
     /**
-     * 지원 커맨드 캐시를 DB에서 다시 로드한다.
+     * 지원 커맨드 캐시와 MessageEngineContext 라우팅 맵을 DB에서 다시 로드한다.
      *
      * <p>Admin에서 FWK_LISTENER_TRX_MESSAGE 변경 후 재기동 없이 반영할 때
      * {@code POST /api/management/reload} (gubun=request_app_mapping) 호출 시 실행된다.</p>
      */
     public void refreshCommands() {
-        supportedCommands = new HashSet<>(metaRoutingMapper.selectRegisteredCommands(GW_ID));
+        messageEngineContext.reload();
+        supportedCommands = messageEngineContext.getRegisteredCommands(GW_ID);
         log.info("[MetaDrivenCommandHandler] 커맨드 캐시 갱신 완료: {}개 — {}", supportedCommands.size(), supportedCommands);
     }
 
@@ -94,17 +101,20 @@ public class MetaDrivenCommandHandler implements CommandHandler<JsonCommandReque
     public JsonCommandResponse handle(String command, JsonCommandRequest request) {
         Map<String, Object> payload = request.getPayload() != null ? request.getPayload() : Map.of();
         String userId = String.valueOf(payload.getOrDefault("userId", ""));
-        String trxId  = metaRoutingMapper.selectTrxId(GW_ID, command);
+        // supports()를 통과한 커맨드이므로 getTrxId/getOrgId는 반드시 non-null
+        String trxId = messageEngineContext.getTrxId(GW_ID, command);
+        String orgId = messageEngineContext.getOrgId(GW_ID, command);
 
         // FWK_MESSAGE_FIELD 기준 마스킹 후 거래 로그 저장 — password 등 민감 필드 보호
+        // maskForLog 키: trxId + "_REQ" (FWK_MESSAGE_FIELD는 TRX_ID 기준으로 필드 정의)
         trxLogger.logRequest(trxId, request.getRequestId(), userId,
-                jsonMessageParser.maskForLog(command + "_REQ", payload));
+                jsonMessageParser.maskForLog(trxId + "_REQ", payload));
 
         try {
             // FWK_MESSAGE_FIELD REQUIRED_YN='Y' 기준 필수 필드 검증 — 미등록 전문은 통과
-            jsonMessageParser.validate(command + "_REQ", payload);
+            jsonMessageParser.validate(trxId + "_REQ", payload);
 
-            String serviceId = metaRoutingMapper.selectServiceId(trxId, ORG_ID, IO_TYPE);
+            String serviceId = metaRoutingMapper.selectServiceId(trxId, orgId, IO_TYPE);
             if (serviceId == null) {
                 throw new IllegalStateException("서비스 미등록: trxId=" + trxId);
             }
@@ -166,7 +176,7 @@ public class MetaDrivenCommandHandler implements CommandHandler<JsonCommandReque
                     .command(command).success(true).payload(toCamelCaseKeys(lastSelectResult)).build();
             // FWK_MESSAGE_FIELD 기준 마스킹 후 응답 거래 로그 저장
             trxLogger.logResponse(trxId, request.getRequestId(), userId,
-                    jsonMessageParser.maskForLog(command + "_RES", lastSelectResult), "Y");
+                    jsonMessageParser.maskForLog(trxId + "_RES", lastSelectResult), "Y");
             return response;
 
         } catch (Exception e) {

--- a/spider-link/src/main/resources/mapper/oracle/meta/MetaRoutingMapper.xml
+++ b/spider-link/src/main/resources/mapper/oracle/meta/MetaRoutingMapper.xml
@@ -4,6 +4,16 @@
 
 <mapper namespace="com.example.spiderlink.domain.meta.mapper.MetaRoutingMapper">
 
+    <!-- FWK_LISTENER_TRX_MESSAGE 전체 로드 — MessageEngineContext 기동 시 1회 실행 -->
+    <select id="selectAllTrxMappings"
+            resultType="com.example.spiderlink.domain.meta.dto.TrxMappingEntry">
+        SELECT GW_ID       AS gwId,
+               REQ_ID_CODE AS reqIdCode,
+               ORG_ID      AS orgId,
+               TRX_ID      AS trxId
+          FROM FWK_LISTENER_TRX_MESSAGE
+    </select>
+
     <!-- 게이트웨이에 등록된 커맨드 목록 (시작 시 지원 커맨드 캐시 초기화용) -->
     <select id="selectRegisteredCommands" resultType="string">
         SELECT REQ_ID_CODE


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #292

## ✨ 변경 사항 (Changes)

기동 시 `FWK_LISTENER_TRX_MESSAGE` 전체를 메모리에 적재하는 `MessageEngineContext`를 추가하고, `MetaDrivenCommandHandler`가 거래마다 DB를 재조회하던 방식을 메모리 조회로 전환한다.

**신규 파일 2건**
| 파일 | 설명 |
|------|------|
| `MessageEngineContext.java` | `@PostConstruct`에서 `FWK_LISTENER_TRX_MESSAGE` 전체 로드 → `getTrxId()` / `getOrgId()` / `getRegisteredCommands()` 메모리 반환 |
| `TrxMappingEntry.java` | `FWK_LISTENER_TRX_MESSAGE` 1건 DTO (gwId, reqIdCode, orgId, trxId) |

**수정 파일 3건**
| 파일 | 변경 내용 |
|------|---------|
| `MetaRoutingMapper.java` | `selectAllTrxMappings()` 추가 — 전체 행 일괄 조회 |
| `MetaRoutingMapper.xml` | `selectAllTrxMappings` SQL 추가 |
| `MetaDrivenCommandHandler.java` | `MessageEngineContext` 주입, `selectTrxId()` DB 조회 → 메모리 조회 전환, `orgId` 동적화, `maskForLog`/`validate` 키 `command` → `trxId` 수정 |

## 🛠 기술적 의사결정

**거래마다 DB 재조회 → 기동 시 1회 메모리 적재**

`MetaDrivenCommandHandler.handle()`은 거래 수신마다 `selectTrxId()`를 DB 조회했다. 라우팅 데이터(`FWK_LISTENER_TRX_MESSAGE`)는 런타임에 거의 변하지 않으므로 기동 시 전체를 메모리 맵으로 캐싱한다. 참고소스의 `MessageEngineContext.initialize()` 역할과 동일하다.

**`ORG_ID = "DEMO"` 하드코딩 제거**

`MessageEngineContext.getOrgId()`로 DB 값을 동적으로 반환한다. 현재 데이터는 여전히 `"DEMO"` 단일이지만, 향후 다기관 확장 시 코드 변경 없이 DB 데이터 추가만으로 대응 가능하다.

**`command` → `trxId` 수정 (Gemini HIGH 코멘트 반영)**

`maskForLog` / `validate` 키를 `command + "_REQ"` 대신 `trxId + "_REQ"`로 변경한다. `FWK_MESSAGE_FIELD`는 TRX_ID 기준으로 필드를 정의하므로 의미상 정확하다. 현재 데이터에서 `command == trxId`이므로 동작 차이 없음.

**`volatile Map` 참조 교체**

`reload()` 호출 시 새 맵 인스턴스를 생성해 참조를 교체한다. 진행 중인 거래는 이전 맵을 계속 사용하므로 동시성 문제 없이 안전하다.

## 🧪 테스트

- [x] spider-link `BUILD SUCCESS`
- [x] biz-common / mock-core / biz-auth / biz-transfer / biz-channel 전체 `BUILD SUCCESS`

## ⚠️ 고려 및 주의 사항

- `Admin > POST /api/management/reload` (gubun=request_app_mapping) 호출 시 `refreshCommands()`가 `messageEngineContext.reload()`도 함께 실행하므로 재기동 없이 캐시 갱신 가능
- `FWK_LISTENER_TRX_MESSAGE`에 `ORG_ID` 컬럼이 없는 경우 `selectAllTrxMappings` SQL 오류 발생 — 기존 DDL에 컬럼이 존재하므로 문제 없음