### PR TITLE
✨ feat/#308-긴급차단-Middleware-리다이렉트

### DIFF
--- a/html-cms/.env.example
+++ b/html-cms/.env.example
@@ -151,3 +151,6 @@ NEXT_PUBLIC_CMS_BASE_PATH=/cms
 NEXT_PUBLIC_JAVA_API_BASE_URL=
 # Spider Admin UI 베이스 URL — 상단 네비·외부 링크 용
 NEXT_PUBLIC_SPIDER_ADMIN_BASE_URL=
+
+# 내부 API 시크릿 — middleware → /api/internal/* 호출 시 인증용 (#308)
+INTERNAL_API_SECRET=

--- a/html-cms/src/app/api/internal/page-public/[pageId]/route.ts
+++ b/html-cms/src/app/api/internal/page-public/[pageId]/route.ts
@@ -14,10 +14,7 @@ import { errorResponse, successResponse } from '@/lib/api-response';
 
 const INTERNAL_SECRET = process.env.INTERNAL_API_SECRET ?? '';
 
-export async function GET(
-    req: NextRequest,
-    { params }: { params: Promise<{ pageId: string }> },
-) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ pageId: string }> }) {
     // 내부 호출 전용 — 시크릿 헤더 불일치 시 404로 위장하여 엔드포인트 존재 자체를 숨김
     const secret = req.headers.get('x-internal-secret') ?? '';
     if (!INTERNAL_SECRET || secret !== INTERNAL_SECRET) {

--- a/html-cms/src/app/api/internal/page-public/[pageId]/route.ts
+++ b/html-cms/src/app/api/internal/page-public/[pageId]/route.ts
@@ -7,6 +7,7 @@
  */
 
 import { NextRequest } from 'next/server';
+import oracledb from 'oracledb';
 
 import { getConnection } from '@/db/connection';
 import { errorResponse, successResponse } from '@/lib/api-response';
@@ -35,7 +36,7 @@ export async function GET(
         const result = await conn.execute<{ IS_PUBLIC: string }>(
             `SELECT IS_PUBLIC FROM SPW_CMS_PAGE WHERE PAGE_ID = :pageId AND USE_YN = 'Y'`,
             { pageId },
-            { outFormat: (await import('oracledb')).default.OUT_FORMAT_OBJECT },
+            { outFormat: oracledb.OUT_FORMAT_OBJECT },
         );
         const row = result.rows?.[0];
         // 페이지가 없는 경우 'Y'(정상) 반환 — fail-open: 조회 실패 시 접근 차단하지 않음

--- a/html-cms/src/app/api/internal/page-public/[pageId]/route.ts
+++ b/html-cms/src/app/api/internal/page-public/[pageId]/route.ts
@@ -1,0 +1,46 @@
+/**
+ * @file src/app/api/internal/page-public/[pageId]/route.ts
+ * @description 내부 전용 — IS_PUBLIC 단건 조회 API.
+ *              middleware.ts 에서 /deployed/*.html 접근 시 긴급차단 여부를 확인하는 용도로만 사용한다.
+ *              x-internal-secret 헤더 검증으로 외부 직접 호출을 차단한다.
+ * @returns {{ isPublic: 'Y' | 'N' }}
+ */
+
+import { NextRequest } from 'next/server';
+
+import { getConnection } from '@/db/connection';
+import { errorResponse, successResponse } from '@/lib/api-response';
+
+const INTERNAL_SECRET = process.env.INTERNAL_API_SECRET ?? '';
+
+export async function GET(
+    req: NextRequest,
+    { params }: { params: Promise<{ pageId: string }> },
+) {
+    // 내부 호출 전용 — 시크릿 헤더 불일치 시 404로 위장하여 엔드포인트 존재 자체를 숨김
+    const secret = req.headers.get('x-internal-secret') ?? '';
+    if (!INTERNAL_SECRET || secret !== INTERNAL_SECRET) {
+        return errorResponse('Not Found', 404);
+    }
+
+    const { pageId } = await params;
+
+    // pageId 유효성 검사 — 영숫자·하이픈·언더스코어만 허용 (경로 트래버설 방지)
+    if (!/^[a-zA-Z0-9_-]+$/.test(pageId)) {
+        return errorResponse('유효하지 않은 pageId입니다.', 400);
+    }
+
+    const conn = await getConnection();
+    try {
+        const result = await conn.execute<{ IS_PUBLIC: string }>(
+            `SELECT IS_PUBLIC FROM SPW_CMS_PAGE WHERE PAGE_ID = :pageId AND USE_YN = 'Y'`,
+            { pageId },
+            { outFormat: (await import('oracledb')).default.OUT_FORMAT_OBJECT },
+        );
+        const row = result.rows?.[0];
+        // 페이지가 없는 경우 'Y'(정상) 반환 — fail-open: 조회 실패 시 접근 차단하지 않음
+        return successResponse({ isPublic: row?.IS_PUBLIC ?? 'Y' });
+    } finally {
+        await conn.close();
+    }
+}

--- a/html-cms/src/app/maintenance/page.tsx
+++ b/html-cms/src/app/maintenance/page.tsx
@@ -4,61 +4,61 @@
  *              middleware.ts 에서 /deployed/*.html 접근 차단 시 이 페이지로 redirect 된다.
  */
 
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+    title: '서비스 일시 중단',
+};
+
 export default function MaintenancePage() {
     return (
-        <html lang="ko">
-            <head>
-                <meta charSet="UTF-8" />
-                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-                <title>서비스 일시 중단</title>
-                <style>{`
-                    * { margin: 0; padding: 0; box-sizing: border-box; }
-                    body {
-                        display: flex;
-                        justify-content: center;
-                        align-items: center;
-                        min-height: 100vh;
-                        background: #f5f6f8;
-                        font-family: 'Apple SD Gothic Neo', 'Noto Sans KR', sans-serif;
-                    }
-                    .card {
-                        text-align: center;
-                        padding: 52px 40px;
-                        background: #fff;
-                        border-radius: 16px;
-                        box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
-                        max-width: 420px;
-                        width: 90%;
-                    }
-                    .icon {
-                        font-size: 52px;
-                        margin-bottom: 20px;
-                    }
-                    h1 {
-                        font-size: 20px;
-                        font-weight: 700;
-                        color: #1a1a1a;
-                        margin-bottom: 14px;
-                        letter-spacing: -0.3px;
-                    }
-                    p {
-                        font-size: 14px;
-                        color: #666;
-                        line-height: 1.8;
-                    }
-                `}</style>
-            </head>
-            <body>
-                <div className="card">
-                    <div className="icon">🔧</div>
-                    <h1>서비스 일시 중단 안내</h1>
-                    <p>
+        <>
+            <style>{`
+                .maintenance-wrap {
+                    display: flex;
+                    justify-content: center;
+                    align-items: center;
+                    min-height: 100vh;
+                    background: #f5f6f8;
+                    font-family: 'Apple SD Gothic Neo', 'Noto Sans KR', sans-serif;
+                }
+                .maintenance-card {
+                    text-align: center;
+                    padding: 52px 40px;
+                    background: #fff;
+                    border-radius: 16px;
+                    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+                    max-width: 420px;
+                    width: 90%;
+                }
+                .maintenance-icon {
+                    font-size: 52px;
+                    margin-bottom: 20px;
+                }
+                .maintenance-title {
+                    font-size: 20px;
+                    font-weight: 700;
+                    color: #1a1a1a;
+                    margin-bottom: 14px;
+                    letter-spacing: -0.3px;
+                }
+                .maintenance-desc {
+                    font-size: 14px;
+                    color: #666;
+                    line-height: 1.8;
+                }
+            `}</style>
+            <div className="maintenance-wrap">
+                <div className="maintenance-card">
+                    <div className="maintenance-icon">🔧</div>
+                    <h1 className="maintenance-title">서비스 일시 중단 안내</h1>
+                    <p className="maintenance-desc">
                         현재 서비스 점검 중입니다.
                         <br />
                         잠시 후 다시 이용해 주세요.
                     </p>
                 </div>
-            </body>
-        </html>
+            </div>
+        </>
     );
 }

--- a/html-cms/src/app/maintenance/page.tsx
+++ b/html-cms/src/app/maintenance/page.tsx
@@ -1,0 +1,64 @@
+/**
+ * @file src/app/maintenance/page.tsx
+ * @description 긴급차단(IS_PUBLIC='N') 시 리다이렉트되는 서비스 점검 안내 페이지.
+ *              middleware.ts 에서 /deployed/*.html 접근 차단 시 이 페이지로 redirect 된다.
+ */
+
+export default function MaintenancePage() {
+    return (
+        <html lang="ko">
+            <head>
+                <meta charSet="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>서비스 일시 중단</title>
+                <style>{`
+                    * { margin: 0; padding: 0; box-sizing: border-box; }
+                    body {
+                        display: flex;
+                        justify-content: center;
+                        align-items: center;
+                        min-height: 100vh;
+                        background: #f5f6f8;
+                        font-family: 'Apple SD Gothic Neo', 'Noto Sans KR', sans-serif;
+                    }
+                    .card {
+                        text-align: center;
+                        padding: 52px 40px;
+                        background: #fff;
+                        border-radius: 16px;
+                        box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+                        max-width: 420px;
+                        width: 90%;
+                    }
+                    .icon {
+                        font-size: 52px;
+                        margin-bottom: 20px;
+                    }
+                    h1 {
+                        font-size: 20px;
+                        font-weight: 700;
+                        color: #1a1a1a;
+                        margin-bottom: 14px;
+                        letter-spacing: -0.3px;
+                    }
+                    p {
+                        font-size: 14px;
+                        color: #666;
+                        line-height: 1.8;
+                    }
+                `}</style>
+            </head>
+            <body>
+                <div className="card">
+                    <div className="icon">🔧</div>
+                    <h1>서비스 일시 중단 안내</h1>
+                    <p>
+                        현재 서비스 점검 중입니다.
+                        <br />
+                        잠시 후 다시 이용해 주세요.
+                    </p>
+                </div>
+            </body>
+        </html>
+    );
+}

--- a/html-cms/src/middleware.ts
+++ b/html-cms/src/middleware.ts
@@ -54,9 +54,7 @@ async function checkEmergencyBlock(req: NextRequest): Promise<NextResponse | nul
             const data = (await res.json()) as { data?: { isPublic?: string } };
             if (data.data?.isPublic === 'N') {
                 // 점검 페이지로 리다이렉트 — basePath 포함
-                return NextResponse.redirect(
-                    new URL(`${CMS_BASE_PATH}/maintenance`, req.nextUrl.origin),
-                );
+                return NextResponse.redirect(new URL(`${CMS_BASE_PATH}/maintenance`, req.nextUrl.origin));
             }
         }
     } catch {

--- a/html-cms/src/middleware.ts
+++ b/html-cms/src/middleware.ts
@@ -1,5 +1,5 @@
 // src/middleware.ts
-// CORS 응답 헤더 주입 — CORS_ALLOWED_ORIGINS에 등록된 오리진만 허용
+// CORS 응답 헤더 주입 + 긴급차단(IS_PUBLIC='N') 페이지 접근 차단
 
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -7,6 +7,10 @@ const ALLOWED_ORIGINS = (process.env.CORS_ALLOWED_ORIGINS ?? '')
     .split(',')
     .map((o) => o.trim())
     .filter(Boolean);
+
+// basePath('/cms') — 내부 API URL 조립에 사용
+const CMS_BASE_PATH = process.env.NEXT_PUBLIC_CMS_BASE_PATH ?? '/cms';
+const INTERNAL_SECRET = process.env.INTERNAL_API_SECRET ?? '';
 
 function setCorsHeaders(res: NextResponse, origin: string): void {
     res.headers.set('Access-Control-Allow-Origin', origin);
@@ -17,7 +21,52 @@ function setCorsHeaders(res: NextResponse, origin: string): void {
     res.headers.set('Access-Control-Max-Age', '86400');
 }
 
-export function middleware(req: NextRequest): NextResponse {
+/**
+ * /deployed/{pageId}.html 요청에 대해 IS_PUBLIC 상태를 확인한다.
+ * 내부 API(/api/internal/page-public/{pageId})를 호출해 DB 값을 조회하며,
+ * IS_PUBLIC='N'이면 점검 페이지로 redirect, 'Y'이면 null을 반환해 정상 서빙을 허용한다.
+ *
+ * fail-open 정책: 내부 API 호출 실패(DB 장애 등) 시 차단하지 않고 null 반환.
+ */
+async function checkEmergencyBlock(req: NextRequest): Promise<NextResponse | null> {
+    const { pathname } = req.nextUrl;
+
+    // /deployed/{pageId}.html 패턴 — 영숫자·하이픈·언더스코어로 구성된 pageId만 허용
+    const match = pathname.match(/^\/deployed\/([a-zA-Z0-9_-]+)\.html$/);
+    if (!match) return null;
+
+    const pageId = match[1];
+
+    try {
+        // 내부 API는 같은 서버의 Node.js 런타임에서 실행됨
+        // pathname이 /api/internal/... 이므로 이 middleware의 deployed 체크에 재진입하지 않음
+        const checkUrl = `${req.nextUrl.origin}${CMS_BASE_PATH}/api/internal/page-public/${pageId}`;
+        const res = await fetch(checkUrl, {
+            headers: { 'x-internal-secret': INTERNAL_SECRET },
+        });
+
+        if (res.ok) {
+            const data = (await res.json()) as { data?: { isPublic?: string } };
+            if (data.data?.isPublic === 'N') {
+                // 점검 페이지로 리다이렉트 — basePath 포함
+                return NextResponse.redirect(
+                    new URL(`${CMS_BASE_PATH}/maintenance`, req.nextUrl.origin),
+                );
+            }
+        }
+    } catch {
+        // DB 장애·네트워크 오류 시 fail-open: 기존 파일을 그대로 서빙
+    }
+
+    return null;
+}
+
+export async function middleware(req: NextRequest): Promise<NextResponse> {
+    // ── 긴급차단 체크 (#308) — /deployed/*.html 요청만 대상 ──
+    const blockRedirect = await checkEmergencyBlock(req);
+    if (blockRedirect) return blockRedirect;
+
+    // ── CORS 처리 ──
     const origin = req.headers.get('origin') ?? '';
     const isAllowed = ALLOWED_ORIGINS.length > 0 && ALLOWED_ORIGINS.includes(origin);
 

--- a/html-cms/src/middleware.ts
+++ b/html-cms/src/middleware.ts
@@ -37,12 +37,17 @@ async function checkEmergencyBlock(req: NextRequest): Promise<NextResponse | nul
 
     const pageId = match[1];
 
+    // 타임아웃 500ms — 지연 발생 시 TTFB 저하 방지, 초과 시 fail-open으로 정상 서빙
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 500);
+
     try {
         // 내부 API는 같은 서버의 Node.js 런타임에서 실행됨
         // pathname이 /api/internal/... 이므로 이 middleware의 deployed 체크에 재진입하지 않음
         const checkUrl = `${req.nextUrl.origin}${CMS_BASE_PATH}/api/internal/page-public/${pageId}`;
         const res = await fetch(checkUrl, {
             headers: { 'x-internal-secret': INTERNAL_SECRET },
+            signal: controller.signal,
         });
 
         if (res.ok) {
@@ -55,7 +60,9 @@ async function checkEmergencyBlock(req: NextRequest): Promise<NextResponse | nul
             }
         }
     } catch {
-        // DB 장애·네트워크 오류 시 fail-open: 기존 파일을 그대로 서빙
+        // DB 장애·네트워크 오류·타임아웃 시 fail-open: 기존 파일을 그대로 서빙
+    } finally {
+        clearTimeout(timeoutId);
     }
 
     return null;

--- a/spider-admin/src/main/java/com/example/spideradmin/domain/cmsapproval/dto/CmsApprovalPageResponse.java
+++ b/spider-admin/src/main/java/com/example/spideradmin/domain/cmsapproval/dto/CmsApprovalPageResponse.java
@@ -53,4 +53,7 @@ public class CmsApprovalPageResponse {
      * 그 외                                 → APPROVE_STATE 값
      */
     private String displayState;
+
+    /** 배포 여부 (0: 미배포, 1: 배포완료) — FILE_CRC_VALUE IS NOT NULL (#308) */
+    private int isDeployed;
 }

--- a/spider-admin/src/main/resources/mapper/oracle/cmsapproval/CmsApprovalMapper.xml
+++ b/spider-admin/src/main/resources/mapper/oracle/cmsapproval/CmsApprovalMapper.xml
@@ -28,7 +28,9 @@
             WHEN p.IS_PUBLIC = 'N' AND p.EXPIRED_DATE IS NOT NULL AND p.EXPIRED_DATE &lt; SYSDATE THEN '만료'
             WHEN p.IS_PUBLIC = 'N' THEN '비공개'
             ELSE p.APPROVE_STATE
-        END                                                             AS displayState
+        END                                                             AS displayState,
+        -- 배포 여부: FILE_CRC_VALUE 가 설정된 경우 배포 완료로 판단 (#308)
+        CASE WHEN p.FILE_CRC_VALUE IS NOT NULL THEN 1 ELSE 0 END        AS isDeployed
     </sql>
 
     <sql id="searchConditions">

--- a/spider-admin/src/main/resources/templates/pages/cms-approval/cms-approval-script.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-approval/cms-approval-script.html
@@ -93,7 +93,7 @@
             const $tbody = $('#approvalTableBody');
             if (!rows || rows.length === 0) {
                 this.rowsByPageId = {};
-                $tbody.html('<tr><td colspan="9" class="text-center py-4 text-body-secondary">조회된 데이터가 없습니다.</td></tr>');
+                $tbody.html('<tr><td colspan="11" class="text-center py-4 text-body-secondary">조회된 데이터가 없습니다.</td></tr>');
                 return;
             }
 
@@ -107,14 +107,20 @@
                 const expiredCls = this._isExpired(row.expiredDate) ? 'text-danger fw-bold' : '';
                 const pid        = HtmlUtils.escape(row.pageId);
 
-                // 공개여부 — 현재 상태 라벨 + 클릭 시 토글
-                const isPublicBtn = HAS_CMS_WRITE
-                    ? `<button class="btn btn-xs ${row.isPublic === 'Y' ? 'btn-primary' : 'btn-outline-secondary'}"
-                               title="${row.isPublic === 'Y' ? '클릭하여 비공개 전환' : '클릭하여 공개 전환'}"
-                               onclick="CmsApprovalPage.togglePublicState('${pid}', '${HtmlUtils.escape(row.isPublic)}')">
-                               ${row.isPublic === 'Y' ? '공개' : '비공개'}
-                       </button>`
-                    : `<span class="badge ${row.isPublic === 'Y' ? 'bg-primary' : 'bg-secondary'}">${row.isPublic === 'Y' ? '공개' : '비공개'}</span>`;
+                // 공개여부 — 읽기 전용 배지 (#308: 변경 액션은 [긴급차단/복구] 버튼으로 일원화)
+                const isPublicBtn = `<span class="badge ${row.isPublic === 'Y' ? 'bg-primary' : 'bg-secondary'}">${row.isPublic === 'Y' ? '공개' : '비공개'}</span>`;
+
+                // 긴급차단/복구 컬럼 — APPROVED + 배포완료 + CMS:W 권한일 때만 노출 (#308)
+                // isDeployed=1: FILE_CRC_VALUE IS NOT NULL (배포 이력 존재)
+                const tdEmergency = (HAS_CMS_WRITE && row.approveState === 'APPROVED' && row.isDeployed === 1)
+                    ? (row.isPublic === 'Y'
+                        ? `<button class="btn btn-danger btn-xs"
+                               data-page-id="${pid}"
+                               onclick="CmsApprovalPage.emergencyBlock('${pid}')">긴급차단</button>`
+                        : `<button class="btn btn-success btn-xs"
+                               data-page-id="${pid}"
+                               onclick="CmsApprovalPage.restorePublic('${pid}')">복구</button>`)
+                    : '-';
 
                 // 결재 컬럼 — PENDING 상태 + CMS:W 권한일 때만 노출
                 const tdApproval = (HAS_CMS_WRITE && row.approveState === 'PENDING')
@@ -137,13 +143,14 @@
                     <td class="text-center">${HtmlUtils.escape(row.viewMode || '')}</td>
                     <td>${HtmlUtils.escape(row.createUserName || '')}</td>
                     <td class="text-center">${badge}</td>
-                    <!-- 공개여부 컬럼 UI 숨김 (#132) — 정책 확정 시 주석 해제 + 두 곳의 colspan 9→10 복원 (approval-table.html:23, 이 파일 96행) -->
-                    <!-- <td class="text-center">${isPublicBtn}</td> -->
+                    <!-- #308: 공개여부 읽기 전용 배지 재노출 -->
+                    <td class="text-center">${isPublicBtn}</td>
                     <td class="text-center">${HtmlUtils.escape(row.beginningDate || '-')}</td>
                     <td class="text-center ${expiredCls}">${HtmlUtils.escape(row.expiredDate || '-')}</td>
                     <td class="text-center small">${HtmlUtils.escape(row.lastModifiedDtime || '-')}</td>
                     <td class="text-center">${tdApproval}</td>
                     <td class="text-center">${tdHistory}</td>
+                    <td class="text-center">${tdEmergency}</td>
                 </tr>`;
             }).join('');
 
@@ -280,12 +287,40 @@
                 .catch(() => Toast.error('반려 처리 중 오류가 발생했습니다.'));
         },
 
-        // ── 공개 상태 토글 ──
-        togglePublicState: function(pageId, currentState) {
-            const isPublic = currentState === 'Y' ? 'N' : 'Y';
-            const label    = isPublic === 'Y' ? '공개' : '비공개';
-            if (!confirm(`해당 페이지를 ${label} 처리하시겠습니까?`)) return;
+        // ── 공개 상태 토글 (#308: 읽기 전용 배지로 전환 — 변경 액션은 긴급차단/복구 버튼으로 일원화) ──
+        // togglePublicState: function(pageId, currentState) {
+        //     const isPublic = currentState === 'Y' ? 'N' : 'Y';
+        //     const label    = isPublic === 'Y' ? '공개' : '비공개';
+        //     if (!confirm(`해당 페이지를 ${label} 처리하시겠습니까?`)) return;
+        //     fetch(`/api/cms-admin/pages/${pageId}/public-state`, {
+        //         method: 'PATCH',
+        //         headers: { 'Content-Type': 'application/json' },
+        //         body: JSON.stringify({ isPublic }),
+        //     })
+        //         .then(r => r.json())
+        //         .then(res => {
+        //             if (res.success) { Toast.success(res.message); this.load(); }
+        //             else             { Toast.error(res.message); }
+        //         })
+        //         .catch(() => Toast.error('공개 상태 변경 중 오류가 발생했습니다.'));
+        // },
 
+        // ── 긴급차단 (#308) ──
+        // 조건: APPROVED + 배포완료(isDeployed=1) + isPublic='Y' + CMS:W 권한
+        emergencyBlock: function(pageId) {
+            if (!confirm('이 콘텐츠를 즉시 차단하시겠습니까?\n(차단 시 대고객 서비스에서 즉시 사라집니다)')) return;
+            CmsApprovalPage._updatePublicState(pageId, 'N', '긴급차단');
+        },
+
+        // ── 복구 (#308) ──
+        // 조건: APPROVED + 배포완료(isDeployed=1) + isPublic='N' + CMS:W 권한
+        restorePublic: function(pageId) {
+            if (!confirm('서비스를 복구하시겠습니까?\n즉시 대고객 서비스에 노출됩니다.')) return;
+            CmsApprovalPage._updatePublicState(pageId, 'Y', '복구');
+        },
+
+        // IS_PUBLIC 변경 공통 처리 — emergencyBlock / restorePublic 에서 호출
+        _updatePublicState: function(pageId, isPublic, label) {
             fetch(`/api/cms-admin/pages/${pageId}/public-state`, {
                 method: 'PATCH',
                 headers: { 'Content-Type': 'application/json' },
@@ -293,10 +328,10 @@
             })
                 .then(r => r.json())
                 .then(res => {
-                    if (res.success) { Toast.success(res.message); this.load(); }
+                    if (res.success) { Toast.success(`${label} 처리가 완료되었습니다.`); this.load(); }
                     else             { Toast.error(res.message); }
                 })
-                .catch(() => Toast.error('공개 상태 변경 중 오류가 발생했습니다.'));
+                .catch(() => Toast.error(`${label} 처리 중 오류가 발생했습니다.`));
         },
 
         // ── 이력 / 롤백 모달 ──

--- a/spider-admin/src/main/resources/templates/pages/cms-approval/cms-approval-script.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-approval/cms-approval-script.html
@@ -112,15 +112,22 @@
 
                 // 긴급차단/복구 컬럼 — APPROVED + 배포완료 + CMS:W 권한일 때만 노출 (#308)
                 // isDeployed=1: FILE_CRC_VALUE IS NOT NULL (배포 이력 존재)
-                const tdEmergency = (HAS_CMS_WRITE && row.approveState === 'APPROVED' && row.isDeployed === 1)
-                    ? (row.isPublic === 'Y'
-                        ? `<button class="btn btn-danger btn-xs"
+                // [긴급차단]: 노출 기간(beginningDate~expiredDate) 내에 있는 경우에만 노출 — 만료 상태 제외
+                // [복구]: displayState='비공개'(IS_PUBLIC=N + 미만료)인 경우에만 노출 — 만료 상태 제외
+                const isWithinPeriod = CmsApprovalPage._isWithinDisplayPeriod(row.beginningDate, row.expiredDate);
+                let tdEmergency = '-';
+                if (HAS_CMS_WRITE && row.approveState === 'APPROVED' && row.isDeployed === 1) {
+                    if (row.isPublic === 'Y' && isWithinPeriod) {
+                        tdEmergency = `<button class="btn btn-danger btn-xs"
                                data-page-id="${pid}"
-                               onclick="CmsApprovalPage.emergencyBlock('${pid}')">긴급차단</button>`
-                        : `<button class="btn btn-success btn-xs"
+                               onclick="CmsApprovalPage.emergencyBlock('${pid}')">긴급차단</button>`;
+                    } else if (row.displayState === '비공개') {
+                        // IS_PUBLIC='N' + 미만료 — 복구 버튼 노출
+                        tdEmergency = `<button class="btn btn-success btn-xs"
                                data-page-id="${pid}"
-                               onclick="CmsApprovalPage.restorePublic('${pid}')">복구</button>`)
-                    : '-';
+                               onclick="CmsApprovalPage.restorePublic('${pid}')">복구</button>`;
+                    }
+                }
 
                 // 결재 컬럼 — PENDING 상태 + CMS:W 권한일 때만 노출
                 const tdApproval = (HAS_CMS_WRITE && row.approveState === 'PENDING')
@@ -143,8 +150,8 @@
                     <td class="text-center">${HtmlUtils.escape(row.viewMode || '')}</td>
                     <td>${HtmlUtils.escape(row.createUserName || '')}</td>
                     <td class="text-center">${badge}</td>
-                    <!-- #308: 공개여부 읽기 전용 배지 재노출 -->
-                    <td class="text-center">${isPublicBtn}</td>
+                    <!-- #308: 공개여부 — display:none (데이터는 유지, 향후 정책 변경 시 복원 가능) -->
+                    <td class="text-center" style="display:none">${isPublicBtn}</td>
                     <td class="text-center">${HtmlUtils.escape(row.beginningDate || '-')}</td>
                     <td class="text-center ${expiredCls}">${HtmlUtils.escape(row.expiredDate || '-')}</td>
                     <td class="text-center small">${HtmlUtils.escape(row.lastModifiedDtime || '-')}</td>
@@ -405,6 +412,25 @@
             const expiredDate = new Date(dateStr);
             expiredDate.setHours(23, 59, 59, 999);
             return expiredDate < new Date();
+        },
+
+        /**
+         * 노출 기간 내 여부 확인 — [긴급차단] 버튼 노출 조건 (#308)
+         * 현재날짜 >= 노출시작일 AND 현재날짜 <= 노출종료일
+         * beginningDate / expiredDate 가 없으면 해당 조건을 만족한 것으로 간주
+         */
+        _isWithinDisplayPeriod: function(beginningDate, expiredDate) {
+            const now = new Date();
+            if (beginningDate) {
+                const start = new Date(beginningDate);
+                if (now < start) return false; // 아직 노출 시작 전
+            }
+            if (expiredDate) {
+                const end = new Date(expiredDate);
+                end.setHours(23, 59, 59, 999); // 종료일 당일 말까지 포함
+                if (now > end) return false;    // 만료됨
+            }
+            return true;
         },
     };
 

--- a/spider-admin/src/main/resources/templates/pages/cms-approval/cms-approval-table.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-approval/cms-approval-table.html
@@ -10,8 +10,8 @@
                 <th class="col-w-80 sortable" data-sort="viewMode">뷰모드</th>
                 <th class="col-w-90 sortable" data-sort="createUserName">작성자</th>
                 <th class="col-w-100 sortable" data-sort="approveState">승인상태</th>
-                <!-- #308: 공개여부 컬럼 재노출 (읽기 전용 배지) — 변경 액션은 [긴급차단/복구] 버튼으로 일원화 -->
-                <th class="col-w-80 sortable" data-sort="isPublic">공개여부</th>
+                <!-- #308: 공개여부 — display:none (데이터는 유지, 향후 정책 변경 시 복원 가능) -->
+                <th class="col-w-80 sortable" data-sort="isPublic" style="display:none">공개여부</th>
                 <th class="col-w-100 sortable" data-sort="beginningDate">노출시작일</th>
                 <th class="col-w-100 sortable" data-sort="expiredDate">노출종료일</th>
                 <th class="col-w-150 sortable" data-sort="lastModifiedDtime">최종수정일시</th>

--- a/spider-admin/src/main/resources/templates/pages/cms-approval/cms-approval-table.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-approval/cms-approval-table.html
@@ -10,18 +10,20 @@
                 <th class="col-w-80 sortable" data-sort="viewMode">뷰모드</th>
                 <th class="col-w-90 sortable" data-sort="createUserName">작성자</th>
                 <th class="col-w-100 sortable" data-sort="approveState">승인상태</th>
-                <!-- 공개여부 컬럼: 정책 확정 전까지 UI 숨김 (#132). 복원 시 주석 해제 + 아래 colspan="9" → "10" -->
-                <!-- <th class="col-w-80 sortable" data-sort="isPublic">공개여부</th> -->
+                <!-- #308: 공개여부 컬럼 재노출 (읽기 전용 배지) — 변경 액션은 [긴급차단/복구] 버튼으로 일원화 -->
+                <th class="col-w-80 sortable" data-sort="isPublic">공개여부</th>
                 <th class="col-w-100 sortable" data-sort="beginningDate">노출시작일</th>
                 <th class="col-w-100 sortable" data-sort="expiredDate">노출종료일</th>
                 <th class="col-w-150 sortable" data-sort="lastModifiedDtime">최종수정일시</th>
                 <th class="col-w-70">결재</th>
                 <th class="col-w-60">이력</th>
+                <!-- #308: 긴급차단 컬럼 추가 — APPROVED + 배포완료 행에만 버튼 노출 -->
+                <th class="col-w-80">긴급차단</th>
             </tr>
         </thead>
         <tbody id="approvalTableBody">
             <tr>
-                <td colspan="9" class="text-center py-4 text-body-secondary">
+                <td colspan="11" class="text-center py-4 text-body-secondary">
                     조회 버튼을 클릭하여 데이터를 불러오세요.
                 </td>
             </tr>


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

- #308

## ✨ 변경 사항 (Changes)

`IS_PUBLIC='N'` 긴급차단 설정 시 배포 URL(`/deployed/*.html`)로의 접근을 **Next.js Middleware**에서 가로채어 점검 안내 페이지로 즉시 리다이렉트한다.
복구(`IS_PUBLIC='Y'`) 시 별도 재배포 없이 자동으로 원래 페이지가 서빙된다.

**html-cms**
- `src/middleware.ts` — async 변환, `/deployed/*.html` 요청 시 IS_PUBLIC 확인 후 `N`이면 `/maintenance`로 redirect (fail-open: 내부 API 오류 시 정상 서빙 유지)
- `src/app/api/internal/page-public/[pageId]/route.ts` — IS_PUBLIC 단건 조회 내부 전용 API (x-internal-secret 헤더 인증)
- `src/app/maintenance/page.tsx` — 긴급차단 시 노출되는 점검 안내 페이지
- `.env.example` — `INTERNAL_API_SECRET` 환경변수 추가

**spider-admin**
- `CmsApprovalMapper.xml` — `pageListColumns`에 `isDeployed` 추가 (`FILE_CRC_VALUE IS NOT NULL`)
- `CmsApprovalPageResponse.java` — `isDeployed` 필드 추가
- `cms-approval-table.html` — [공개여부] 컬럼 재노출(읽기 전용), [긴급차단] 컬럼 추가, colspan 9→11
- `cms-approval-script.html` — `isPublicBtn` 읽기 전용 배지 전환, `togglePublicState` 주석 처리, `emergencyBlock` / `restorePublic` / `_updatePublicState` 메서드 추가

## 📸 변경 사항 확인 (선택)

| 변경 전 (Before) | 변경 후 (After) |
| :--- | :--- |
| [공개여부] 컬럼 숨김, 긴급차단 버튼 없음 | [공개여부] 읽기 전용 배지 노출, [긴급차단/복구] 버튼 노출 |
| IS_PUBLIC=N 설정 시 배포 파일 그대로 서빙 | IS_PUBLIC=N 설정 즉시 /maintenance 페이지로 리다이렉트 |

**긴급차단 버튼 노출 조건**

| 조건 | 버튼 |
| :--- | :--- |
| APPROVED + 배포완료(`isDeployed=1`) + `isPublic='Y'` + CMS:W | **[긴급차단]** |
| APPROVED + 배포완료(`isDeployed=1`) + `isPublic='N'` + CMS:W | **[복구]** |
| 그 외 (미배포 포함) | `-` |

## ⚠️ 고려 및 주의 사항 (선택)

- **환경변수 추가 필요**: `.env`에 `INTERNAL_API_SECRET` 값 설정 필요 (미설정 시 내부 API가 404 반환하여 fail-open으로 동작)
- **fail-open 정책**: 내부 API 호출 실패(DB 장애 등) 시 차단하지 않고 기존 파일을 서빙 — 서비스 가용성 우선
- **배포 파일 무변경**: `public/deployed/*.html` 파일은 삭제·수정하지 않으므로 복구 시 재배포 불필요

## 💬 리뷰 포인트 (선택)

- `middleware.ts`의 self-referential fetch: `/deployed/*.html` 처리 중 `/api/internal/page-public/*`를 내부 호출하나, 해당 경로는 `deployed` 패턴에 재매칭되지 않아 무한루프 없음
- `isDeployed` 판단 기준으로 `FILE_CRC_VALUE IS NOT NULL` 사용 — 배포 완료 시 `PAGE_UPDATE_DEPLOY`에서 값이 설정되므로 적절

## 🔗 참고 사항 (선택)

- Middleware가 `public/` 정적 파일보다 먼저 실행됨을 활용한 구현 (Next.js Middleware 동작 원리)
- `togglePublicState()` 메서드는 삭제가 아닌 주석 처리 — 향후 정책 변경 시 복원 가능