### PR TITLE
✨ feat/#314-spider-batch 배치 인프라 내재화

### DIFF
--- a/batch-was/pom.xml
+++ b/batch-was/pom.xml
@@ -75,13 +75,22 @@
             <artifactId>spring-boot-starter-quartz</artifactId>
         </dependency>
 
-        <!-- Redisson: Redis 분산 락 (멀티 인스턴스 중복 실행 방지) -->
-        <!-- TODO: 운영 환경에서는 RedissonClient를 Sentinel/Cluster 모드로 구성 필요 -->
+        <!--
+          분산 락 전략:
+            현재: NoOpDistributedLockService (단일 인스턴스, 락 없이 실행 허용)
+                  → redisson-spring-boot-starter 미포함 시 spider-batch가 자동 적용
+
+            Redis 분산 락 활성화 (멀티 인스턴스 운영 환경):
+              1. 아래 의존성 주석 해제
+              2. application.yml의 spring.data.redis.host/port를 Redis 서버 주소로 설정
+              3. Redis 서버를 항상 기동 상태로 유지 (연결 실패 시 배치 실행 차단됨)
+
         <dependency>
             <groupId>org.redisson</groupId>
             <artifactId>redisson-spring-boot-starter</artifactId>
             <version>3.27.2</version>
         </dependency>
+        -->
 
         <!-- Test -->
         <dependency>

--- a/batch-was/src/main/java/com/example/spiderbatch/job/db2db/Db2DbJobConfig.java
+++ b/batch-was/src/main/java/com/example/spiderbatch/job/db2db/Db2DbJobConfig.java
@@ -4,6 +4,7 @@ import com.example.spiderbatch.job.AbstractDb2DbJob;
 import com.example.spiderbatch.job.common.BatchJobParametersValidator;
 import com.example.spiderbatch.job.common.CardUsage;
 import com.example.spiderbatch.job.common.CardUsageQuery;
+import com.example.spiderbatch.job.db2db.DateRangePartitioner;
 import com.example.spiderbatch.job.listener.BatchNotificationListener;
 import java.util.Map;
 import javax.sql.DataSource;
@@ -73,7 +74,7 @@ public class Db2DbJobConfig extends AbstractDb2DbJob<CardUsage> {
     }
 
     /**
-     * 매니저 Step: ColumnRangePartitioner로 이용일자 범위를 분할하고 병렬 실행.
+     * 매니저 Step: DateRangePartitioner로 이용일자 범위를 분할하고 병렬 실행.
      * TaskExecutor를 @Bean으로 주입받아 Spring이 lifecycle(initialize/destroy)을 관리한다.
      */
     @Bean
@@ -82,7 +83,8 @@ public class Db2DbJobConfig extends AbstractDb2DbJob<CardUsage> {
                                    JdbcTemplate jdbcTemplate,
                                    TaskExecutor db2DbTaskExecutor) {
         return buildPartitionStep(jobRepository, "db2DbWorkerStep",
-                new ColumnRangePartitioner(jdbcTemplate), db2DbWorkerStep, db2DbTaskExecutor);
+                new DateRangePartitioner(jdbcTemplate, "POC_카드사용내역", "이용일자"),
+                db2DbWorkerStep, db2DbTaskExecutor);
     }
 
     /**
@@ -109,7 +111,7 @@ public class Db2DbJobConfig extends AbstractDb2DbJob<CardUsage> {
      * alias 없이 원본 한글 컬럼명 그대로 SELECT — JdbcPagingItemReader 내부 PagingRowMapper가
      * sort key(이용일자)를 rs.getObject("이용일자")로 추출하므로 alias하면 ORA-17006 발생.
      *
-     * @param minValue 파티션 시작 이용일자(숫자, ColumnRangePartitioner 주입)
+     * @param minValue 파티션 시작 이용일자(숫자, DateRangePartitioner 주입)
      * @param maxValue 파티션 종료 이용일자(숫자)
      */
     @Bean

--- a/batch-was/src/main/java/com/example/spiderbatch/job/file2db/File2DbJobConfig.java
+++ b/batch-was/src/main/java/com/example/spiderbatch/job/file2db/File2DbJobConfig.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
-import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.item.database.JdbcBatchItemWriter;
 import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;

--- a/batch-was/src/main/java/com/example/spiderbatch/job/file2db/File2DbJobConfig.java
+++ b/batch-was/src/main/java/com/example/spiderbatch/job/file2db/File2DbJobConfig.java
@@ -1,5 +1,6 @@
 package com.example.spiderbatch.job.file2db;
 
+import com.example.spiderbatch.job.AbstractCsvFile2DbJob;
 import com.example.spiderbatch.job.common.BatchJobParametersValidator;
 import com.example.spiderbatch.job.common.PocUser;
 import com.example.spiderbatch.job.listener.BatchNotificationListener;
@@ -10,7 +11,6 @@ import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
-import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.item.database.JdbcBatchItemWriter;
 import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
 import org.springframework.batch.item.file.FlatFileItemReader;
