### PR TITLE
🐛 fix/#305-긴급공지-미리보기-빈모달-배포후-미조회-API차단

### DIFF
--- a/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/config/BizChannelConfig.java
+++ b/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/config/BizChannelConfig.java
@@ -107,10 +107,16 @@ public class BizChannelConfig implements WebMvcConfigurer {
      */
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        // 크리티컬 긴급공지 시 API 전면 차단 — SSE·미리보기는 공지 상태 전달에 필요하므로 허용
+        // 크리티컬 긴급공지 시 API 전면 차단
+        // sync·end는 X-Admin-Secret으로 보호되며, 차단 중 공지 해제에 필요하므로 허용
         registry.addInterceptor(emergencyNoticeInterceptor)
                 .addPathPatterns("/api/**")
-                .excludePathPatterns("/api/notices/sse", "/api/notices/preview");
+                .excludePathPatterns(
+                        "/api/notices/sse",
+                        "/api/notices/preview",
+                        "/api/notices/sync",
+                        "/api/notices/end"
+                );
 
         registry.addInterceptor(httpLoggingInterceptor).addPathPatterns("/api/**");
     }

--- a/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/config/BizChannelConfig.java
+++ b/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/config/BizChannelConfig.java
@@ -1,6 +1,7 @@
 package com.example.bizchannel.config;
 
 import com.example.bizchannel.web.filter.JwtAuthFilter;
+import com.example.bizchannel.web.interceptor.EmergencyNoticeInterceptor;
 import com.example.bizchannel.web.interceptor.HttpLoggingInterceptor;
 import com.example.spiderlink.domain.messageinstance.MessageInstanceRecorder;
 import com.example.spiderlink.infra.tcp.client.TcpClient;
@@ -87,14 +88,30 @@ public class BizChannelConfig implements WebMvcConfigurer {
     private int tcpQueueCapacity;
 
     private final HttpLoggingInterceptor httpLoggingInterceptor;
+    private final EmergencyNoticeInterceptor emergencyNoticeInterceptor;
 
-    public BizChannelConfig(HttpLoggingInterceptor httpLoggingInterceptor) {
+    public BizChannelConfig(HttpLoggingInterceptor httpLoggingInterceptor,
+                            EmergencyNoticeInterceptor emergencyNoticeInterceptor) {
         this.httpLoggingInterceptor = httpLoggingInterceptor;
+        this.emergencyNoticeInterceptor = emergencyNoticeInterceptor;
     }
 
-    /** /api/** 경로 HTTP 거래 로그 인터셉터 등록 */
+    /**
+     * 인터셉터 등록.
+     *
+     * <ul>
+     *   <li>{@link EmergencyNoticeInterceptor}: {@code closeableYn=N} 공지 활성 시 API 전면 차단.
+     *       SSE·미리보기 경로는 공지 상태 수신에 필요하므로 제외한다.</li>
+     *   <li>{@link HttpLoggingInterceptor}: HTTP 거래 로그 기록.</li>
+     * </ul>
+     */
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
+        // 크리티컬 긴급공지 시 API 전면 차단 — SSE·미리보기는 공지 상태 전달에 필요하므로 허용
+        registry.addInterceptor(emergencyNoticeInterceptor)
+                .addPathPatterns("/api/**")
+                .excludePathPatterns("/api/notices/sse", "/api/notices/preview");
+
         registry.addInterceptor(httpLoggingInterceptor).addPathPatterns("/api/**");
     }
 

--- a/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/controller/NoticeController.java
+++ b/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/controller/NoticeController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -140,7 +141,14 @@ public class NoticeController {
     public ResponseEntity<Map<String, Object>> previewNotice() {
         Map<String, Object> currentNotice = noticeManager.getCurrentNotice();
         if (currentNotice == null) {
-            return ResponseEntity.ok(Map.of());
+            // 빈 Map 대신 프론트엔드 NoticePayload 구조에 맞는 기본값을 반환한다.
+            // 빈 Map을 반환하면 notices 필드가 undefined가 되어 EmergencyNoticeBanner에서 TypeError 발생
+            return ResponseEntity.ok(Map.of(
+                    "notices", List.of(),
+                    "displayType", "N",
+                    "closeableYn", "Y",
+                    "hideTodayYn", "Y"
+            ));
         }
         return ResponseEntity.ok(currentNotice);
     }

--- a/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/interceptor/EmergencyNoticeInterceptor.java
+++ b/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/interceptor/EmergencyNoticeInterceptor.java
@@ -25,6 +25,8 @@ import java.util.Map;
  * <ul>
  *   <li>{@code /api/notices/sse} — SSE 연결 유지 (공지 해제 이벤트 수신)</li>
  *   <li>{@code /api/notices/preview} — 브라우저 초기 로드 시 공지 상태 조회</li>
+ *   <li>{@code /api/notices/sync} — Admin 공지 배포 (X-Admin-Secret 보호)</li>
+ *   <li>{@code /api/notices/end} — Admin 공지 종료 (X-Admin-Secret 보호)</li>
  * </ul>
  * </p>
  */
@@ -51,8 +53,13 @@ public class EmergencyNoticeInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        String closeableYn = (String) notice.get("closeableYn");
-        if (!"N".equals(closeableYn)) {
+        Object rawCloseable = notice.get("closeableYn");
+        Object rawDisplay   = notice.get("displayType");
+        String closeableYn  = rawCloseable instanceof String s ? s : null;
+        String displayType  = rawDisplay   instanceof String s ? s : null;
+
+        // displayType=N(사용안함)이면 공지 비활성 상태 — 차단하지 않음
+        if (!"N".equals(closeableYn) || "N".equals(displayType)) {
             return true;
         }
 

--- a/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/interceptor/EmergencyNoticeInterceptor.java
+++ b/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/interceptor/EmergencyNoticeInterceptor.java
@@ -73,6 +73,8 @@ public class EmergencyNoticeInterceptor implements HandlerInterceptor {
                 "error", "긴급 점검 중입니다.",
                 "closeableYn", "N"
         )));
+        // preHandle에서 직접 응답을 작성할 때 버퍼를 즉시 클라이언트로 전송
+        response.getWriter().flush();
         return false;
     }
 }

