### PR TITLE
♻️ refactor/#300-OverlayCanvas useLayoutEffect → 콜백 ref 패턴 리팩토링

### DIFF
--- a/react-cms/src/cms-core/canvas/OverlayCanvas.tsx
+++ b/react-cms/src/cms-core/canvas/OverlayCanvas.tsx
@@ -7,31 +7,32 @@
  * - pt-7 스페이서 불필요 → 빌더/런타임 간 WYSIWYG 일치
  * transform: translateZ(0) — fixed 포지셔닝도 프레임 안에 포함.
  */
-import { useContext, useLayoutEffect, useRef, useState } from "react";
+import { useContext, useState } from "react";
 import type { CMSOverlay } from "../types";
 import { OverlayTemplatesContext } from "../context";
 import { UserScopeWrapper } from "../UserScopeWrapper";
 
 const PHONE_FRAME_W = 390;
 /** CSS 변수로 툴바 높이·패딩 참조 — cms-theme.css의 --cms-toolbar-h, --cms-canvas-pad 값 사용 */
-const CANVAS_MIN_H = "calc(100dvh - var(--cms-toolbar-h, 3rem) - var(--cms-canvas-pad, 1.5rem) * 2)";
+const CANVAS_MIN_H =
+  "calc(100dvh - var(--cms-toolbar-h, 3rem) - var(--cms-canvas-pad, 1.5rem) * 2)";
 
 /**
  * @description 오버레이 편집 모드용 캔버스 프레임.
  * @param overlay 편집 중인 오버레이
  * @param children 오버레이 내부에 렌더링할 블록 목록
  */
