### PR TITLE
🎨 style/#295-통계페이지-상세모달-UI개선

### DIFF
--- a/spider-admin/src/main/resources/templates/pages/cms-statistics/cms-statistics-script.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-statistics/cms-statistics-script.html
@@ -84,9 +84,9 @@
 
             const html = rows.map(row => {
                 const pid = HtmlUtils.escape(row.pageId || '');
-                const escapedName = HtmlUtils.escape(row.pageName || '').replace(/'/g, '&#39;');
-                const escapedDeployedUrl = HtmlUtils.escape(row.deployedUrl || '').replace(/'/g, '&#39;');
-                const escapedViewMode = HtmlUtils.escape(row.viewMode || '').replace(/'/g, '&#39;');
+                const escapedName = HtmlUtils.escape(row.pageName || '').replace(/'/g, "\\'");
+                const escapedDeployedUrl = HtmlUtils.escape(row.deployedUrl || '').replace(/'/g, "\\'");
+                const escapedViewMode = HtmlUtils.escape(row.viewMode || '').replace(/'/g, "\\'");
                 const detailBtn = row.clickCount > 0
                     ? `<button class="btn btn-outline-primary btn-xs"
                            onclick="CmsStatisticsPage.openDetailModal('${pid}', '${escapedName}', '${HtmlUtils.escape(startDate)}', '${HtmlUtils.escape(endDate)}', '${escapedDeployedUrl}', '${escapedViewMode}')">상세</button>`
@@ -194,14 +194,14 @@
                 this._detailChart = null;
             }
 
-            // 미리보기 버튼 — deployedUrl이 있을 때만 표시
+            // 미리보기 버튼 — deployedUrl이 있을 때만 표시, js-stat-preview 전역 리스너가 처리
             const $previewBtn = $('#detailPreviewBtn');
             if (deployedUrl) {
-                $previewBtn.removeClass('d-none').off('click').on('click', function() {
-                    CmsStatisticsPage.openPreview(deployedUrl, viewMode || '');
-                });
+                $previewBtn.removeClass('d-none')
+                    .data('deployed-url', deployedUrl)
+                    .data('view-mode', viewMode || '');
             } else {
-                $previewBtn.addClass('d-none').off('click');
+                $previewBtn.addClass('d-none');
             }
 
             // 로딩 상태로 초기화

--- a/spider-admin/src/main/resources/templates/pages/cms-statistics/cms-statistics-script.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-statistics/cms-statistics-script.html
@@ -85,9 +85,11 @@
             const html = rows.map(row => {
                 const pid = HtmlUtils.escape(row.pageId || '');
                 const escapedName = HtmlUtils.escape(row.pageName || '').replace(/'/g, '&#39;');
+                const escapedDeployedUrl = HtmlUtils.escape(row.deployedUrl || '').replace(/'/g, '&#39;');
+                const escapedViewMode = HtmlUtils.escape(row.viewMode || '').replace(/'/g, '&#39;');
                 const detailBtn = row.clickCount > 0
                     ? `<button class="btn btn-outline-primary btn-xs"
-                           onclick="CmsStatisticsPage.openDetailModal('${pid}', '${escapedName}', '${HtmlUtils.escape(startDate)}', '${HtmlUtils.escape(endDate)}')">상세</button>`
+                           onclick="CmsStatisticsPage.openDetailModal('${pid}', '${escapedName}', '${HtmlUtils.escape(startDate)}', '${HtmlUtils.escape(endDate)}', '${escapedDeployedUrl}', '${escapedViewMode}')">상세</button>`
                     : '-';
                 const previewBtn = row.deployedUrl
                     ? `<button type="button" class="btn btn-info btn-xs js-stat-preview"
@@ -183,7 +185,7 @@
             );
         },
 
-        openDetailModal: function(pageId, pageName, startDate, endDate) {
+        openDetailModal: function(pageId, pageName, startDate, endDate, deployedUrl, viewMode) {
             $('#detailPageName').text(pageName);
 
             // 모달 재오픈 시 기존 차트 인스턴스 해제 (캔버스 재사용 시 오류 방지)
@@ -192,10 +194,20 @@
                 this._detailChart = null;
             }
 
+            // 미리보기 버튼 — deployedUrl이 있을 때만 표시
+            const $previewBtn = $('#detailPreviewBtn');
+            if (deployedUrl) {
+                $previewBtn.removeClass('d-none').off('click').on('click', function() {
+                    CmsStatisticsPage.openPreview(deployedUrl, viewMode || '');
+                });
+            } else {
+                $previewBtn.addClass('d-none').off('click');
+            }
+
             // 로딩 상태로 초기화
             $('#detailLoading').show();
             $('#detailChartWrapper').addClass('d-none');
-            $('#detailSummaryTable').addClass('d-none');
+            $('#detailTotalClicks').addClass('d-none').text('');
             $('#detailNoData').addClass('d-none').removeClass('text-danger').text('');
 
             // getOrCreateInstance — 매 호출마다 새 인스턴스를 생성하지 않아 메모리 누수 방지
@@ -221,7 +233,7 @@
         },
 
         /**
-         * 컴포넌트별 클릭 수를 가로형 막대 차트 + 요약 테이블로 렌더링한다.
+         * 컴포넌트별 클릭 수를 가로형 막대 차트로 렌더링한다.
          * - 최대 클릭 컴포넌트: 강조색(#0d6efd), 나머지: 무채색(#adb5bd)
          * - 막대 끝 afterDraw 플러그인으로 "클릭수 (비율%)" 레이블 표시
          * - 레이블 길이에 따라 오른쪽 패딩을 동적 계산하여 잘림 방지
@@ -249,6 +261,7 @@
             $('#detailBarChart').css('height', canvasHeight + 'px');
 
             const canvas = document.getElementById('detailBarChart');
+            $('#detailTotalClicks').text(`총 ${total.toLocaleString()}회 클릭`).removeClass('d-none');
             $('#detailChartWrapper').removeClass('d-none');
 
             this._detailChart = new Chart(canvas.getContext('2d'), {
@@ -286,38 +299,6 @@
                 }
             });
 
-            // 요약 테이블 렌더링
-            this._renderSummaryTable(data, total, maxClick);
-        },
-
-        /**
-         * 차트 하단 요약 테이블을 렌더링한다.
-         * - 최다 클릭 행에 강조 배지 표시
-         * - 합계 행(tfoot) 추가
-         */
-        _renderSummaryTable: function(data, total, maxClick) {
-            const rows = data.map(d => {
-                const count = d.clickCount || 0;
-                const pct = this._pct(count, total);
-                const badge = count === maxClick
-                    ? ' <span class="badge bg-primary ms-1" style="font-size:10px;">최다</span>'
-                    : '';
-                return `<tr>
-                    <td class="text-monospace small">${HtmlUtils.escape(d.componentId || '')}${badge}</td>
-                    <td class="text-end">${count.toLocaleString()}</td>
-                    <td class="text-end text-body-secondary">${pct}%</td>
-                </tr>`;
-            }).join('');
-
-            $('#detailSummaryBody').html(rows);
-            $('#detailSummaryFoot').html(`
-                <tr>
-                    <td>합계</td>
-                    <td class="text-end">${total.toLocaleString()}</td>
-                    <td class="text-end">100.0%</td>
-                </tr>
-            `);
-            $('#detailSummaryTable').removeClass('d-none');
         },
 
         _today: function() {

--- a/spider-admin/src/main/resources/templates/pages/cms-statistics/cms-statistics.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-statistics/cms-statistics.html
@@ -61,7 +61,7 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" id="detailPreviewBtn" class="btn btn-info btn-sm d-none me-auto">
+                    <button type="button" id="detailPreviewBtn" class="btn btn-info btn-sm d-none me-auto js-stat-preview">
                         <i class="bi bi-box-arrow-up-right"></i> 페이지 미리보기
                     </button>
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>

--- a/spider-admin/src/main/resources/templates/pages/cms-statistics/cms-statistics.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-statistics/cms-statistics.html
@@ -52,28 +52,18 @@
                     <!-- 데이터 없음 / 오류 메시지 (기본 숨김) -->
                     <p id="detailNoData" class="text-center text-body-secondary d-none mb-0 py-4"></p>
 
+                    <!-- 전체 누적 클릭 수 — 차트 렌더링 시 표시 -->
+                    <p id="detailTotalClicks" class="d-none text-body-secondary small mb-2"></p>
+
                     <!-- 차트 영역 — 가운데 정렬, 좌우 여백으로 레이블 잘림 방지 -->
                     <div id="detailChartWrapper" class="d-none px-2 mb-4" style="max-width: 600px;">
                         <canvas id="detailBarChart"></canvas>
                     </div>
-
-                    <!-- 요약 테이블 — 차트 하단 구분선 후 표시 -->
-                    <div id="detailSummaryTable" class="d-none">
-                        <hr class="my-3">
-                        <table class="table table-sm table-hover sp-data-grid mb-0">
-                            <thead class="table-light">
-                                <tr>
-                                    <th>컴포넌트 ID</th>
-                                    <th class="text-end" style="width: 100px;">클릭 수</th>
-                                    <th class="text-end" style="width: 80px;">비율</th>
-                                </tr>
-                            </thead>
-                            <tbody id="detailSummaryBody"></tbody>
-                            <tfoot id="detailSummaryFoot" class="table-light fw-semibold"></tfoot>
-                        </table>
-                    </div>
                 </div>
                 <div class="modal-footer">
+                    <button type="button" id="detailPreviewBtn" class="btn btn-info btn-sm d-none me-auto">
+                        <i class="bi bi-box-arrow-up-right"></i> 페이지 미리보기
+                    </button>
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
                 </div>
             </div>


### PR DESCRIPTION
## 📌 개요
통계 페이지(`/cms-admin/statistics`) 상세 모달 UI 개선

## 🎯 변경 사항
- 차트와 중복되는 요약 테이블 제거로 모달 간소화
- 전체 누적 클릭 수 텍스트 추가 (`총 N회 클릭`)
- 페이지 미리보기 버튼 추가 (배포관리 페이지와 동일한 팝업 방식)

## 🛠 기술적 의사결정
`deployedUrl`/`viewMode`는 이미 목록 API(`CmsStatisticsResponse`)에 포함되어 있어 백엔드 변경 없이 `openDetailModal` 파라미터 추가만으로 해결.
미리보기는 기존 `openPreview()` 메서드를 재사용.

## 📸 변경 사항 확인
**Before**: 차트 + 요약 테이블(컴포넌트 ID / 클릭 수 / 비율)
**After**: 차트 + 총 클릭 수 텍스트 + footer 미리보기 버튼

## ✅ 인수 기준
- [x] 상세 모달에서 요약 테이블이 노출되지 않는다
- [x] 전체 누적 클릭 수가 차트 위에 표시된다
- [x] 미리보기 버튼 클릭 시 새 탭으로 배포된 페이지가 열린다

closes #295