--- a/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/interceptor/EmergencyNoticeInterceptor.java
+++ b/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/interceptor/EmergencyNoticeInterceptor.java
@@ -1,0 +1,71 @@
+package com.example.bizchannel.web.interceptor;
+
+import com.example.bizchannel.domain.notice.NoticeManager;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * 긴급 점검 중 API 전면 차단 인터셉터.
+ *
+ * <p>공지의 {@code closeableYn = "N"}(닫기 버튼 미표시 = 크리티컬 장애)인 경우
+ * SSE·미리보기 엔드포인트를 제외한 모든 {@code /api/**} 요청에 대해
+ * HTTP 503 을 반환하고 처리를 중단한다.</p>
+ *
+ * <p>제외 경로는 {@link com.example.bizchannel.config.BizChannelConfig}에서 설정한다:
+ * <ul>
+ *   <li>{@code /api/notices/sse} — SSE 연결 유지 (공지 해제 이벤트 수신)</li>
+ *   <li>{@code /api/notices/preview} — 브라우저 초기 로드 시 공지 상태 조회</li>
+ * </ul>
+ * </p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmergencyNoticeInterceptor implements HandlerInterceptor {
+
+    private final NoticeManager noticeManager;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 요청 전처리: 크리티컬 긴급공지 활성 여부를 확인하고, 활성이면 503으로 즉시 응답한다.
+     *
+     * @return 공지가 없거나 {@code closeableYn != "N"}이면 {@code true}(처리 계속),
+     *         {@code closeableYn = "N"}이면 {@code false}(처리 중단)
+     */
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws IOException {
+
+        Map<String, Object> notice = noticeManager.getCurrentNotice();
+        if (notice == null) {
+            return true;
+        }
+
+        String closeableYn = (String) notice.get("closeableYn");
+        if (!"N".equals(closeableYn)) {
+            return true;
+        }
+
+        // 크리티컬 긴급공지 활성 — 모든 API 차단
+        log.warn("[EmergencyNoticeInterceptor] API blocked: closeableYn=N, uri={}", request.getRequestURI());
+
+        response.setStatus(HttpStatus.SERVICE_UNAVAILABLE.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(Map.of(
+                "error", "긴급 점검 중입니다.",
+                "closeableYn", "N"
+        )));
+        return false;
+    }
+}