-export function OverlayCanvas({ overlay, children }: { overlay: CMSOverlay; children?: React.ReactNode }) {
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const [containerReady, setContainerReady] = useState(false);
+export function OverlayCanvas({
+  overlay,
+  children,
+}: {
+  overlay: CMSOverlay;
+  children?: React.ReactNode;
+}) {
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const overlayTemplates = useContext(OverlayTemplatesContext);
   const template = overlayTemplates.find((t) => t.type === overlay.type);
   const Renderer = template?.renderer;
-
-  // useLayoutEffect: 브라우저 페인트 전 동기 실행 → 첫 렌더에서도 프레임만 보이는 현상 방지
-  useLayoutEffect(() => {
-    setContainerReady(true);
-  }, []);
 
   if (!Renderer) {
     return (
@@ -44,7 +45,9 @@ export function OverlayCanvas({ overlay, children }: { overlay: CMSOverlay; chil
           className="relative bg-gray-100/80"
           style={{ width: PHONE_FRAME_W, minHeight: CANVAS_MIN_H }}
         >
-          <p className="text-xs text-gray-400 mb-2 px-4 pt-4">오버레이: {overlay.type}</p>
+          <p className="text-xs text-gray-400 mb-2 px-4 pt-4">
+            오버레이: {overlay.type}
+          </p>
           <div className="bg-white rounded-xl shadow p-4">{children}</div>
           <div className="absolute inset-0 rounded-xl shadow-lg border border-gray-200 pointer-events-none" />
         </div>
@@ -65,12 +68,21 @@ export function OverlayCanvas({ overlay, children }: { overlay: CMSOverlay; chil
        */}
       <UserScopeWrapper style={{ display: "contents" }}>
         <div
-          ref={containerRef}
+          ref={setContainer}
           className="relative bg-gray-100/80"
-          style={{ width: PHONE_FRAME_W, minHeight: CANVAS_MIN_H, transform: "translateZ(0)" }}
+          style={{
+            width: PHONE_FRAME_W,
+            minHeight: CANVAS_MIN_H,
+            transform: "translateZ(0)",
+          }}
         >
-          {containerReady && containerRef.current && (
-            <Renderer open onClose={() => {}} container={containerRef.current} props={overlay.props}>
+          {container && (
+            <Renderer
+              open
+              onClose={() => {}}
+              container={container}
+              props={overlay.props}
+            >
               {/* pt-7: Renderer body 안에 overflow가 있을 경우 첫 번째 블록 컨트롤 바(-top-6)가 잘리지 않도록 공간 확보 */}
               <div className="pt-7">{children}</div>
             </Renderer>

--- a/react-cms/src/cms-core/canvas/OverlayCanvas.tsx
+++ b/react-cms/src/cms-core/canvas/OverlayCanvas.tsx
@@ -13,6 +13,8 @@ import { OverlayTemplatesContext } from "../context";
 import { UserScopeWrapper } from "../UserScopeWrapper";
 
 const PHONE_FRAME_W = 390;
+/** 편집 모드에서 오버레이를 닫는 동작은 없으므로 no-op 고정 콜백 사용 — 매 렌더 새 참조 방지 */
+const NOOP = () => {};
 /** CSS 변수로 툴바 높이·패딩 참조 — cms-theme.css의 --cms-toolbar-h, --cms-canvas-pad 값 사용 */
 const CANVAS_MIN_H =
   "calc(100dvh - var(--cms-toolbar-h, 3rem) - var(--cms-canvas-pad, 1.5rem) * 2)";
@@ -38,19 +40,22 @@ export function OverlayCanvas({
     return (
       <div className="p-6 flex justify-center items-start">
         {/*
+         * UserScopeWrapper로 감싸 fallback 상태에서도 children의 CSS 스코핑을 유지한다.
          * overflow-hidden 제거 → 컨트롤 바(-top-6)가 프레임 밖으로 노출.
          * 시각 크롬(border·shadow)은 DOM 마지막의 absolute 오버레이로 표현.
          */}
-        <div
-          className="relative bg-gray-100/80"
-          style={{ width: PHONE_FRAME_W, minHeight: CANVAS_MIN_H }}
-        >
-          <p className="text-xs text-gray-400 mb-2 px-4 pt-4">
-            오버레이: {overlay.type}
-          </p>
-          <div className="bg-white rounded-xl shadow p-4">{children}</div>
-          <div className="absolute inset-0 rounded-xl shadow-lg border border-gray-200 pointer-events-none" />
-        </div>
+        <UserScopeWrapper style={{ display: "contents" }}>
+          <div
+            className="relative bg-gray-100/80"
+            style={{ width: PHONE_FRAME_W, minHeight: CANVAS_MIN_H }}
+          >
+            <p className="text-xs text-gray-400 mb-2 px-4 pt-4">
+              오버레이: {overlay.type}
+            </p>
+            <div className="bg-white rounded-xl shadow p-4">{children}</div>
+            <div className="absolute inset-0 rounded-xl shadow-lg border border-gray-200 pointer-events-none" />
+          </div>
+        </UserScopeWrapper>
       </div>
     );
   }
@@ -79,7 +84,7 @@ export function OverlayCanvas({
           {container && (
             <Renderer
               open
-              onClose={() => {}}
+              onClose={NOOP}
               container={container}
               props={overlay.props}
             >


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #300

## ✨ 변경 사항 (Changes)
`OverlayCanvas`에서 `useLayoutEffect` + `useRef` + `containerReady` 상태 조합을 제거하고, `useState` 콜백 ref 패턴으로 교체합니다.

- `useLayoutEffect` / `useRef<HTMLDivElement>` / `containerReady: boolean` 제거
- `useState<HTMLDivElement | null>(null)` + `ref={setContainer}` 콜백 ref 패턴으로 교체
- `containerReady && containerRef.current` 이중 조건 → `container` 단일 조건으로 단순화
- JSX 인라인 props 다중 줄 포맷팅 개선

## 🛠 기술적 의사결정 (선택)
`useLayoutEffect`로 `containerReady` 플래그를 세우는 기존 방식은 동작하지만, DOM 참조 자체를 state로 관리하면 조건 분기가 하나로 줄고 "DOM이 준비됐을 때만 렌더링"이라는 의도가 더 명확해집니다. React 공식 문서에서도 콜백 ref를 통한 DOM 마운트 감지를 권장합니다.