### PR TITLE
🐛 fix/#309-CMS 페이지 소프트 삭제 버그 수정

### DIFF
--- a/react-cms/src/db/repository/page.repository.ts
+++ b/react-cms/src/db/repository/page.repository.ts
@@ -45,6 +45,7 @@ const SQL_SELECT_LIST = `
            ) AS RN
     FROM SPW_CMS_PAGE
     WHERE PAGE_TYPE = '${PAGE_TYPE}'
+      AND USE_YN = 'Y'
       AND (:search IS NULL OR UPPER(PAGE_NAME) LIKE '%' || UPPER(:search) || '%')
       AND (:approveState IS NULL OR APPROVE_STATE = :approveState)
   )
@@ -55,6 +56,7 @@ const SQL_COUNT = `
   SELECT COUNT(*) AS TOTAL_COUNT
   FROM   SPW_CMS_PAGE
   WHERE  PAGE_TYPE = '${PAGE_TYPE}'
+    AND  USE_YN = 'Y'
     AND  (:search IS NULL OR UPPER(PAGE_NAME) LIKE '%' || UPPER(:search) || '%')
     AND  (:approveState IS NULL OR APPROVE_STATE = :approveState)
 `;

--- a/react-cms/src/db/repository/page.repository.ts
+++ b/react-cms/src/db/repository/page.repository.ts
@@ -30,6 +30,7 @@ const SQL_SELECT_BY_ID = `
   FROM   SPW_CMS_PAGE
   WHERE  PAGE_ID = :pageId
     AND  PAGE_TYPE = '${PAGE_TYPE}'
+    AND  USE_YN = 'Y'
 `;
 
 const SQL_SELECT_LIST = `

--- a/react-cms/src/vite-plugin/cmsBankPlugin.ts
+++ b/react-cms/src/vite-plugin/cmsBankPlugin.ts
@@ -270,7 +270,9 @@ export function cmsBankPlugin(options: CmsBankPluginOptions = {}): Plugin {
               if (existing) {
                 await repo.updatePage({ pageId, pageName: body.pageName, pageJson: body.pageJson, pageCode: body.pageCode, user });
               } else {
-                // 클라이언트가 보낸 pageId가 DB에 없으면 신규 생성
+                // pageId가 DB에 없으면 소프트 삭제된 행이거나 무효 ID — 새 UUID로 신규 생성.
+                // 기존 pageId로 INSERT하면 USE_YN='N' 행과 PK 충돌(ORA-00001)이 발생한다.
+                pageId = uuidv4();
                 await repo.createPage({ pageId, pageName: body.pageName, pageJson: body.pageJson, pageCode: body.pageCode, user });
               }
             } else {

--- a/spider-admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard-script.html
+++ b/spider-admin/src/main/resources/templates/pages/react-cms-dashboard/react-cms-dashboard-script.html
@@ -229,16 +229,6 @@
             this.load();
           },
 
-          reset: function () {
-            $("#filterApproveState").val("");
-            $("#filterSearch").val("");
-            this.sortBy = null;
-            this.sortDirection = null;
-            this.updateSortIndicators();
-            this.itemsPerPage = parseInt($("#limitRows").val()) || 10;
-            this.load(1);
-          },
-
           // ── React CMS 에디터 — 팝업 창으로 열기 ──
           openEditor: function (pageId) {
             window.open(
@@ -360,6 +350,10 @@
               .then((r) => r.json())
               .then((res) => {
                 if (res.success) {
+                  // react-cms 빌더가 저장한 pageName → pageId 캐시 제거.
+                  // 삭제 후 동일 페이지명으로 새 페이지를 만들 때 소프트 삭제된 행을
+                  // UPDATE하는 버그를 방지한다.
+                  localStorage.removeItem("cms_page_id_" + (row.pageName || ""));
                   Toast.success(res.message);
                   this.load();
                 } else {


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #309

## ✨ 변경 사항 (Changes)
소프트 삭제(`USE_YN='N'`)된 CMS 페이지 관련 버그 3건을 수정합니다.

- `page.repository.ts` — `SQL_SELECT_BY_ID` 쿼리에 `AND USE_YN = 'Y'` 조건 추가, 삭제된 페이지 조회 차단
- `cmsBankPlugin.ts` — pageId가 DB에 없을 때(소프트 삭제 행 또는 무효 ID) 새 `uuidv4()` 발급 후 INSERT, 기존 pageId 재사용 시 발생하던 `ORA-00001` PK 충돌 방지
- `react-cms-dashboard-script.html` — 페이지 삭제 성공 후 `localStorage.removeItem("cms_page_id_" + pageName)` 호출, 동일 페이지명 재생성 시 캐시로 인한 오동작 방지

## 🛠 기술적 의사결정 (선택)
소프트 삭제 행이 DB에 남아있는 상태에서 동일 pageId로 INSERT하면 PK 충돌이 발생합니다. UPDATE로 복구하는 대신 새 UUID를 발급하는 방식을 선택했습니다. 삭제된 페이지는 이력으로만 보존하고 새 페이지로 취급하는 것이 의도에 맞기 때문입니다.

## ⚠️ 고려 및 주의 사항 (선택)
- localStorage 키 형식 `cms_page_id_{pageName}` 은 react-cms 빌더 내부 캐시 규칙과 동일하게 맞춤