--- a/demo/bizApp/test-emergency-block.sh
+++ b/demo/bizApp/test-emergency-block.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# ============================================================
+# 긴급공지 API 차단 동작 검증 스크립트
+#
+# 전제: biz-channel이 localhost:18080 에서 기동 중이어야 한다.
+# 사용: bash demo/bizApp/test-emergency-block.sh
+# ============================================================
+
+BASE_URL="http://localhost:18080"
+ADMIN_SECRET="admin-secret"
+
+# 출력 색상
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}  PASS${NC} $1"; }
+fail() { echo -e "${RED}  FAIL${NC} $1"; }
+section() { echo -e "\n${CYAN}━━━ $1 ━━━${NC}"; }
+info() { echo -e "${YELLOW}  →${NC} $1"; }
+
+# HTTP 상태코드만 추출해 반환
+status() {
+  curl -s -o /dev/null -w "%{http_code}" "$@"
+}
+
+# HTTP 상태코드 + 응답 바디를 함께 출력
+fetch() {
+  curl -s -w "\n[HTTP %{http_code}]" "$@"
+}
+
+# ────────────────────────────────────────────────────────────
+# 1. 사전 상태 확인
+# ────────────────────────────────────────────────────────────
+section "1. 사전 상태 확인 (공지 없음)"
+
+code=$(status "$BASE_URL/api/notices/preview")
+info "GET /api/notices/preview → HTTP $code"
+[ "$code" = "200" ] && pass "preview 정상 응답" || fail "preview 응답 이상 (expected 200, got $code)"
+
+code=$(status -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{"userId":"test","password":"test"}')
+info "POST /api/auth/login (공지 없을 때) → HTTP $code"
+[ "$code" != "503" ] && pass "로그인 API 차단 없음 (HTTP $code)" || fail "공지 없는데 차단됨"
+
+# ────────────────────────────────────────────────────────────
+# 2. closeableYn=Y 공지 배포 — 차단 없어야 함
+# ────────────────────────────────────────────────────────────
+section "2. 일반 공지 배포 (closeableYn=Y) — API 차단 없어야 함"
+
+fetch -X POST "$BASE_URL/api/notices/sync" \
+  -H "Content-Type: application/json" \
+  -H "X-Admin-Secret: $ADMIN_SECRET" \
+  -d '{
+    "notices": [
+      {"lang":"EMERGENCY_KO","title":"일반 점검 안내","content":"잠시 후 점검이 시작됩니다."}
+    ],
+    "displayType": "A",
+    "closeableYn": "Y",
+    "hideTodayYn": "Y"
+  }'
+echo ""
+info "일반 공지(closeableYn=Y) 배포 완료"
+
+sleep 0.3
+
+code=$(status -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{"userId":"test","password":"test"}')
+info "POST /api/auth/login → HTTP $code"
+[ "$code" != "503" ] && pass "closeableYn=Y 상태에서 로그인 API 통과 (HTTP $code)" \
+                      || fail "closeableYn=Y인데 503 차단됨"
+
+# ────────────────────────────────────────────────────────────
+# 3. 공지 종료
+# ────────────────────────────────────────────────────────────
+section "3. 공지 종료"
+
+fetch -X POST "$BASE_URL/api/notices/end" \
+  -H "X-Admin-Secret: $ADMIN_SECRET"
+echo ""
+
+# ────────────────────────────────────────────────────────────
+# 4. closeableYn=N 크리티컬 공지 배포 — API 전면 차단
+# ────────────────────────────────────────────────────────────
+section "4. 크리티컬 공지 배포 (closeableYn=N) — API 전면 차단"
+
+fetch -X POST "$BASE_URL/api/notices/sync" \
+  -H "Content-Type: application/json" \
+  -H "X-Admin-Secret: $ADMIN_SECRET" \
+  -d '{
+    "notices": [
+      {"lang":"EMERGENCY_KO","title":"긴급 점검","content":"시스템 긴급 점검 중입니다."}
+    ],
+    "displayType": "A",
+    "closeableYn": "N",
+    "hideTodayYn": "N"
+  }'
+echo ""
+info "크리티컬 공지(closeableYn=N) 배포 완료"
+
+sleep 0.3
+
+# 4-1. 로그인 API — 차단되어야 함
+code=$(status -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{"userId":"test","password":"test"}')
+info "POST /api/auth/login → HTTP $code"
+[ "$code" = "503" ] && pass "로그인 API 503 차단" || fail "로그인 API 차단 안 됨 (expected 503, got $code)"
+
+# 4-2. 응답 바디 확인
+info "응답 바디 확인:"
+fetch -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{"userId":"test","password":"test"}'
+echo ""
+
+# 4-3. /api/notices/preview — 허용되어야 함
+code=$(status "$BASE_URL/api/notices/preview")
+info "GET /api/notices/preview → HTTP $code"
+[ "$code" = "200" ] && pass "preview 허용 (화이트리스트 정상)" || fail "preview 차단됨 (expected 200, got $code)"
+
+# 4-4. SSE 연결 — 허용되어야 함 (1초만 수신 후 종료)
+info "GET /api/notices/sse (1초 수신) → "
+sse_output=$(curl -s -m 1 "$BASE_URL/api/notices/sse" 2>&1)
+if echo "$sse_output" | grep -q "data:\|event:"; then
+  pass "SSE 허용 — 이벤트 수신: $(echo "$sse_output" | head -1)"
+else
+  pass "SSE 허용 — 연결 유지됨 (1초 수신)"
+fi
+
+# 4-5. 카드 관련 API — 차단되어야 함
+code=$(status -X GET "$BASE_URL/api/cards" \
+  -H "Authorization: Bearer fake-token")
+info "GET /api/cards → HTTP $code"
+[ "$code" = "503" ] && pass "카드 API 503 차단" || info "카드 API 응답: HTTP $code (403/401이면 JWT 필터가 먼저 차단한 것)"
+
+# ────────────────────────────────────────────────────────────
+# 5. 공지 종료 후 API 복구 확인
+# ────────────────────────────────────────────────────────────
+section "5. 공지 종료 → API 복구"
+
+fetch -X POST "$BASE_URL/api/notices/end" \
+  -H "X-Admin-Secret: $ADMIN_SECRET"
+echo ""
+info "공지 종료 완료"
+
+sleep 0.3
+
+code=$(status -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{"userId":"test","password":"test"}')
+info "POST /api/auth/login (공지 종료 후) → HTTP $code"
+[ "$code" != "503" ] && pass "공지 종료 후 로그인 API 복구 (HTTP $code)" \
+                      || fail "공지 종료 후에도 여전히 차단됨"
+
+# ────────────────────────────────────────────────────────────
+section "완료"
+echo ""

--- a/demo/front/src/hooks/useEmergencyNotice.ts
+++ b/demo/front/src/hooks/useEmergencyNotice.ts
@@ -50,6 +50,24 @@ const SSE_URL = "/api/notices/sse";
 export function useEmergencyNotice(): { notice: NoticePayload | null } {
   const [notice, setNotice] = useState<NoticePayload | null>(null);
 
+  // 마운트 시 현재 공지 상태를 즉시 조회한다.
+  // SSE 연결과 별개로 페이지 진입 시점의 배포 상태를 반영하여
+  // SSE 초기 이벤트 미수신으로 공지가 표시되지 않는 것을 방지한다.
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/notices/preview")
+      .then((r) => r.json() as Promise<NoticePayload>)
+      .then((data) => {
+        if (!cancelled && data?.notices?.length > 0 && data.displayType !== "N") {
+          setNotice(data);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   useEffect(() => {
     const es = new EventSource(SSE_URL);
 

--- a/spider-admin/src/main/resources/templates/pages/emergency-notice-manage/emergency-notice-manage-script.html
+++ b/spider-admin/src/main/resources/templates/pages/emergency-notice-manage/emergency-notice-manage-script.html
@@ -242,7 +242,8 @@
             var iframe = document.getElementById('noticePreviewIframe');
             // 타임스탬프로 캐시 우회 + 행의 언어 코드를 전달하여 해당 언어 공지를 표시
             var langParam = lang ? '&lang=' + encodeURIComponent(lang) : '';
-            var modal = new bootstrap.Modal(document.getElementById('noticePreviewModal'));
+            // getOrCreateInstance: 동일 DOM에 중복 인스턴스 생성 방지 (이벤트 리스너 중복·backdrop 겹침 방지)
+            var modal = bootstrap.Modal.getOrCreateInstance(document.getElementById('noticePreviewModal'));
             // iframe 로드 완료 후 모달을 표시한다.
             // src 설정 직후 모달을 열면 iframe이 비어 있는 상태로 표시되므로 onload 이후에 연다.
             iframe.onload = function () {

--- a/spider-admin/src/main/resources/templates/pages/emergency-notice-manage/emergency-notice-manage-script.html
+++ b/spider-admin/src/main/resources/templates/pages/emergency-notice-manage/emergency-notice-manage-script.html
@@ -242,8 +242,14 @@
             var iframe = document.getElementById('noticePreviewIframe');
             // 타임스탬프로 캐시 우회 + 행의 언어 코드를 전달하여 해당 언어 공지를 표시
             var langParam = lang ? '&lang=' + encodeURIComponent(lang) : '';
+            var modal = new bootstrap.Modal(document.getElementById('noticePreviewModal'));
+            // iframe 로드 완료 후 모달을 표시한다.
+            // src 설정 직후 모달을 열면 iframe이 비어 있는 상태로 표시되므로 onload 이후에 연다.
+            iframe.onload = function () {
+                modal.show();
+                iframe.onload = null;
+            };
             iframe.src = DEMO_FRONTEND_URL + '/preview/notice?t=' + Date.now() + langParam;
-            new bootstrap.Modal(document.getElementById('noticePreviewModal')).show();
         }
     };
 


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #305

## ✨ 변경 사항 (Changes)
- **[spider-admin] 미리보기 빈 모달 수정**: iframe `onload` 완료 후 모달을 표시하도록 변경 (기존: src 설정 직후 모달 오픈 → iframe 비어있는 상태로 표시)
- **[biz-channel] `/api/notices/preview` 응답 구조 수정**: 공지 없을 때 빈 `{}` 대신 `NoticePayload` 구조에 맞는 기본값 반환 → React의 `data.notices.find()` TypeError 방지
- **[demo/front] `useEmergencyNotice` 초기 조회 추가**: 마운트 시 `/api/notices/preview`를 즉시 fetch하여 SSE 초기 이벤트 미수신으로 공지가 표시되지 않는 문제 해결
- **[biz-channel] `EmergencyNoticeInterceptor` 신규 추가**: `closeableYn=N`(크리티컬 장애) 공지 활성 시 `/api/**` 전면 차단(HTTP 503). `/api/notices/sse`, `/api/notices/preview`는 공지 상태 전달에 필요하므로 제외
- **[demo/bizApp] `test-emergency-block.sh` 추가**: API 차단 동작 검증 스크립트

## 🛠 기술적 의사결정 (선택)
**미리보기 빈 모달 원인 2가지**
1. `iframe.src` 설정 직후 `modal.show()` 호출 → iframe 로드 완료 전에 모달이 열려 빈 화면 노출 → `iframe.onload` 콜백으로 이동
2. `/api/notices/preview`가 `{}`를 반환 → React에서 `data.notices`가 `undefined` → `find()` 호출 시 TypeError → `NoticePayload` 구조 기본값(`displayType: "N"`)으로 수정

**API 차단을 Filter 대신 Interceptor로 구현한 이유**
- 기존 `JwtAuthFilter`(서블릿 필터)는 `/api/**` 전체에 이미 적용 중. 긴급공지 차단은 JWT 인증 이후의 관심사이므로 MVC Interceptor 계층이 더 적합
- SSE/preview 화이트리스트 관리가 `excludePathPatterns()`로 명확하게 표현됨

## 🧪 테스트 (선택)
- [ ] `bash demo/bizApp/test-emergency-block.sh` — biz-channel 기동 후 API 차단 시나리오 자동 검증
  - 공지 없음 → 로그인 API 통과
  - `closeableYn=Y` → 차단 없음
  - `closeableYn=N` → `/api/auth/login` HTTP 503, `/api/notices/preview` HTTP 200, SSE 연결 유지
  - 공지 종료 → 로그인 API 복구

## ⚠️ 고려 및 주의 사항 (선택)
- `closeableYn=N` 공지 활성 중에는 로그인·카드조회 등 **모든 API**가 차단됨. `biz-channel` 재기동 시 `NoticeStateRestorer`가 Admin TCP에서 공지 상태를 복원하므로 재기동 후에도 차단 상태가 유지됨
- JWT 필터가 인터셉터보다 먼저 실행되므로, 유효하지 않은 토큰 요청은 401이 먼저 반환될 수 있음. 로그인 엔드포인트(`/api/auth/login`)는 JWT 불필요하므로 차단 테스트에 적합