### PR TITLE
🎨 style/#308-긴급차단-컬럼-임시-비활성화

### DIFF
--- a/spider-admin/src/main/resources/templates/pages/cms-approval/cms-approval-script.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-approval/cms-approval-script.html
@@ -157,7 +157,7 @@
                     <td class="text-center small">${HtmlUtils.escape(row.lastModifiedDtime || '-')}</td>
                     <td class="text-center">${tdApproval}</td>
                     <td class="text-center">${tdHistory}</td>
-                    <td class="text-center">${tdEmergency}</td>
+                    <td class="text-center" style="display:none">${tdEmergency}</td>
                 </tr>`;
             }).join('');
 

--- a/spider-admin/src/main/resources/templates/pages/cms-approval/cms-approval-table.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-approval/cms-approval-table.html
@@ -17,8 +17,8 @@
                 <th class="col-w-150 sortable" data-sort="lastModifiedDtime">최종수정일시</th>
                 <th class="col-w-70">결재</th>
                 <th class="col-w-60">이력</th>
-                <!-- #308: 긴급차단 컬럼 추가 — APPROVED + 배포완료 행에만 버튼 노출 -->
-                <th class="col-w-80">긴급차단</th>
+                <!-- #308: 긴급차단 컬럼 — 현재 display:none (nginx 미들웨어 우회 문제로 임시 비활성화) -->
+                <th class="col-w-80" style="display:none">긴급차단</th>
             </tr>
         </thead>
         <tbody id="approvalTableBody">


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
- #308

## ✨ 변경 사항 (Changes)
- `cms-approval-table.html`: 긴급차단 `<th>` 컬럼에 `style="display:none"` 추가
- `cms-approval-script.html`: 긴급차단 `<td>` 셀에 `style="display:none"` 추가

## 🛠 기술적 의사결정 (선택)
컬럼 제거 대신 `display:none` 선택 — nginx 설정 변경 시 CSS 속성만 제거하면 즉시 복원 가능하도록 코드·로직은 그대로 유지

## ⚠️ 고려 및 주의 사항 (선택)
긴급차단 기능이 동작하려면 nginx `location /cms/deployed/` 블록을 `alias /data/deployed/` → `proxy_pass http://localhost:3001`으로 변경해야 합니다.
현재 nginx가 배포 HTML을 파일시스템에서 직접 서빙하므로 Next.js 미들웨어(IS_PUBLIC 체크)가 우회됩니다.
nginx 설정 변경 후 이 PR의 `display:none`을 제거하면 긴급차단 버튼이 활성화됩니다.