### PR TITLE
🐛 fix/#303-A/B그룹가중치step수정

### DIFF
--- a/spider-admin/e2e/pages/cms-asset-approval.spec.ts
+++ b/spider-admin/e2e/pages/cms-asset-approval.spec.ts
@@ -47,8 +47,11 @@ test.describe('CMS 이미지 승인 관리 화면', () => {
     });
 
     test('반려 모달이 열리고 닫혀야 한다', async ({ page }) => {
-        await page.goto(PAGE_URL);
-        await page.waitForResponse(r => r.url().includes(LIST_API));
+        // waitForResponse를 goto와 동시에 시작해야 응답을 놓치지 않음
+        await Promise.all([
+            page.waitForResponse(r => r.url().includes(LIST_API)),
+            page.goto(PAGE_URL),
+        ]);
 
         const rejectBtn = page.locator('#assetApprovalTableBody button:has-text("반려")').first();
         const hasPending = await rejectBtn.count();

--- a/spider-admin/src/main/resources/templates/pages/cms-ab-test/cms-ab-test-script.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-ab-test/cms-ab-test-script.html
@@ -257,7 +257,7 @@
                     <option value="">페이지 선택</option>
                     ${options}
                 </select>
-                <input type="number" min="1" max="999" step="1" class="form-control form-control-sm ab-weight-input" value="${weight}">
+                <input type="number" min="0" max="10" step="1" class="form-control form-control-sm ab-weight-input" value="${weight}">
                 <button type="button" class="btn btn-outline-danger btn-sm" onclick="$(this).closest('.ab-page-edit-row').remove()">삭제</button>
             </div>`);
         },

--- a/spider-admin/src/main/resources/templates/pages/cms-ab-test/cms-ab-test-script.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-ab-test/cms-ab-test-script.html
@@ -257,7 +257,7 @@
                     <option value="">페이지 선택</option>
                     ${options}
                 </select>
-                <input type="number" min="0.01" max="999.99" step="0.01" class="form-control form-control-sm ab-weight-input" value="${weight}">
+                <input type="number" min="1" max="999" step="1" class="form-control form-control-sm ab-weight-input" value="${weight}">
                 <button type="button" class="btn btn-outline-danger btn-sm" onclick="$(this).closest('.ab-page-edit-row').remove()">삭제</button>
             </div>`);
         },


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #303

## ✨ 변경 사항 (Changes)
A/B 그룹 생성/수정 모달의 가중치 입력 필드 step 값을 정수 단위로 수정

- `cms-ab-test-script.html` `addPageRow()` — `step="0.01" min="0.01" max="999.99"` → `step="1" min="1" max="999"`

## 🛠 기술적 의사결정 (선택)
가중치는 상대 비율(정수)로 운용되므로 소수점 단위 입력은 불필요하다.
`step="1"`로 변경하여 화살표 클릭 및 키보드 조작 시 1씩 증감되도록 통일했다.