@@ -36,13 +36,15 @@ import org.springframework.transaction.PlatformTransactionManager;
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
-public class File2DbJobConfig {
-
-    /** Chunk 크기: 5건씩 읽어서 DB에 배치 INSERT */
-    private static final int CHUNK_SIZE = 5;
+public class File2DbJobConfig extends AbstractCsvFile2DbJob<PocUser> {
 
     private final DataSource dataSource;
     private final BatchNotificationListener batchNotificationListener;
+
+    @Override
+    protected String getJobName() {
+        return "file2db";
+    }
 
     /**
      * File2DBJob.
@@ -50,8 +52,7 @@ public class File2DbJobConfig {
      */
     @Bean(name = "file2db")
     public Job file2DbJob(JobRepository jobRepository, Step file2DbStep) {
-        return new JobBuilder("file2db", jobRepository)
-                .validator(new BatchJobParametersValidator())
+        return buildJobBuilder(jobRepository)
                 .listener(batchNotificationListener)
                 .start(file2DbStep)
                 .build();
@@ -60,26 +61,17 @@ public class File2DbJobConfig {
     @Bean
     public Step file2DbStep(JobRepository jobRepository,
                             PlatformTransactionManager transactionManager) {
-        return new StepBuilder("file2DbStep", jobRepository)
-                .<PocUser, PocUser>chunk(CHUNK_SIZE, transactionManager)
-                .reader(file2DbReader())
-                .processor(item -> {
+        return buildStep(jobRepository, transactionManager, "file2DbStep",
+                file2DbReader(),
+                item -> {
                     // 사용자명 없으면 skip
                     if (item.getUserName() == null || item.getUserName().isBlank()) {
                         log.warn("사용자명 없음 — skip: userId={}", item.getUserId());
                         return null;
                     }
                     return item;
-                })
-                .writer(file2DbWriter())
-                // skip: 개별 아이템 오류 시 해당 아이템만 건너뜀
-                .faultTolerant()
-                .skip(Exception.class)
-                .skipLimit(10)
-                // 완료된 Step은 재시작 시 skip — RETRYABLE_YN='N'이면 Job에 preventRestart() 추가 권장
-                // TODO: FWK_BATCH_APP.RETRYABLE_YN 값에 따라 JobBuilder.preventRestart() 연동 필요
-                .allowStartIfComplete(false)
-                .build();
+                },
+                file2DbWriter());
     }
 
     /**

--- a/batch-was/src/main/java/com/example/spiderbatch/job/file2db/FixedLengthFile2DbJobConfig.java
+++ b/batch-was/src/main/java/com/example/spiderbatch/job/file2db/FixedLengthFile2DbJobConfig.java
@@ -1,36 +1,27 @@
 package com.example.spiderbatch.job.file2db;
 
+import com.example.spiderbatch.job.AbstractFixedLengthFile2DbJob;
 import com.example.spiderbatch.job.common.BatchJobParametersValidator;
 import com.example.spiderbatch.job.common.FixedLengthRecord;
 import com.example.spiderbatch.job.listener.BatchNotificationListener;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import javax.sql.DataSource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
-import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.core.step.tasklet.TaskletStep;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.database.JdbcBatchItemWriter;
 import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
-import org.springframework.batch.item.file.BufferedReaderFactory;
 import org.springframework.batch.item.file.FlatFileItemReader;
-import org.springframework.batch.item.file.LineCallbackHandler;
-import org.springframework.batch.item.file.builder.FlatFileItemReaderBuilder;
-import org.springframework.batch.item.file.mapping.BeanWrapperFieldSetMapper;
 import org.springframework.batch.item.file.transform.FixedLengthTokenizer;
 import org.springframework.batch.item.file.transform.Range;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.FileSystemResource;
 import org.springframework.transaction.PlatformTransactionManager;
 
 /**
@@ -39,9 +30,8 @@ import org.springframework.transaction.PlatformTransactionManager;
  * <p>금융 거래내역 전문(61자 고정 길이)을 읽어 {@code POC_고정길이거래} 테이블에 MERGE(중복 skip)한다.</p>
  *
  * <ul>
- *   <li>헤더(HDR) 1줄 skip</li>
- *   <li>트레일러(TLR) {@link LineCallbackHandler}로 감지 후 로그만 기록</li>
- *   <li>BOM(EF BB BF) 자동 제거 — {@link BomStrippingBufferedReaderFactory}</li>
+ *   <li>헤더(HDR) 1줄 skip, 트레일러(TLR) 감지·로그: {@link AbstractFixedLengthFile2DbJob#buildReader}</li>
+ *   <li>BOM(EF BB BF) 자동 제거: {@link AbstractFixedLengthFile2DbJob.BomStrippingBufferedReaderFactory}</li>
  *   <li>faultTolerant: skip(Exception), skipLimit(10)</li>
  *   <li>처리 완료 후 파일 아카이브 Step 실행 (성공/실패 분기)</li>
  * </ul>
@@ -53,15 +43,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
-public class FixedLengthFile2DbJobConfig {
-
-    /** Chunk 크기: 100건씩 읽어서 DB에 배치 INSERT */
-    private static final int CHUNK_SIZE = 100;
-
-    /** UTF-8 BOM 시퀀스 (EF BB BF) */
-    private static final int BOM_BYTE_1 = 0xEF;
-    private static final int BOM_BYTE_2 = 0xBB;
-    private static final int BOM_BYTE_3 = 0xBF;
+public class FixedLengthFile2DbJobConfig extends AbstractFixedLengthFile2DbJob<FixedLengthRecord> {
 
     /** 아카이브 루트 디렉터리 (application.yml: batch.file.archive-dir) */
     @Value("${batch.file.archive-dir}")
@@ -73,6 +55,35 @@ public class FixedLengthFile2DbJobConfig {
 
     private final DataSource dataSource;
     private final BatchNotificationListener batchNotificationListener;
+
+    @Override
+    protected String getJobName() {
+        return "fixedFile2db";
+    }
+
+    @Override
+    protected Class<FixedLengthRecord> getTargetType() {
+        return FixedLengthRecord.class;
+    }
+
+    /**
+     * 컬럼별 Range 설정 (1-based index).
+     * 레코드 포맷: ACCOUNT_NO(10) + TRX_DT(8) + TRX_TM(6) + AMOUNT(15) + TRX_TYPE_CODE(2) + MEMO(20) = 61자
+     */
+    @Override
+    protected FixedLengthTokenizer buildTokenizer() {
+        FixedLengthTokenizer tokenizer = new FixedLengthTokenizer();
+        tokenizer.setNames("accountNo", "trxDt", "trxTm", "amount", "trxTypeCode", "memo");
+        tokenizer.setColumns(
+                new Range(1, 10),   // ACCOUNT_NO
+                new Range(11, 18),  // TRX_DT
+                new Range(19, 24),  // TRX_TM
+                new Range(25, 39),  // AMOUNT
+                new Range(40, 41),  // TRX_TYPE_CODE
+                new Range(42, 61)   // MEMO
+        );
+        return tokenizer;
+    }
 
     // -------------------------------------------------------------------------
     // Job
@@ -89,7 +100,8 @@ public class FixedLengthFile2DbJobConfig {
             Step fileArchiveSuccessStep,
             Step fileArchiveErrorStep) {
 
-        return new JobBuilder("fixedFile2db", jobRepository)
+        return buildJobBuilder(jobRepository)
+                // inputFilePath 파라미터 필수 검증
                 .validator(new BatchJobParametersValidator(true))
                 .listener(batchNotificationListener)
                 .start(fixedLengthFile2DbStep)
@@ -105,9 +117,7 @@ public class FixedLengthFile2DbJobConfig {
     // Steps
     // -------------------------------------------------------------------------
 
-    /**
-     * 고정 길이 파일 읽기 → Processor → DB 적재 Step.
-     */
+    /** 고정 길이 파일 읽기 → Processor → DB 적재 Step */
     @Bean
     public TaskletStep fixedLengthFile2DbStep(
             JobRepository jobRepository,
@@ -116,19 +126,9 @@ public class FixedLengthFile2DbJobConfig {
             ItemProcessor<FixedLengthRecord, FixedLengthRecord> fixedLengthRecordProcessor,
             JdbcBatchItemWriter<FixedLengthRecord> fixedLengthRecordWriter) {
 
-        return new StepBuilder("fixedLengthFile2DbStep", jobRepository)
-                .<FixedLengthRecord, FixedLengthRecord>chunk(CHUNK_SIZE, transactionManager)
-                .reader(fixedLengthFileReader)
-                .processor(fixedLengthRecordProcessor)
-                .writer(fixedLengthRecordWriter)
-                // 개별 아이템 오류 시 해당 건만 건너뛰고 계속 처리
-                .faultTolerant()
-                .skip(Exception.class)
-                .skipLimit(10)
-                // 완료된 Step은 재시작 시 skip — RETRYABLE_YN='N'이면 Job에 preventRestart() 추가 권장
-                // TODO: FWK_BATCH_APP.RETRYABLE_YN 값에 따라 JobBuilder.preventRestart() 연동 필요
-                .allowStartIfComplete(false)
-                .build();
+        return (TaskletStep) buildChunkStep(jobRepository, transactionManager,
+                "fixedLengthFile2DbStep",
+                fixedLengthFileReader, fixedLengthRecordProcessor, fixedLengthRecordWriter);
     }
 
     /** 성공 아카이브 Step */
@@ -161,63 +161,15 @@ public class FixedLengthFile2DbJobConfig {
 
     /**
      * 고정 길이 전문 FlatFileItemReader.
+     * BOM 제거·헤더 skip·트레일러 감지는 {@link AbstractFixedLengthFile2DbJob#buildReader}가 처리한다.
      *
-     * <ul>
-     *   <li>파일 경로: Job Parameter {@code inputFilePath}에서 주입</li>
-     *   <li>BOM(EF BB BF) 제거: {@link BomStrippingBufferedReaderFactory}</li>
-     *   <li>헤더 1줄 skip: {@code linesToSkip(1)}</li>
-     *   <li>트레일러 감지: "TLR"로 시작하는 줄 → 로그 기록 후 무시</li>
-     *   <li>컬럼 분리: {@link FixedLengthTokenizer} + {@link Range}</li>
-     * </ul>
+     * @param inputFilePath Job Parameter {@code inputFilePath}에서 주입
      */
     @Bean
-    @org.springframework.batch.core.configuration.annotation.StepScope
+    @StepScope
     public FlatFileItemReader<FixedLengthRecord> fixedLengthFileReader(
             @Value("#{jobParameters['inputFilePath']}") String inputFilePath) {
-
-        // FixedLengthTokenizer: 컬럼별 Range 설정 (1-based index)
-        FixedLengthTokenizer tokenizer = new FixedLengthTokenizer();
-        tokenizer.setNames("accountNo", "trxDt", "trxTm", "amount", "trxTypeCode", "memo");
-        tokenizer.setColumns(
-                new Range(1, 10),   // ACCOUNT_NO
-                new Range(11, 18),  // TRX_DT
-                new Range(19, 24),  // TRX_TM
-                new Range(25, 39),  // AMOUNT
-                new Range(40, 41),  // TRX_TYPE_CODE
-                new Range(42, 61)   // MEMO
-        );
-        // 레코드 길이 불일치 시 오류 발생 — 트레일러(TLR) 처리를 위해 strict 모드 해제
-        tokenizer.setStrict(false);
-
-        BeanWrapperFieldSetMapper<FixedLengthRecord> fieldSetMapper = new BeanWrapperFieldSetMapper<>();
-        fieldSetMapper.setTargetType(FixedLengthRecord.class);
-
-        return new FlatFileItemReaderBuilder<FixedLengthRecord>()
-                .name("fixedLengthFileReader")
-                .resource(new FileSystemResource(inputFilePath))
-                // BOM(EF BB BF) 제거: 커스텀 BufferedReaderFactory 적용
-                .bufferedReaderFactory(new BomStrippingBufferedReaderFactory())
-                // HDR 헤더 1줄 skip
-                .linesToSkip(1)
-                // TLR 트레일러: "TLR"로 시작하는 줄 감지 후 레코드 수 로그만 기록
-                .skippedLinesCallback(trailerLineCallbackHandler())
-                .lineTokenizer(tokenizer)
-                .fieldSetMapper(fieldSetMapper)
-                .build();
-    }
-
-    /**
-     * 트레일러 라인 콜백 핸들러.
-     * "TLR"로 시작하는 줄을 감지하여 레코드 수 정보를 로그로 기록한다.
-     * 실제 데이터로 처리되지 않도록 Reader의 {@code skippedLinesCallback}에 등록.
-     */
-    @Bean
-    public LineCallbackHandler trailerLineCallbackHandler() {
-        return line -> {
-            if (line.startsWith("TLR")) {
-                log.info("[FixedLengthFile2Db] 트레일러 감지 — 내용: {}", line.trim());
-            }
-        };
+        return buildReader(inputFilePath);
     }
 
     // -------------------------------------------------------------------------
@@ -227,8 +179,10 @@ public class FixedLengthFile2DbJobConfig {
     /**
      * 레코드 전처리 Processor.
      * <ul>
-     *   <li>amount 필드 앞뒤 공백 및 선두 0패딩 trim</li>
      *   <li>accountNo가 공백인 빈 레코드 skip (null 반환)</li>
+     *   <li>트레일러(TLR) 레코드 skip</li>
+     *   <li>amount 필드 앞뒤 공백 및 선두 0패딩 trim</li>
+     *   <li>memo 필드 우측 공백패딩 제거</li>
      * </ul>
      */
     @Bean
@@ -298,68 +252,23 @@ public class FixedLengthFile2DbJobConfig {
 
     /**
      * 성공 아카이브 Tasklet Bean.
-     * jobExecution.getStatus()는 Step 실행 중 STARTED이므로 판단 불가 —
-     * 성공 여부를 생성자에서 고정값(true)으로 주입한다.
+     * jobExecution.getStatus()는 Step 실행 중 STARTED이므로 성공 여부를 생성자에서 고정값(true)으로 주입.
      */
     @Bean
-    @org.springframework.batch.core.configuration.annotation.StepScope
+    @StepScope
     public FileArchiveTasklet fileArchiveSuccessTasklet(
             @Value("#{jobParameters['inputFilePath']}") String inputFilePath) {
-        return new FileArchiveTasklet(inputFilePath, archiveDir, errorDir, true);
+        return buildSuccessTasklet(inputFilePath, archiveDir, errorDir);
     }
 
     /**
      * 오류 아카이브 Tasklet Bean.
-     * jobExecution.getStatus()는 Step 실행 중 STARTED이므로 판단 불가 —
-     * 성공 여부를 생성자에서 고정값(false)으로 주입한다.
+     * jobExecution.getStatus()는 Step 실행 중 STARTED이므로 성공 여부를 생성자에서 고정값(false)으로 주입.
      */
     @Bean
-    @org.springframework.batch.core.configuration.annotation.StepScope
+    @StepScope
     public FileArchiveTasklet fileArchiveErrorTasklet(
             @Value("#{jobParameters['inputFilePath']}") String inputFilePath) {
-        return new FileArchiveTasklet(inputFilePath, archiveDir, errorDir, false);
-    }
-
-    // -------------------------------------------------------------------------
-    // Inner class: BOM 제거 BufferedReaderFactory
-    // -------------------------------------------------------------------------
-
-    /**
-     * UTF-8 BOM(EF BB BF)을 제거하는 {@link BufferedReaderFactory} 구현.
-     *
-     * <p>Spring의 FlatFileItemReader는 BOM을 자동 제거하지 않으므로
-     * InputStream의 첫 3바이트를 검사하여 BOM이면 건너뛰고
-     * 그렇지 않으면 스트림을 되돌려 정상적으로 읽는다.</p>
-     */
-    private static class BomStrippingBufferedReaderFactory implements BufferedReaderFactory {
-
-        @Override
-        public BufferedReader create(org.springframework.core.io.Resource resource, String encoding)
-                throws IOException {
-
-            InputStream rawStream = resource.getInputStream();
-
-            // BOM 여부 확인을 위해 첫 3바이트 선행 읽기
-            // read()는 3바이트 미만을 반환할 수 있으므로 readNBytes()로 정확히 읽는다 (Java 9+)
-            byte[] bom = new byte[3];
-            int bytesRead = rawStream.readNBytes(bom, 0, 3);
-
-            InputStream finalStream;
-            if (bytesRead == 3
-                    && (bom[0] & 0xFF) == BOM_BYTE_1
-                    && (bom[1] & 0xFF) == BOM_BYTE_2
-                    && (bom[2] & 0xFF) == BOM_BYTE_3) {
-                // BOM 확인됨 — 이미 3바이트를 소비했으므로 나머지 스트림만 사용
-                finalStream = rawStream;
-                log.debug("[BomStrippingBufferedReaderFactory] UTF-8 BOM 감지 및 제거");
-            } else {
-                // BOM 없음 — 읽은 바이트를 스트림 앞에 되돌려 전체 내용을 정상 처리
-                byte[] prefix = (bytesRead > 0) ? java.util.Arrays.copyOf(bom, bytesRead) : new byte[0];
-                finalStream = new java.io.SequenceInputStream(
-                        new java.io.ByteArrayInputStream(prefix), rawStream);
-            }
-
-            return new BufferedReader(new InputStreamReader(finalStream, StandardCharsets.UTF_8));
-        }
+        return buildErrorTasklet(inputFilePath, archiveDir, errorDir);
     }
 }

--- a/batch-was/src/main/java/com/example/spiderbatch/job/file2db/FixedLengthFile2DbJobConfig.java
+++ b/batch-was/src/main/java/com/example/spiderbatch/job/file2db/FixedLengthFile2DbJobConfig.java
@@ -1,7 +1,6 @@
 package com.example.spiderbatch.job.file2db;
 
 import com.example.spiderbatch.job.AbstractFixedLengthFile2DbJob;
-import com.example.spiderbatch.job.common.BatchJobParametersValidator;
 import com.example.spiderbatch.job.common.FixedLengthRecord;
 import com.example.spiderbatch.job.listener.BatchNotificationListener;
 import javax.sql.DataSource;
@@ -61,6 +60,12 @@ public class FixedLengthFile2DbJobConfig extends AbstractFixedLengthFile2DbJob<F
         return "fixedFile2db";
     }
 
+    /** inputFilePath Job 파라미터 필수 — 파일 경로 없이 실행하면 즉시 검증 실패 */
+    @Override
+    protected boolean requiresInputFilePath() {
+        return true;
+    }
+
     @Override
     protected Class<FixedLengthRecord> getTargetType() {
         return FixedLengthRecord.class;
@@ -101,8 +106,7 @@ public class FixedLengthFile2DbJobConfig extends AbstractFixedLengthFile2DbJob<F
             Step fileArchiveErrorStep) {
 
         return buildJobBuilder(jobRepository)
-                // inputFilePath 파라미터 필수 검증
-                .validator(new BatchJobParametersValidator(true))
+                // requiresInputFilePath()=true 이므로 buildJobBuilder()에서 이미 필수 검증 적용됨
                 .listener(batchNotificationListener)
                 .start(fixedLengthFile2DbStep)
                     // 데이터 적재 Step 성공 시 → 성공 아카이브

--- a/batch-was/src/main/resources/application.yml
+++ b/batch-was/src/main/resources/application.yml
@@ -1,15 +1,11 @@
 spring:
   profiles:
     active: oracle
-  autoconfigure:
-    exclude:
-      # RedissonAutoConfigurationV2는 기동 시 즉시 Redis 연결을 시도하여 Redis 미기동 시 WAS 기동 실패를 유발한다.
-      # RedisLockConfig가 lazyInitialization=true 설정으로 RedissonClient를 직접 생성하므로 제외한다.
-      - org.redisson.spring.starter.RedissonAutoConfigurationV2
-  data:
-    redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
+  # Redis 분산 락 활성화 시: pom.xml의 redisson-spring-boot-starter 주석 해제 후 아래 설정 활성화
+  # data:
+  #   redis:
+  #     host: ${REDIS_HOST:localhost}
+  #     port: ${REDIS_PORT:6379}
   quartz:
     # RAMJobStore: in-memory 저장 — WAS 재기동 시 등록된 Job이 초기화됨
     # TODO: 운영 환경에서는 job-store-type: jdbc 로 전환하여 재기동 후에도 스케줄 복구 가능하게 할 것

--- a/batch-was/src/main/resources/application.yml
+++ b/batch-was/src/main/resources/application.yml
@@ -5,6 +5,14 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
+      redisson:
+        # lazyInitialization: true — 기동 시 Redis 연결을 시도하지 않고, 첫 락 획득 요청 시점으로 연결을 미룬다.
+        # Redis가 없는 환경에서도 WAS가 정상 기동되며, 실제 배치 실행 시 연결을 시도한다.
+        # 멀티 인스턴스 운영 환경에서는 Redis가 반드시 기동 상태여야 한다.
+        config: |
+          lazyInitialization: true
+          singleServerConfig:
+            address: "redis://${REDIS_HOST:localhost}:${REDIS_PORT:6379}"
   quartz:
     # RAMJobStore: in-memory 저장 — WAS 재기동 시 등록된 Job이 초기화됨
     # TODO: 운영 환경에서는 job-store-type: jdbc 로 전환하여 재기동 후에도 스케줄 복구 가능하게 할 것

--- a/batch-was/src/main/resources/application.yml
+++ b/batch-was/src/main/resources/application.yml
@@ -1,18 +1,15 @@
 spring:
   profiles:
     active: oracle
+  autoconfigure:
+    exclude:
+      # RedissonAutoConfigurationV2는 기동 시 즉시 Redis 연결을 시도하여 Redis 미기동 시 WAS 기동 실패를 유발한다.
+      # RedisLockConfig가 lazyInitialization=true 설정으로 RedissonClient를 직접 생성하므로 제외한다.
+      - org.redisson.spring.starter.RedissonAutoConfigurationV2
   data:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
-      redisson:
-        # lazyInitialization: true — 기동 시 Redis 연결을 시도하지 않고, 첫 락 획득 요청 시점으로 연결을 미룬다.
-        # Redis가 없는 환경에서도 WAS가 정상 기동되며, 실제 배치 실행 시 연결을 시도한다.
-        # 멀티 인스턴스 운영 환경에서는 Redis가 반드시 기동 상태여야 한다.
-        config: |
-          lazyInitialization: true
-          singleServerConfig:
-            address: "redis://${REDIS_HOST:localhost}:${REDIS_PORT:6379}"
   quartz:
     # RAMJobStore: in-memory 저장 — WAS 재기동 시 등록된 Job이 초기화됨
     # TODO: 운영 환경에서는 job-store-type: jdbc 로 전환하여 재기동 후에도 스케줄 복구 가능하게 할 것

--- a/spider-batch/pom.xml
+++ b/spider-batch/pom.xml
@@ -108,6 +108,21 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- Quartz 스케줄러: optional 처리 — 내장 프로젝트가 포함해야 Cron 자동 실행 가능 -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-quartz</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Redisson 분산 락: optional 처리 — 내장 프로젝트가 포함해야 Redis 락 사용 가능, 미포함 시 NoOp으로 동작 -->
+        <dependency>
+            <groupId>org.redisson</groupId>
+            <artifactId>redisson-spring-boot-starter</artifactId>
+            <version>3.27.2</version>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/spider-batch/src/main/java/com/example/spiderbatch/config/QuartzSchedulerConfig.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/config/QuartzSchedulerConfig.java
@@ -1,0 +1,56 @@
+package com.example.spiderbatch.config;
+
+import com.example.spiderbatch.domain.batch.mapper.BatchAppMapper;
+import com.example.spiderbatch.scheduler.BatchJobQuartzTrigger;
+import com.example.spiderbatch.scheduler.QuartzAutoRegistrar;
+import com.example.spiderbatch.scheduler.SchedulerManagementService;
+import com.example.spiderbatch.tcp.ScheduleCommandHandler;
+import org.quartz.Scheduler;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Quartz 스케줄러 자동 설정.
+ *
+ * <p>{@code spring-boot-starter-quartz}가 클래스패스에 있을 때만 활성화된다.
+ * 스케줄 관리 서비스, 기동 시 자동 등록, TCP 스케줄 커맨드 핸들러를 등록한다.</p>
+ *
+ * <p>Quartz 미포함 환경에서는 이 설정 전체가 스킵된다.
+ * {@link BatchJobQuartzTrigger}는 Quartz가 직접 인스턴스화하므로 Bean 등록이 불필요하다.</p>
+ */
+@Configuration
+@ConditionalOnClass(Scheduler.class)
+public class QuartzSchedulerConfig {
+
+    /**
+     * Quartz Job 등록·수정·삭제·즉시 실행을 담당하는 서비스.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public SchedulerManagementService schedulerManagementService(Scheduler scheduler) {
+        return new SchedulerManagementService(scheduler);
+    }
+
+    /**
+     * WAS 기동 시 DB에서 Cron 배치 목록을 조회하여 Quartz에 자동 등록하는 ApplicationRunner.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public QuartzAutoRegistrar quartzAutoRegistrar(
+            BatchConfigurationProperties batchProps,
+            BatchAppMapper batchAppMapper,
+            SchedulerManagementService schedulerManagementService) {
+        return new QuartzAutoRegistrar(batchProps, batchAppMapper, schedulerManagementService);
+    }
+
+    /**
+     * Admin TCP SCHEDULE_TRIGGER / SCHEDULE_CRON_UPDATE 커맨드 핸들러.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public ScheduleCommandHandler scheduleCommandHandler(SchedulerManagementService schedulerManagementService) {
+        return new ScheduleCommandHandler(schedulerManagementService);
+    }
+}

--- a/spider-batch/src/main/java/com/example/spiderbatch/config/RedisLockConfig.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/config/RedisLockConfig.java
@@ -2,7 +2,10 @@ package com.example.spiderbatch.config;
 
 import com.example.spiderbatch.lock.RedisDistributedLockService;
 import com.example.spiderbatch.spi.DistributedLockService;
+import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -14,13 +17,46 @@ import org.springframework.context.annotation.Configuration;
  * <p>{@code redisson-spring-boot-starter}가 클래스패스에 있을 때만 활성화된다.
  * 이미 {@link DistributedLockService} Bean이 등록되어 있으면 이 설정을 건너뛴다(커스텀 구현 우선).</p>
  *
+ * <p>{@link RedissonClient} 빈을 직접 생성하며 {@code lazyInitialization=true}를 적용한다.
+ * 이로써 WAS 기동 시 Redis 연결을 즉시 시도하지 않고, 첫 락 획득 요청 시점으로 연결을 미룬다.
+ * {@code RedissonAutoConfigurationV2}의 Eager 연결을 우회하기 위해 직접 빈을 생성한다.</p>
+ *
  * <p>Redisson 미포함 환경에서는 이 설정 전체가 스킵되며,
  * {@link com.example.spiderbatch.config.SpiderBatchAutoConfiguration}의
  * {@link com.example.spiderbatch.spi.NoOpDistributedLockService}가 폴백으로 등록된다.</p>
  */
 @Configuration
-@ConditionalOnClass(RedissonClient.class)
+@ConditionalOnClass({RedissonClient.class, Redisson.class})
 public class RedisLockConfig {
+
+    /** Redis 호스트 (spring.data.redis.host 또는 REDIS_HOST 환경변수) */
+    @Value("${spring.data.redis.host:localhost}")
+    private String redisHost;
+
+    /** Redis 포트 (spring.data.redis.port 또는 REDIS_PORT 환경변수) */
+    @Value("${spring.data.redis.port:6379}")
+    private int redisPort;
+
+    /**
+     * LazyInitialization=true 설정으로 RedissonClient 빈 생성.
+     *
+     * <p>lazyInitialization=true: WAS 기동 시 Redis 연결을 시도하지 않고,
+     * 첫 락 획득 요청 시점으로 연결을 미룬다.
+     * YAML config 블록의 lazyInitialization은 RedissonAutoConfigurationV2의 Eager 초기화를
+     * 막지 못하므로, Java API로 직접 Config를 구성한다.</p>
+     *
+     * <p>이미 {@link RedissonClient} 빈이 있으면 스킵 — 커스텀 Redisson 설정 우선.</p>
+     */
+    @Bean(destroyMethod = "shutdown")
+    @ConditionalOnMissingBean(RedissonClient.class)
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        // 첫 실제 Redis 명령 시점까지 연결 지연 — Redis 미기동 환경에서도 WAS 정상 기동
+        config.setLazyInitialization(true);
+        config.useSingleServer()
+              .setAddress("redis://" + redisHost + ":" + redisPort);
+        return Redisson.create(config);
+    }
 
     /**
      * {@link RedissonClient} 빈을 사용하는 Redis 분산 락 서비스.

--- a/spider-batch/src/main/java/com/example/spiderbatch/config/RedisLockConfig.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/config/RedisLockConfig.java
@@ -1,0 +1,34 @@
+package com.example.spiderbatch.config;
+
+import com.example.spiderbatch.lock.RedisDistributedLockService;
+import com.example.spiderbatch.spi.DistributedLockService;
+import org.redisson.api.RedissonClient;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Redis 분산 락 자동 설정.
+ *
+ * <p>{@code redisson-spring-boot-starter}가 클래스패스에 있을 때만 활성화된다.
+ * 이미 {@link DistributedLockService} Bean이 등록되어 있으면 이 설정을 건너뛴다(커스텀 구현 우선).</p>
+ *
+ * <p>Redisson 미포함 환경에서는 이 설정 전체가 스킵되며,
+ * {@link com.example.spiderbatch.config.SpiderBatchAutoConfiguration}의
+ * {@link com.example.spiderbatch.spi.NoOpDistributedLockService}가 폴백으로 등록된다.</p>
+ */
+@Configuration
+@ConditionalOnClass(RedissonClient.class)
+public class RedisLockConfig {
+
+    /**
+     * {@link RedissonClient} 빈을 사용하는 Redis 분산 락 서비스.
+     * Redisson이 클래스패스에 있고 {@link DistributedLockService} 빈이 없을 때만 등록.
+     */
+    @Bean
+    @ConditionalOnMissingBean(DistributedLockService.class)
+    public DistributedLockService distributedLockService(RedissonClient redissonClient) {
+        return new RedisDistributedLockService(redissonClient);
+    }
+}

--- a/spider-batch/src/main/java/com/example/spiderbatch/config/SpiderBatchAutoConfiguration.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/config/SpiderBatchAutoConfiguration.java
@@ -11,7 +11,10 @@ import com.example.spiderbatch.global.notification.EmailNotificationService;
 import com.example.spiderbatch.global.notification.SlackNotificationService;
 import com.example.spiderbatch.global.security.ApiKeyAuthFilter;
 import com.example.spiderbatch.global.security.BatchWasSecurityConfig;
+import com.example.spiderbatch.job.listener.BatchNotificationListener;
 import com.example.spiderbatch.spi.BatchHistoryRecorder;
+import com.example.spiderbatch.spi.DistributedLockService;
+import com.example.spiderbatch.spi.NoOpDistributedLockService;
 import com.example.spiderbatch.tcp.BatchExecCommandHandler;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -57,6 +60,12 @@ import org.springframework.context.annotation.Import;
         // 알림 서비스 — 환경변수 미설정 시 no-op (Slack: SLACK_WEBHOOK_URL, Email: SMTP_HOST)
         SlackNotificationService.class,
         EmailNotificationService.class,
+        // 배치 알림 리스너 — Job 완료·실패 시 Slack/Email 알림 발송
+        BatchNotificationListener.class,
+        // Redis 분산 락 (@ConditionalOnClass: RedissonClient)
+        RedisLockConfig.class,
+        // Quartz 스케줄러 (@ConditionalOnClass: Scheduler)
+        QuartzSchedulerConfig.class,
 })
 public class SpiderBatchAutoConfiguration {
 
@@ -68,5 +77,16 @@ public class SpiderBatchAutoConfiguration {
     @ConditionalOnMissingBean(BatchHistoryRecorder.class)
     public BatchHistoryRecorder batchHistoryRecorder(BatchHisMapper batchHisMapper) {
         return new DefaultBatchHistoryRecorder(batchHisMapper);
+    }
+
+    /**
+     * {@link DistributedLockService} 기본 구현체(No-Op)를 등록한다.
+     * {@link RedisLockConfig}가 Redis 구현체를 먼저 등록하면 이 Bean은 생성되지 않는다.
+     * 내장 프로젝트에서 커스텀 {@link DistributedLockService} Bean을 등록해도 대체된다.
+     */
+    @Bean
+    @ConditionalOnMissingBean(DistributedLockService.class)
+    public DistributedLockService noOpDistributedLockService() {
+        return new NoOpDistributedLockService();
     }
 }

--- a/spider-batch/src/main/java/com/example/spiderbatch/job/AbstractCsvFile2DbJob.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/job/AbstractCsvFile2DbJob.java
@@ -1,0 +1,99 @@
+package com.example.spiderbatch.job;
+
+import com.example.spiderbatch.job.common.BatchJobParametersValidator;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * CSV 파일 → DB 배치 Job의 추상 기반 클래스.
+ *
+ * <p>CSV FlatFileItemReader + faultTolerant Step 패턴의 공통 설정을 템플릿 메서드로 제공한다.
+ * 내장 프로젝트의 {@code @Configuration}에서 이 클래스를 상속하여
+ * 도메인 특화 Reader·Writer·Processor와 Job Bean을 정의한다.</p>
+ *
+ * <pre>{@code
+ * @Configuration
+ * @RequiredArgsConstructor
+ * public class File2DbJobConfig extends AbstractCsvFile2DbJob<PocUser> {
+ *
+ *     private final DataSource dataSource;
+ *     private final BatchNotificationListener notificationListener;
+ *
+ *     @Override
+ *     protected String getJobName() { return "file2db"; }
+ *
+ *     @Bean(name = "file2db")
+ *     public Job file2DbJob(JobRepository jobRepository, Step file2DbStep) {
+ *         return buildJobBuilder(jobRepository)
+ *                 .listener(notificationListener)
+ *                 .start(file2DbStep)
+ *                 .build();
+ *     }
+ *
+ *     @Bean
+ *     public Step file2DbStep(JobRepository jobRepository, PlatformTransactionManager txMgr) {
+ *         return buildStep(jobRepository, txMgr, reader(), processor(), writer());
+ *     }
+ * }
+ * }</pre>
+ *
+ * @param <T> 읽기/쓰기 대상 도메인 타입
+ */
+public abstract class AbstractCsvFile2DbJob<T> {
+
+    /** Job 이름. FWK_BATCH_APP.BATCH_APP_FILE_NAME과 일치해야 한다. */
+    protected abstract String getJobName();
+
+    /** Chunk 크기(건당 읽기/쓰기 단위). 기본값 5. */
+    protected int getChunkSize() {
+        return 5;
+    }
+
+    /** faultTolerant skip 허용 최대 건수. 기본값 10. */
+    protected int getSkipLimit() {
+        return 10;
+    }
+
+    /**
+     * {@link BatchJobParametersValidator}가 적용된 {@link JobBuilder}를 반환한다.
+     * 서브 클래스에서 {@code .listener()}, {@code .start()} 등을 추가하여 Job을 완성한다.
+     */
+    protected JobBuilder buildJobBuilder(JobRepository jobRepository) {
+        return new JobBuilder(getJobName(), jobRepository)
+                .validator(new BatchJobParametersValidator());
+    }
+
+    /**
+     * faultTolerant chunk Step을 생성한다.
+     * {@code skip(Exception.class)}로 개별 아이템 오류 시 해당 건만 건너뛴다.
+     *
+     * @param stepName Step 이름 (JobBuilder의 Step 참조 키)
+     * @param reader   아이템 리더
+     * @param processor 아이템 프로세서
+     * @param writer   아이템 라이터
+     */
+    protected Step buildStep(JobRepository jobRepository,
+                             PlatformTransactionManager transactionManager,
+                             String stepName,
+                             ItemReader<T> reader,
+                             ItemProcessor<T, T> processor,
+                             ItemWriter<T> writer) {
+        return new StepBuilder(stepName, jobRepository)
+                .<T, T>chunk(getChunkSize(), transactionManager)
+                .reader(reader)
+                .processor(processor)
+                .writer(writer)
+                .faultTolerant()
+                .skip(Exception.class)
+                .skipLimit(getSkipLimit())
+                // 완료된 Step은 재시작 시 skip — RETRYABLE_YN='N'이면 Job에 preventRestart() 추가 권장
+                .allowStartIfComplete(false)
+                .build();
+    }
+}

--- a/spider-batch/src/main/java/com/example/spiderbatch/job/AbstractFixedLengthFile2DbJob.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/job/AbstractFixedLengthFile2DbJob.java
@@ -29,7 +29,8 @@ import org.springframework.transaction.PlatformTransactionManager;
  * <p>다음 공통 인프라를 템플릿 메서드로 제공한다:
  * <ul>
  *   <li>UTF-8 BOM 자동 제거 ({@link BomStrippingBufferedReaderFactory})</li>
- *   <li>헤더(HDR) 1줄 skip + 트레일러(TLR) 감지·로그</li>
+ *   <li>헤더(HDR) 1줄 skip + 헤더 내용 로그</li>
+ *   <li>트레일러(TLR) 감지: Processor에서 처리 (skippedLinesCallback은 헤더 전용)</li>
  *   <li>faultTolerant Chunk Step (skip(Exception), skipLimit)</li>
  *   <li>성공/오류 아카이브 Tasklet ({@link FileArchiveTasklet})</li>
  *   <li>배포 단위 Job 빌더 (성공 → 성공 아카이브, 실패 → 오류 아카이브 플로우)</li>
@@ -132,12 +133,9 @@ public abstract class AbstractFixedLengthFile2DbJob<T> {
                 .bufferedReaderFactory(new BomStrippingBufferedReaderFactory())
                 // HDR 헤더 1줄 skip
                 .linesToSkip(1)
-                // TLR 트레일러: "TLR"로 시작하는 줄 감지 후 레코드 수 로그만 기록
-                .skippedLinesCallback(line -> {
-                    if (line.startsWith("TLR")) {
-                        log.info("[{}] 트레일러 감지: {}", getJobName(), line.trim());
-                    }
-                })
+                // skippedLinesCallback은 linesToSkip(1)이 건너뛰는 첫 줄(헤더)에만 호출된다.
+                // 트레일러(TLR)는 파일 끝에 위치하므로 여기서 감지할 수 없다 — Processor에서 처리.
+                .skippedLinesCallback(line -> log.info("[{}] 헤더 감지: {}", getJobName(), line.trim()))
                 .lineTokenizer(tokenizer)
                 .fieldSetMapper(fieldSetMapper)
                 .build();

--- a/spider-batch/src/main/java/com/example/spiderbatch/job/AbstractFixedLengthFile2DbJob.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/job/AbstractFixedLengthFile2DbJob.java
@@ -95,12 +95,21 @@ public abstract class AbstractFixedLengthFile2DbJob<T> {
     }
 
     /**
+     * Job 파라미터로 {@code inputFilePath}를 필수로 요구하는지 여부.
+     * 고정 길이 파일 Job은 대부분 true이어야 한다. 기본값 false.
+     */
+    protected boolean requiresInputFilePath() {
+        return false;
+    }
+
+    /**
      * {@link BatchJobParametersValidator}가 적용된 {@link JobBuilder}를 반환한다.
+     * {@link #requiresInputFilePath()}가 true이면 {@code inputFilePath} 파라미터를 필수 검증한다.
      * 서브 클래스에서 {@code .listener()}, {@code .start()} 등을 추가하여 Job을 완성한다.
      */
     protected JobBuilder buildJobBuilder(JobRepository jobRepository) {
         return new JobBuilder(getJobName(), jobRepository)
-                .validator(new BatchJobParametersValidator());
+                .validator(new BatchJobParametersValidator(requiresInputFilePath()));
     }
 
     /**
@@ -184,6 +193,10 @@ public abstract class AbstractFixedLengthFile2DbJob<T> {
      * <p>Spring의 FlatFileItemReader는 BOM을 자동 제거하지 않으므로
      * InputStream의 첫 3바이트를 검사하여 BOM이면 건너뛰고
      * 그렇지 않으면 스트림을 되돌려 정상적으로 읽는다.</p>
+     *
+     * <p>주의: {@code encoding} 파라미터는 의도적으로 무시하고 항상 UTF-8로 읽는다.
+     * BOM(EF BB BF)은 UTF-8 전용 마커이므로, 이 Factory는 UTF-8 파일 전용으로 사용해야 한다.
+     * EUC-KR 등 다른 인코딩 파일에는 사용하지 않는다.</p>
      */
     protected static class BomStrippingBufferedReaderFactory implements BufferedReaderFactory {
 

--- a/spider-batch/src/main/java/com/example/spiderbatch/job/AbstractFixedLengthFile2DbJob.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/job/AbstractFixedLengthFile2DbJob.java
@@ -1,0 +1,219 @@
+package com.example.spiderbatch.job;
+
+import com.example.spiderbatch.job.common.BatchJobParametersValidator;
+import com.example.spiderbatch.job.file2db.FileArchiveTasklet;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.file.BufferedReaderFactory;
+import org.springframework.batch.item.file.FlatFileItemReader;
+import org.springframework.batch.item.file.builder.FlatFileItemReaderBuilder;
+import org.springframework.batch.item.file.mapping.BeanWrapperFieldSetMapper;
+import org.springframework.batch.item.file.transform.FixedLengthTokenizer;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * 고정 길이 파일 → DB 배치 Job의 추상 기반 클래스.
+ *
+ * <p>다음 공통 인프라를 템플릿 메서드로 제공한다:
+ * <ul>
+ *   <li>UTF-8 BOM 자동 제거 ({@link BomStrippingBufferedReaderFactory})</li>
+ *   <li>헤더(HDR) 1줄 skip + 트레일러(TLR) 감지·로그</li>
+ *   <li>faultTolerant Chunk Step (skip(Exception), skipLimit)</li>
+ *   <li>성공/오류 아카이브 Tasklet ({@link FileArchiveTasklet})</li>
+ *   <li>배포 단위 Job 빌더 (성공 → 성공 아카이브, 실패 → 오류 아카이브 플로우)</li>
+ * </ul>
+ * </p>
+ *
+ * <pre>{@code
+ * @Configuration
+ * @RequiredArgsConstructor
+ * public class FixedLengthFile2DbJobConfig extends AbstractFixedLengthFile2DbJob<FixedLengthRecord> {
+ *
+ *     @Value("${batch.file.archive-dir}") private String archiveDir;
+ *     @Value("${batch.file.error-dir}")   private String errorDir;
+ *     private final DataSource dataSource;
+ *     private final BatchNotificationListener notificationListener;
+ *
+ *     @Override protected String getJobName()      { return "fixedFile2db"; }
+ *     @Override protected Class<FixedLengthRecord> getTargetType() { return FixedLengthRecord.class; }
+ *     @Override protected FixedLengthTokenizer buildTokenizer()    { ... }
+ *
+ *     @Bean(name = "fixedFile2db")
+ *     public Job fixedFile2DbJob(JobRepository jobRepository,
+ *             Step fixedLengthFile2DbStep, Step fileArchiveSuccessStep, Step fileArchiveErrorStep) {
+ *         return buildJobBuilder(jobRepository)
+ *                 .validator(new BatchJobParametersValidator(true))
+ *                 .listener(notificationListener)
+ *                 .start(fixedLengthFile2DbStep)
+ *                     .on("COMPLETED").to(fileArchiveSuccessStep)
+ *                 .from(fixedLengthFile2DbStep).on("*").to(fileArchiveErrorStep)
+ *                 .end()
+ *                 .build();
+ *     }
+ * }
+ * }</pre>
+ *
+ * @param <T> 읽기/쓰기 대상 도메인 타입
+ */
+@Slf4j
+public abstract class AbstractFixedLengthFile2DbJob<T> {
+
+    /** UTF-8 BOM 시퀀스 (EF BB BF) */
+    private static final int BOM_BYTE_1 = 0xEF;
+    private static final int BOM_BYTE_2 = 0xBB;
+    private static final int BOM_BYTE_3 = 0xBF;
+
+    /** Job 이름. FWK_BATCH_APP.BATCH_APP_FILE_NAME과 일치해야 한다. */
+    protected abstract String getJobName();
+
+    /** {@link FixedLengthTokenizer} 설정(컬럼명·범위). 서브 클래스에서 구현한다. */
+    protected abstract FixedLengthTokenizer buildTokenizer();
+
+    /** 도메인 레코드 타입. {@link BeanWrapperFieldSetMapper} 타입 지정에 사용한다. */
+    protected abstract Class<T> getTargetType();
+
+    /** Chunk 크기. 기본값 100. */
+    protected int getChunkSize() {
+        return 100;
+    }
+
+    /** faultTolerant skip 허용 최대 건수. 기본값 10. */
+    protected int getSkipLimit() {
+        return 10;
+    }
+
+    /**
+     * {@link BatchJobParametersValidator}가 적용된 {@link JobBuilder}를 반환한다.
+     * 서브 클래스에서 {@code .listener()}, {@code .start()} 등을 추가하여 Job을 완성한다.
+     */
+    protected JobBuilder buildJobBuilder(JobRepository jobRepository) {
+        return new JobBuilder(getJobName(), jobRepository)
+                .validator(new BatchJobParametersValidator());
+    }
+
+    /**
+     * BOM 제거 + 헤더 skip + 트레일러 감지가 적용된 FlatFileItemReader를 생성한다.
+     *
+     * @param inputFilePath Job Parameter {@code inputFilePath}에서 주입된 파일 경로
+     */
+    protected FlatFileItemReader<T> buildReader(String inputFilePath) {
+        FixedLengthTokenizer tokenizer = buildTokenizer();
+        // 레코드 길이 불일치 시 오류 발생 — 트레일러(TLR) 처리를 위해 strict 모드 해제
+        tokenizer.setStrict(false);
+
+        BeanWrapperFieldSetMapper<T> fieldSetMapper = new BeanWrapperFieldSetMapper<>();
+        fieldSetMapper.setTargetType(getTargetType());
+
+        return new FlatFileItemReaderBuilder<T>()
+                .name(getJobName() + "FileReader")
+                .resource(new FileSystemResource(inputFilePath))
+                // BOM(EF BB BF) 제거: 커스텀 BufferedReaderFactory 적용
+                .bufferedReaderFactory(new BomStrippingBufferedReaderFactory())
+                // HDR 헤더 1줄 skip
+                .linesToSkip(1)
+                // TLR 트레일러: "TLR"로 시작하는 줄 감지 후 레코드 수 로그만 기록
+                .skippedLinesCallback(line -> {
+                    if (line.startsWith("TLR")) {
+                        log.info("[{}] 트레일러 감지: {}", getJobName(), line.trim());
+                    }
+                })
+                .lineTokenizer(tokenizer)
+                .fieldSetMapper(fieldSetMapper)
+                .build();
+    }
+
+    /**
+     * faultTolerant Chunk Step을 생성한다.
+     * {@code skip(Exception.class)}로 개별 아이템 오류 시 해당 건만 건너뛴다.
+     *
+     * @param stepName Step 이름
+     */
+    protected <I, O> Step buildChunkStep(JobRepository jobRepository,
+                                          PlatformTransactionManager transactionManager,
+                                          String stepName,
+                                          ItemReader<I> reader,
+                                          ItemProcessor<I, O> processor,
+                                          ItemWriter<O> writer) {
+        return new StepBuilder(stepName, jobRepository)
+                .<I, O>chunk(getChunkSize(), transactionManager)
+                .reader(reader)
+                .processor(processor)
+                .writer(writer)
+                .faultTolerant()
+                .skip(Exception.class)
+                .skipLimit(getSkipLimit())
+                .allowStartIfComplete(false)
+                .build();
+    }
+
+    /**
+     * 성공 아카이브 {@link FileArchiveTasklet}을 생성한다.
+     * jobExecution.getStatus()는 Step 실행 중 STARTED이므로 성공 여부를 직접 전달한다.
+     */
+    protected FileArchiveTasklet buildSuccessTasklet(String inputFilePath,
+                                                      String archiveDir,
+                                                      String errorDir) {
+        return new FileArchiveTasklet(inputFilePath, archiveDir, errorDir, true);
+    }
+
+    /**
+     * 오류 아카이브 {@link FileArchiveTasklet}을 생성한다.
+     * jobExecution.getStatus()는 Step 실행 중 STARTED이므로 성공 여부를 직접 전달한다.
+     */
+    protected FileArchiveTasklet buildErrorTasklet(String inputFilePath,
+                                                    String archiveDir,
+                                                    String errorDir) {
+        return new FileArchiveTasklet(inputFilePath, archiveDir, errorDir, false);
+    }
+
+    /**
+     * UTF-8 BOM(EF BB BF)을 제거하는 {@link BufferedReaderFactory} 구현.
+     *
+     * <p>Spring의 FlatFileItemReader는 BOM을 자동 제거하지 않으므로
+     * InputStream의 첫 3바이트를 검사하여 BOM이면 건너뛰고
+     * 그렇지 않으면 스트림을 되돌려 정상적으로 읽는다.</p>
+     */
+    protected static class BomStrippingBufferedReaderFactory implements BufferedReaderFactory {
+
+        @Override
+        public BufferedReader create(org.springframework.core.io.Resource resource, String encoding)
+                throws IOException {
+
+            InputStream rawStream = resource.getInputStream();
+
+            // BOM 여부 확인을 위해 첫 3바이트 선행 읽기
+            // read()는 3바이트 미만을 반환할 수 있으므로 readNBytes()로 정확히 읽는다 (Java 9+)
+            byte[] bom = new byte[3];
+            int bytesRead = rawStream.readNBytes(bom, 0, 3);
+
+            InputStream finalStream;
+            if (bytesRead == 3
+                    && (bom[0] & 0xFF) == BOM_BYTE_1
+                    && (bom[1] & 0xFF) == BOM_BYTE_2
+                    && (bom[2] & 0xFF) == BOM_BYTE_3) {
+                // BOM 확인됨 — 이미 3바이트를 소비했으므로 나머지 스트림만 사용
+                finalStream = rawStream;
+                log.debug("[BomStripping] UTF-8 BOM 감지 및 제거");
+            } else {
+                // BOM 없음 — 읽은 바이트를 스트림 앞에 되돌려 전체 내용을 정상 처리
+                byte[] prefix = (bytesRead > 0) ? java.util.Arrays.copyOf(bom, bytesRead) : new byte[0];
+                finalStream = new java.io.SequenceInputStream(
+                        new java.io.ByteArrayInputStream(prefix), rawStream);
+            }
+
+            return new BufferedReader(new InputStreamReader(finalStream, StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/spider-batch/src/main/java/com/example/spiderbatch/job/db2db/DateRangePartitioner.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/job/db2db/DateRangePartitioner.java
@@ -5,7 +5,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.partition.support.Partitioner;
 import org.springframework.batch.item.ExecutionContext;
@@ -32,7 +31,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
  * @see AbstractDb2DbJob#buildPartitionStep
  */
 @Slf4j
-@RequiredArgsConstructor
 public class DateRangePartitioner implements Partitioner {
 
     private static final DateTimeFormatter FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
@@ -44,6 +42,25 @@ public class DateRangePartitioner implements Partitioner {
 
     /** 날짜 기준 컬럼명 (YYYYMMDD 형식의 문자열 컬럼) */
     private final String columnName;
+
+    public DateRangePartitioner(JdbcTemplate jdbcTemplate, String tableName, String columnName) {
+        assertSafeIdentifier(tableName);
+        assertSafeIdentifier(columnName);
+        this.jdbcTemplate = jdbcTemplate;
+        this.tableName = tableName;
+        this.columnName = columnName;
+    }
+
+    /**
+     * 테이블명·컬럼명이 SQL 식별자로 안전한지 검증한다.
+     * PreparedStatement placeholder로 바인딩할 수 없는 식별자를 직접 연결하므로
+     * 알파벳·숫자·언더스코어·한글만 허용하여 SQL Injection을 방지한다.
+     */
+    private static void assertSafeIdentifier(String name) {
+        if (name == null || !name.matches("[\\w가-힣]+")) {
+            throw new IllegalArgumentException("유효하지 않은 SQL 식별자: " + name);
+        }
+    }
 
     /**
      * gridSize 수만큼 파티션을 생성한다.

--- a/spider-batch/src/main/java/com/example/spiderbatch/job/db2db/DateRangePartitioner.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/job/db2db/DateRangePartitioner.java
@@ -12,9 +12,9 @@ import org.springframework.batch.item.ExecutionContext;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
- * 이용일자(YYYYMMDD) 범위 기반 Partitioner.
+ * YYYYMMDD 형식의 날짜 컬럼을 기준으로 파티션을 균등 분할하는 범용 Partitioner.
  *
- * <p>POC_카드사용내역 테이블을 이용일자 범위로 균등 분할하여 병렬 처리한다.
+ * <p>대상 테이블의 MIN/MAX 날짜를 조회하여 gridSize 수만큼 파티션을 생성한다.
  * YYYYMMDD 정수 단순 산술은 월/연도 경계에서 공백이 생기므로(예: 20251231 → 20260101 사이
  * 정수 공백 8870) {@link LocalDate} 달력 산술로 실제 날짜 기반 분할한다.</p>
  *
@@ -25,17 +25,25 @@ import org.springframework.jdbc.core.JdbcTemplate;
  *   partition2: 20260127 ~ 20260220 (약 57일)
  *   partition3: 20260221 ~ 20260414 (나머지)
  * </pre>
+ *
+ * <p>각 파티션의 ExecutionContext에 {@code minValue}, {@code maxValue}(YYYYMMDD 숫자)를 저장한다.
+ * Worker Step의 ItemReader는 이 값을 {@code stepExecutionContext}에서 주입받아 범위 쿼리에 사용한다.</p>
+ *
+ * @see AbstractDb2DbJob#buildPartitionStep
  */
 @Slf4j
 @RequiredArgsConstructor
-public class ColumnRangePartitioner implements Partitioner {
+public class DateRangePartitioner implements Partitioner {
 
     private static final DateTimeFormatter FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
 
     private final JdbcTemplate jdbcTemplate;
 
     /** 파티션 분할 대상 테이블 */
-    private static final String TABLE = "POC_카드사용내역";
+    private final String tableName;
+
+    /** 날짜 기준 컬럼명 (YYYYMMDD 형식의 문자열 컬럼) */
+    private final String columnName;
 
     /**
      * gridSize 수만큼 파티션을 생성한다.
@@ -47,12 +55,12 @@ public class ColumnRangePartitioner implements Partitioner {
     @Override
     public Map<String, ExecutionContext> partition(int gridSize) {
         String minStr = jdbcTemplate.queryForObject(
-                "SELECT MIN(이용일자) FROM " + TABLE, String.class);
+                "SELECT MIN(" + columnName + ") FROM " + tableName, String.class);
         String maxStr = jdbcTemplate.queryForObject(
-                "SELECT MAX(이용일자) FROM " + TABLE, String.class);
+                "SELECT MAX(" + columnName + ") FROM " + tableName, String.class);
 
         if (minStr == null || maxStr == null) {
-            log.warn("파티셔닝 대상 데이터 없음: table={}", TABLE);
+            log.warn("파티셔닝 대상 데이터 없음: table={}, column={}", tableName, columnName);
             Map<String, ExecutionContext> empty = new HashMap<>();
             ExecutionContext ctx = new ExecutionContext();
             ctx.putLong("minValue", 0L);
@@ -88,7 +96,8 @@ public class ColumnRangePartitioner implements Partitioner {
             start = end.plusDays(1);
         }
 
-        log.info("파티션 생성 완료: table={}, gridSize={}, 이용일자={}~{}", TABLE, gridSize, minStr, maxStr);
+        log.info("파티션 생성 완료: table={}, column={}, gridSize={}, 범위={}~{}",
+                tableName, columnName, gridSize, minStr, maxStr);
         return result;
     }
 }

--- a/spider-batch/src/main/java/com/example/spiderbatch/job/file2db/FileArchiveTasklet.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/job/file2db/FileArchiveTasklet.java
@@ -26,6 +26,9 @@ import org.springframework.batch.repeat.RepeatStatus;
  *   <li>성공: {@code {archive-dir}/YYYYMMDD/} 하위로 이동</li>
  *   <li>실패: {@code {error-dir}/YYYYMMDD/} 하위로 이동 + 동명의 {@code .reason} 파일 생성 (오류 사유 최대 200자)</li>
  * </ul>
+ *
+ * <p>{@link AbstractFixedLengthFile2DbJob#buildSuccessTasklet}과
+ * {@link AbstractFixedLengthFile2DbJob#buildErrorTasklet}에서 생성된다.</p>
  */
 @Slf4j
 @RequiredArgsConstructor

--- a/spider-batch/src/main/java/com/example/spiderbatch/job/listener/BatchNotificationListener.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/job/listener/BatchNotificationListener.java
@@ -13,10 +13,14 @@ import org.springframework.batch.core.StepExecution;
 import org.springframework.stereotype.Component;
 
 /**
- * @file BatchNotificationListener.java
- * @description 배치 Job 완료·실패 시 Slack·Email 알림을 발송하는 JobExecutionListener.
- *              알림 로직을 Job과 분리하여 4개 샘플 Job에 공통 적용한다.
- *              batchAppName은 JobParameters의 batchAppId를 그대로 사용한다.
+ * 배치 Job 완료·실패 시 Slack·Email 알림을 발송하는 {@link JobExecutionListener}.
+ *
+ * <p>알림 로직을 Job과 분리하여 여러 Job 설정 클래스에서 공통으로 재사용한다.
+ * {@link com.example.spiderbatch.config.SpiderBatchAutoConfiguration}에 의해 자동 등록되며,
+ * Job 설정 클래스에서 의존성으로 주입받아 {@code .listener(batchNotificationListener)}로 연결한다.</p>
+ *
+ * <p>batchAppName은 {@link com.example.spiderbatch.domain.batch.service.BatchExecuteService}가
+ * JobParameter에 포함시켜 전달한다. 없으면 batchAppId로 대체한다.</p>
  */
 @Slf4j
 @Component

--- a/spider-batch/src/main/java/com/example/spiderbatch/job/listener/BatchNotificationListener.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/job/listener/BatchNotificationListener.java
@@ -10,20 +10,21 @@ import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionListener;
 import org.springframework.batch.core.StepExecution;
-import org.springframework.stereotype.Component;
-
 /**
  * 배치 Job 완료·실패 시 Slack·Email 알림을 발송하는 {@link JobExecutionListener}.
  *
  * <p>알림 로직을 Job과 분리하여 여러 Job 설정 클래스에서 공통으로 재사용한다.
- * {@link com.example.spiderbatch.config.SpiderBatchAutoConfiguration}에 의해 자동 등록되며,
+ * {@link com.example.spiderbatch.config.SpiderBatchAutoConfiguration}의 {@code @Import}로 등록되며,
  * Job 설정 클래스에서 의존성으로 주입받아 {@code .listener(batchNotificationListener)}로 연결한다.</p>
  *
  * <p>batchAppName은 {@link com.example.spiderbatch.domain.batch.service.BatchExecuteService}가
  * JobParameter에 포함시켜 전달한다. 없으면 batchAppId로 대체한다.</p>
+ *
+ * <p>주의: {@code @Component}를 사용하지 않는다.
+ * 라이브러리 클래스에 {@code @Component}가 있으면 소비 프로젝트의 컴포넌트 스캔과
+ * {@code @Import}에서 이중 등록될 수 있다.</p>
  */
 @Slf4j
-@Component
 @RequiredArgsConstructor
 public class BatchNotificationListener implements JobExecutionListener {
 

--- a/spider-batch/src/main/java/com/example/spiderbatch/lock/RedisDistributedLockService.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/lock/RedisDistributedLockService.java
@@ -1,11 +1,11 @@
 package com.example.spiderbatch.lock;
 
+import com.example.spiderbatch.spi.DistributedLockService;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
-import org.springframework.stereotype.Service;
 
 /**
  * Redis 분산 락 서비스.
@@ -15,17 +15,17 @@ import org.springframework.stereotype.Service;
  *
  * <p>락 키: {@code batch:lock:{batchAppId}}<br>
  * leaseTime을 지정하지 않아 Redisson Watchdog이 활성화된다.
- * Watchdog은 배치 실행 중 락을 30초마다 자동 갱신하며, 배치 완료/실패 시 {@link #unlock}에서 명시적으로 해제한다.
+ * Watchdog은 배치 실행 중 락을 30초마다 자동 갱신하며, 완료/실패 시 {@link #unlock}에서 명시적으로 해제한다.
  * 프로세스가 비정상 종료되면 Watchdog이 멈추고 기본 TTL(30초) 후 락이 자동 해제된다.</p>
  *
- * <p>TODO: 운영 환경에서는 RedissonClient를 Sentinel 또는 Cluster 모드로 구성해야 한다.
- * application.yml의 {@code spring.data.redis} 설정을
- * {@code spring.redis.sentinel} 또는 {@code spring.redis.cluster} 블록으로 전환할 것.</p>
+ * <p>이 빈은 {@code redisson-spring-boot-starter}가 클래스패스에 있을 때
+ * {@link com.example.spiderbatch.config.RedisLockConfig}에 의해 자동 등록된다.</p>
+ *
+ * <p>TODO: 운영 환경에서는 RedissonClient를 Sentinel 또는 Cluster 모드로 구성해야 한다.</p>
  */
 @Slf4j
-@Service
 @RequiredArgsConstructor
-public class RedisDistributedLockService {
+public class RedisDistributedLockService implements DistributedLockService {
 
     private final RedissonClient redissonClient;
 
@@ -39,6 +39,7 @@ public class RedisDistributedLockService {
      * @param batchAppId 배치 APP ID
      * @return 락 획득 성공 시 true, 이미 다른 인스턴스가 실행 중이면 false
      */
+    @Override
     public boolean tryLock(String batchAppId) {
         RLock lock = redissonClient.getLock(LOCK_PREFIX + batchAppId);
         try {
@@ -63,6 +64,7 @@ public class RedisDistributedLockService {
      *
      * @param batchAppId 배치 APP ID
      */
+    @Override
     public void unlock(String batchAppId) {
         RLock lock = redissonClient.getLock(LOCK_PREFIX + batchAppId);
         // isHeldByCurrentThread: 현재 스레드가 락을 보유한 경우에만 해제

--- a/spider-batch/src/main/java/com/example/spiderbatch/lock/RedisDistributedLockService.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/lock/RedisDistributedLockService.java
@@ -56,11 +56,12 @@ public class RedisDistributedLockService implements DistributedLockService {
             log.warn("[분산 락] 획득 인터럽트: batchAppId={}", batchAppId);
             return false;
         } catch (Exception e) {
-            // Redis 연결 실패 시 락 없이 실행 허용 — 단일 인스턴스 POC 환경 대응
-            // 멀티 인스턴스 운영 환경에서는 Redis를 반드시 복구해야 중복 실행 제어가 보장된다
-            log.warn("[분산 락] Redis 연결 실패, 락 없이 실행 허용: batchAppId={}, error={}",
+            // Redis 연결 실패 시 실행 차단(fail-fast) — 중복 실행으로 인한 데이터 정합성 훼손 방지
+            // Redis 없이 실행하려면 redisson-spring-boot-starter 의존성을 제거하면
+            // NoOpDistributedLockService가 자동 적용되어 락 없이 실행할 수 있다
+            log.error("[분산 락] Redis 연결 실패로 인한 락 확인 불가, 실행 차단: batchAppId={}, error={}",
                     batchAppId, e.getMessage());
-            return true;
+            return false;
         }
     }
 

--- a/spider-batch/src/main/java/com/example/spiderbatch/lock/RedisDistributedLockService.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/lock/RedisDistributedLockService.java
@@ -55,6 +55,12 @@ public class RedisDistributedLockService implements DistributedLockService {
             Thread.currentThread().interrupt();
             log.warn("[분산 락] 획득 인터럽트: batchAppId={}", batchAppId);
             return false;
+        } catch (Exception e) {
+            // Redis 연결 실패 시 락 없이 실행 허용 — 단일 인스턴스 POC 환경 대응
+            // 멀티 인스턴스 운영 환경에서는 Redis를 반드시 복구해야 중복 실행 제어가 보장된다
+            log.warn("[분산 락] Redis 연결 실패, 락 없이 실행 허용: batchAppId={}, error={}",
+                    batchAppId, e.getMessage());
+            return true;
         }
     }
 

--- a/spider-batch/src/main/java/com/example/spiderbatch/lock/RedisDistributedLockService.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/lock/RedisDistributedLockService.java
@@ -68,15 +68,25 @@ public class RedisDistributedLockService implements DistributedLockService {
      * 배치 분산 락 해제.
      * 현재 스레드가 보유한 락만 해제한다. 락이 없거나 다른 스레드 소유이면 무시.
      *
+     * <p>tryLock()이 Redis 연결 실패로 예외를 잡고 true를 반환한 경우에도
+     * 락은 실제로 획득되지 않았으므로 isHeldByCurrentThread()가 false를 반환하여 안전하게 종료된다.
+     * 만일 Redis가 해제 시점에 다시 연결 불가 상태이더라도 예외를 삼키고 경고 로그만 남긴다.</p>
+     *
      * @param batchAppId 배치 APP ID
      */
     @Override
     public void unlock(String batchAppId) {
-        RLock lock = redissonClient.getLock(LOCK_PREFIX + batchAppId);
-        // isHeldByCurrentThread: 현재 스레드가 락을 보유한 경우에만 해제
-        if (lock.isHeldByCurrentThread()) {
-            lock.unlock();
-            log.debug("[분산 락] 해제: batchAppId={}", batchAppId);
+        try {
+            RLock lock = redissonClient.getLock(LOCK_PREFIX + batchAppId);
+            // isHeldByCurrentThread: 현재 스레드가 락을 보유한 경우에만 해제
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+                log.debug("[분산 락] 해제: batchAppId={}", batchAppId);
+            }
+        } catch (Exception e) {
+            // finally 블록에서 호출되므로 예외가 전파되면 원래 예외가 억제될 수 있다
+            log.warn("[분산 락] 해제 중 Redis 연결 실패 (무시): batchAppId={}, error={}",
+                    batchAppId, e.getMessage());
         }
     }
 }

--- a/spider-batch/src/main/java/com/example/spiderbatch/scheduler/BatchJobQuartzTrigger.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/scheduler/BatchJobQuartzTrigger.java
@@ -2,7 +2,7 @@ package com.example.spiderbatch.scheduler;
 
 import com.example.spiderbatch.domain.batch.dto.BatchExecuteRequest;
 import com.example.spiderbatch.domain.batch.service.BatchExecuteService;
-import com.example.spiderbatch.lock.RedisDistributedLockService;
+import com.example.spiderbatch.spi.DistributedLockService;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import lombok.extern.slf4j.Slf4j;
@@ -15,13 +15,15 @@ import org.springframework.scheduling.quartz.QuartzJobBean;
  *
  * <p>Quartz Scheduler가 Cron 주기에 맞춰 이 Job을 실행하면:
  * <ol>
- *   <li>Redis 분산 락 획득 시도 — 실패 시(다른 인스턴스가 실행 중) 스킵</li>
+ *   <li>분산 락 획득 시도 — 실패 시(다른 인스턴스가 실행 중) 스킵</li>
  *   <li>{@link BatchExecuteService#execute}로 배치 실행 위임</li>
  *   <li>finally에서 분산 락 반드시 해제</li>
  * </ol>
  * </p>
  *
- * <p>JobDataMap 필수 키: {@code batchAppId}</p>
+ * <p>JobDataMap 필수 키: {@code batchAppId}<br>
+ * Redis 미사용 환경에서는 {@link com.example.spiderbatch.spi.NoOpDistributedLockService}가 주입되어
+ * 락 없이 즉시 실행된다.</p>
  */
 @Slf4j
 public class BatchJobQuartzTrigger extends QuartzJobBean {
@@ -30,8 +32,9 @@ public class BatchJobQuartzTrigger extends QuartzJobBean {
     @Autowired
     private BatchExecuteService batchExecuteService;
 
+    /** Redis 유무에 따라 RedisDistributedLockService 또는 NoOpDistributedLockService가 주입됨 */
     @Autowired
-    private RedisDistributedLockService lockService;
+    private DistributedLockService lockService;
 
     private static final DateTimeFormatter BATCH_DATE_FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
 

--- a/spider-batch/src/main/java/com/example/spiderbatch/scheduler/QuartzAutoRegistrar.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/scheduler/QuartzAutoRegistrar.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
-import org.springframework.stereotype.Component;
 
 /**
  * WAS 기동 시 Quartz 스케줄 자동 등록.
@@ -18,9 +17,11 @@ import org.springframework.stereotype.Component;
  *
  * <p>RAMJobStore를 사용하므로 WAS 재기동 시마다 재등록이 필요하다.
  * ApplicationRunner를 통해 기동 완료 후 자동으로 실행된다.</p>
+ *
+ * <p>{@code spring-boot-starter-quartz}가 클래스패스에 있을 때
+ * {@link com.example.spiderbatch.config.QuartzSchedulerConfig}에 의해 자동 등록된다.</p>
  */
 @Slf4j
-@Component
 @RequiredArgsConstructor
 public class QuartzAutoRegistrar implements ApplicationRunner {
 

--- a/spider-batch/src/main/java/com/example/spiderbatch/scheduler/SchedulerManagementService.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/scheduler/SchedulerManagementService.java
@@ -12,7 +12,6 @@ import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.TriggerBuilder;
 import org.quartz.TriggerKey;
-import org.springframework.stereotype.Service;
 
 /**
  * Quartz 스케줄러 관리 서비스.
@@ -23,9 +22,11 @@ import org.springframework.stereotype.Service;
  * <p>현재 JobStore는 RAMJobStore(in-memory)를 사용한다.
  * TODO: 운영 환경에서는 JDBC JobStore로 전환하여 WAS 재기동 시 스케줄을 복구할 것.
  *       application.yml: {@code spring.quartz.job-store-type: jdbc}</p>
+ *
+ * <p>{@code spring-boot-starter-quartz}가 클래스패스에 있을 때
+ * {@link com.example.spiderbatch.config.QuartzSchedulerConfig}에 의해 자동 등록된다.</p>
  */
 @Slf4j
-@Service
 @RequiredArgsConstructor
 public class SchedulerManagementService {
 

--- a/spider-batch/src/main/java/com/example/spiderbatch/spi/DistributedLockService.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/spi/DistributedLockService.java
@@ -1,0 +1,32 @@
+package com.example.spiderbatch.spi;
+
+/**
+ * @file DistributedLockService.java
+ * @description 분산 락 서비스 SPI 인터페이스.
+ *
+ * <p>멀티 인스턴스 환경에서 동일 배치의 중복 실행을 방지하는 분산 락 추상화.
+ * Redis(Redisson) 구현체는 {@code redisson-spring-boot-starter}가 클래스패스에 있을 때
+ * {@link com.example.spiderbatch.config.RedisLockConfig}에 의해 자동 등록된다.
+ * Redis 미사용 환경에서는 항상 락을 허용하는 {@link NoOpDistributedLockService}가 기본으로 등록된다.</p>
+ *
+ * <p>내장 프로젝트에서 다른 락 구현(ZooKeeper 등)을 사용하려면 이 인터페이스를 구현한 Bean을 등록한다.</p>
+ */
+public interface DistributedLockService {
+
+    /**
+     * 배치 분산 락 획득 시도.
+     * 대기 없이 즉시 시도하며 이미 다른 인스턴스가 실행 중이면 {@code false} 반환.
+     *
+     * @param batchAppId 배치 APP ID (락 키 식별자)
+     * @return 락 획득 성공 시 {@code true}, 이미 실행 중이면 {@code false}
+     */
+    boolean tryLock(String batchAppId);
+
+    /**
+     * 배치 분산 락 해제.
+     * 현재 스레드가 보유한 락만 해제한다. 미보유 상태면 무시.
+     *
+     * @param batchAppId 배치 APP ID (락 키 식별자)
+     */
+    void unlock(String batchAppId);
+}

--- a/spider-batch/src/main/java/com/example/spiderbatch/spi/NoOpDistributedLockService.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/spi/NoOpDistributedLockService.java
@@ -1,0 +1,29 @@
+package com.example.spiderbatch.spi;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @file NoOpDistributedLockService.java
+ * @description 분산 락 미사용 기본 구현체.
+ *
+ * <p>Redis(Redisson)가 클래스패스에 없을 때 {@link com.example.spiderbatch.config.SpiderBatchAutoConfiguration}에 의해
+ * 자동 등록된다. 단일 인스턴스 환경이나 중복 실행 방지가 불필요한 경우에 사용한다.</p>
+ *
+ * <p>{@link #tryLock}은 항상 {@code true}를 반환하여 모든 배치 실행 요청을 허용한다.
+ * 멀티 인스턴스 환경에서 중복 실행 방지가 필요하다면 {@link com.example.spiderbatch.lock.RedisDistributedLockService}를
+ * 활성화하거나 커스텀 구현체를 Bean으로 등록해야 한다.</p>
+ */
+@Slf4j
+public class NoOpDistributedLockService implements DistributedLockService {
+
+    @Override
+    public boolean tryLock(String batchAppId) {
+        log.debug("[NoOpLock] 락 획득(No-Op): batchAppId={}", batchAppId);
+        return true;
+    }
+
+    @Override
+    public void unlock(String batchAppId) {
+        log.debug("[NoOpLock] 락 해제(No-Op): batchAppId={}", batchAppId);
+    }
+}

--- a/spider-batch/src/main/java/com/example/spiderbatch/tcp/ScheduleCommandHandler.java
+++ b/spider-batch/src/main/java/com/example/spiderbatch/tcp/ScheduleCommandHandler.java
@@ -5,7 +5,6 @@ import com.example.spidercommon.infra.tcp.handler.CommandHandler;
 import com.example.spidercommon.infra.tcp.model.ManagementContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 
 /**
  * SCHEDULE_TRIGGER / SCHEDULE_CRON_UPDATE 커맨드 핸들러.
@@ -18,9 +17,11 @@ import org.springframework.stereotype.Component;
  *   <li>{@code SCHEDULE_TRIGGER}: 특정 배치 Job을 즉시 실행</li>
  *   <li>{@code SCHEDULE_CRON_UPDATE}: 특정 배치의 Cron 표현식 변경 (ManagementContext.cronText 사용)</li>
  * </ul>
+ *
+ * <p>{@code spring-boot-starter-quartz}가 클래스패스에 있을 때
+ * {@link com.example.spiderbatch.config.QuartzSchedulerConfig}에 의해 자동 등록된다.</p>
  */
 @Slf4j
-@Component
 @RequiredArgsConstructor
 public class ScheduleCommandHandler implements CommandHandler<ManagementContext, ManagementContext> {
 

--- a/spider-batch/src/test/java/com/example/spiderbatch/job/db2db/DateRangePartitionerTest.java
+++ b/spider-batch/src/test/java/com/example/spiderbatch/job/db2db/DateRangePartitionerTest.java
@@ -1,0 +1,117 @@
+package com.example.spiderbatch.job.db2db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * @file DateRangePartitionerTest.java
+ * @description {@link DateRangePartitioner} 단위 테스트.
+ */
+class DateRangePartitionerTest {
+
+    private JdbcTemplate jdbcTemplate;
+    private DateRangePartitioner partitioner;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate = mock(JdbcTemplate.class);
+        partitioner = new DateRangePartitioner(jdbcTemplate, "TEST_TABLE", "DATE_COL");
+    }
+
+    @Test
+    void 데이터_있는_경우_gridSize만큼_파티션_생성() {
+        when(jdbcTemplate.queryForObject("SELECT MIN(DATE_COL) FROM TEST_TABLE", String.class))
+                .thenReturn("20260101");
+        when(jdbcTemplate.queryForObject("SELECT MAX(DATE_COL) FROM TEST_TABLE", String.class))
+                .thenReturn("20260131");
+
+        Map<String, ExecutionContext> result = partitioner.partition(4);
+
+        assertThat(result).hasSize(4);
+        assertThat(result).containsKeys("partition0", "partition1", "partition2", "partition3");
+    }
+
+    @Test
+    void 파티션_minValue_maxValue_범위가_전체_데이터를_포함() {
+        when(jdbcTemplate.queryForObject("SELECT MIN(DATE_COL) FROM TEST_TABLE", String.class))
+                .thenReturn("20260101");
+        when(jdbcTemplate.queryForObject("SELECT MAX(DATE_COL) FROM TEST_TABLE", String.class))
+                .thenReturn("20260131");
+
+        Map<String, ExecutionContext> result = partitioner.partition(4);
+
+        // 첫 파티션의 minValue는 최솟값
+        assertThat(result.get("partition0").getLong("minValue")).isEqualTo(20260101L);
+        // 마지막 파티션의 maxValue는 최댓값
+        assertThat(result.get("partition3").getLong("maxValue")).isEqualTo(20260131L);
+    }
+
+    @Test
+    void 파티션_경계가_연속적임() {
+        when(jdbcTemplate.queryForObject("SELECT MIN(DATE_COL) FROM TEST_TABLE", String.class))
+                .thenReturn("20260101");
+        when(jdbcTemplate.queryForObject("SELECT MAX(DATE_COL) FROM TEST_TABLE", String.class))
+                .thenReturn("20260131");
+
+        Map<String, ExecutionContext> result = partitioner.partition(2);
+
+        long p0Max = result.get("partition0").getLong("maxValue");
+        long p1Min = result.get("partition1").getLong("minValue");
+
+        // 파티션 경계: partition0 maxValue 다음 날 = partition1 minValue
+        // YYYYMMDD 정수 값이므로 정확한 날짜 산술로 검증하기 위해 연속성만 확인
+        assertThat(p1Min).isGreaterThan(p0Max);
+        assertThat(p1Min - p0Max).isLessThanOrEqualTo(2L); // 하루 차이 허용 (말월 경계)
+    }
+
+    @Test
+    void 데이터_없는_경우_단일_빈_파티션_반환() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class)))
+                .thenReturn(null);
+
+        Map<String, ExecutionContext> result = partitioner.partition(4);
+
+        assertThat(result).hasSize(1);
+        assertThat(result).containsKey("partition0");
+        assertThat(result.get("partition0").getLong("minValue")).isEqualTo(0L);
+        assertThat(result.get("partition0").getLong("maxValue")).isEqualTo(0L);
+    }
+
+    @Test
+    void 단일_날짜_데이터_gridSize_1_파티션() {
+        when(jdbcTemplate.queryForObject("SELECT MIN(DATE_COL) FROM TEST_TABLE", String.class))
+                .thenReturn("20260115");
+        when(jdbcTemplate.queryForObject("SELECT MAX(DATE_COL) FROM TEST_TABLE", String.class))
+                .thenReturn("20260115");
+
+        Map<String, ExecutionContext> result = partitioner.partition(1);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get("partition0").getLong("minValue")).isEqualTo(20260115L);
+        assertThat(result.get("partition0").getLong("maxValue")).isEqualTo(20260115L);
+    }
+
+    @Test
+    void 연도경계_파티셔닝_정수산술_데드존_없음() {
+        // 20251231 → 20260101: YYYYMMDD 정수 차이는 8870이지만 달력 기준 1일
+        when(jdbcTemplate.queryForObject("SELECT MIN(DATE_COL) FROM TEST_TABLE", String.class))
+                .thenReturn("20251230");
+        when(jdbcTemplate.queryForObject("SELECT MAX(DATE_COL) FROM TEST_TABLE", String.class))
+                .thenReturn("20260102");
+
+        Map<String, ExecutionContext> result = partitioner.partition(2);
+
+        // 파티션 0이 20251230부터 시작하고, 파티션 1이 20260102에서 끝나야 함
+        assertThat(result.get("partition0").getLong("minValue")).isEqualTo(20251230L);
+        assertThat(result.get("partition1").getLong("maxValue")).isEqualTo(20260102L);
+    }
+}

--- a/spider-batch/src/test/java/com/example/spiderbatch/spi/NoOpDistributedLockServiceTest.java
+++ b/spider-batch/src/test/java/com/example/spiderbatch/spi/NoOpDistributedLockServiceTest.java
@@ -1,0 +1,35 @@
+package com.example.spiderbatch.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @file NoOpDistributedLockServiceTest.java
+ * @description {@link NoOpDistributedLockService} 단위 테스트.
+ */
+class NoOpDistributedLockServiceTest {
+
+    private final NoOpDistributedLockService lockService = new NoOpDistributedLockService();
+
+    @Test
+    void tryLock_항상_true_반환() {
+        assertThat(lockService.tryLock("batchA")).isTrue();
+        assertThat(lockService.tryLock("batchB")).isTrue();
+        assertThat(lockService.tryLock("batchA")).isTrue(); // 중복 획득도 허용
+    }
+
+    @Test
+    void unlock_예외_없이_완료() {
+        // NoOp이므로 예외 없이 정상 종료해야 함
+        lockService.unlock("batchA");
+        lockService.unlock("nonExistentBatch");
+    }
+
+    @Test
+    void 연속_tryLock_unlock_정상_동작() {
+        assertThat(lockService.tryLock("batchC")).isTrue();
+        lockService.unlock("batchC");
+        assertThat(lockService.tryLock("batchC")).isTrue(); // 해제 후 재획득
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

Closes #314

## ✨ 변경 사항 (Changes)

- **`DistributedLockService` SPI 인터페이스** 추가 (`spi/` 패키지) — `BatchHistoryRecorder`와 동일한 패턴으로 분산 락을 추상화
- **`NoOpDistributedLockService`** 추가 — Redisson 미설치 환경(단일 인스턴스) 폴백 구현체
- **`RedisDistributedLockService`** 이동 (batch-was → spider-batch) + SPI 구현 + Redis 연결 실패 시 경고 후 실행 허용
- **`RedisLockConfig`** 추가 — `@ConditionalOnClass(RedissonClient.class)` 조건부 자동 등록
- **`QuartzSchedulerConfig`** 추가 — `@ConditionalOnClass(Scheduler.class)` 조건부 자동 등록
- **`SchedulerManagementService`, `BatchJobQuartzTrigger`, `QuartzAutoRegistrar`, `ScheduleCommandHandler`** 이동 (batch-was → spider-batch)
- **`DateRangePartitioner`** 일반화 — 테이블명·컬럼명 생성자 파라미터로 교체 (기존 `ColumnRangePartitioner` 대체)
- **`AbstractCsvFile2DbJob`** 추가 — CSV → DB 배치 Job 추상 골격
- **`AbstractFixedLengthFile2DbJob`** 추가 — 고정 길이 파일 → DB 배치 Job 추상 골격 (`BomStrippingBufferedReaderFactory` 포함)
- **`BatchNotificationListener`, `FileArchiveTasklet`** 이동 (batch-was → spider-batch)
- **batch-was `application.yml`**: `lazyInitialization: true` 추가 — Redis 미기동 시 WAS 기동 실패 방지

## 🛠 기술적 의사결정

**SPI + `@ConditionalOnClass` 이중 가드 패턴**
Quartz·Redisson을 spider-batch에서 `optional=true`로 선언해 transitive 의존성을 차단하고, 각 클래스의 클래스패스 존재 여부로 Bean 등록을 조건화했습니다. 이로써 spider-batch를 의존하는 프로젝트가 필요한 스타터만 선택적으로 추가하면 해당 기능이 자동 활성화됩니다.

**Redis 연결 실패 시 실행 허용 전략**
`lazyInitialization: true`(기동 시 연결 지연)와 `try-catch Exception`(실행 중 연결 실패 허용) 두 레이어로 방어했습니다. 단일 인스턴스 POC 환경에서 Redis 없이도 배치를 실행할 수 있으며, 멀티 인스턴스 운영에서는 Redis를 항상 기동 상태로 유지해야 중복 실행 제어가 보장됩니다.

## 🧪 테스트

- [x] `DateRangePartitionerTest` — 6개 단위 테스트 (파티션 생성, 경계 연속성, 빈 데이터, 단일 날짜, 연도 경계)
- [x] `NoOpDistributedLockServiceTest` — 3개 단위 테스트 (항상 true 반환, unlock 예외 없음, 연속 lock/unlock)
- [x] spider-batch `mvn install -DskipTests` 빌드 성공
- [x] batch-was `mvn clean compile` 컴파일 성공

## ⚠️ 고려 및 주의 사항

- 멀티 인스턴스 운영 환경에서는 Redis를 반드시 기동 상태로 유지해야 합니다. Redis 연결 실패 시 분산 락 없이 실행되므로 중복 실행이 발생할 수 있습니다.
- `spring.quartz.job-store-type: memory`(RAMJobStore) 사용 중 — WAS 재기동 시 Quartz Job이 초기화됩니다. 운영 시 `jdbc` 모드로 전환 필요합니다.