### PR TITLE
✨ feat/#319-즉시결제 PIN 시도 횟수 공유 저장소 분리 및 초기화 기능 구현

### DIFF
--- a/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/controller/CardController.java
+++ b/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/controller/CardController.java
@@ -150,7 +150,9 @@ public class CardController {
 
         Map<String, Object> payload = new HashMap<>();
         payload.put("userId", userId);
-        if (yearMonth != null)  payload.put("yearMonth", yearMonth);
+        // 프론트엔드가 "YYYY-MM" 형식으로 전달하는 경우 하이픈 제거
+        // mock-core 고정길이 프로토콜의 yearMonth 필드가 C(6, YYYYMM)이라 7자 이상이면 잘림
+        if (yearMonth != null)  payload.put("yearMonth", yearMonth.replace("-", ""));
         if (paymentDay != null) payload.put("paymentDay", paymentDay);
 
         try {
@@ -237,8 +239,17 @@ public class CardController {
         try {
             JsonCommandResponse resp = bizClient.sendToTransfer(BizCommands.TRANSFER_IMMEDIATE_PAY, payload, requestId);
             if (!resp.isSuccess()) {
+                String errorMsg = resp.getError() != null ? resp.getError()
+                        : resp.getMessage() != null ? resp.getMessage()
+                        : "즉시결제 실패";
+                // payload가 있으면 PIN 오류 계열(attemptsLeft 포함) — 403으로 전달
+                if (resp.getPayload() != null && !resp.getPayload().isEmpty()) {
+                    Map<String, Object> errorBody = new HashMap<>(resp.getPayload());
+                    errorBody.put("error", errorMsg);
+                    return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorBody);
+                }
                 return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                        .body(Map.of("error", resp.getMessage() != null ? resp.getMessage() : "즉시결제 실패"));
+                        .body(Map.of("error", errorMsg));
             }
             return ResponseEntity.ok(resp.getPayload());
         } catch (IOException e) {
@@ -269,10 +280,24 @@ public class CardController {
             @PathVariable String cardId) {
 
         String userId = (String) request.getAttribute("userId");
+        String requestId = (String) request.getAttribute("requestId");
         log.info("[CardController] Reset PIN attempts: userId={}, cardId={}", userId, cardId);
 
-        // PIN 시도 횟수는 이체AP(biz-transfer) 내부에서 관리
-        // 채널AP 는 현재 단순 OK 응답만 반환 (이체AP 연동은 추후 확장)
-        return ResponseEntity.ok(Map.of("ok", true));
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("userId", userId);
+        payload.put("cardId", cardId);
+
+        try {
+            JsonCommandResponse resp = bizClient.sendToTransfer(BizCommands.TRANSFER_RESET_PIN_ATTEMPTS, payload, requestId);
+            if (!resp.isSuccess()) {
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .body(Map.of("error", resp.getError() != null ? resp.getError() : "PIN 초기화 실패"));
+            }
+            return ResponseEntity.ok(Map.of("ok", true));
+        } catch (IOException e) {
+            log.error("[CardController] biz-transfer TCP error (reset-pin-attempts): {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "이체 서버 통신 오류"));
+        }
     }
 }

--- a/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/controller/CardController.java
+++ b/demo/bizApp/biz-channel/src/main/java/com/example/bizchannel/web/controller/CardController.java
@@ -242,8 +242,8 @@ public class CardController {
                 String errorMsg = resp.getError() != null ? resp.getError()
                         : resp.getMessage() != null ? resp.getMessage()
                         : "즉시결제 실패";
-                // payload가 있으면 PIN 오류 계열(attemptsLeft 포함) — 403으로 전달
-                if (resp.getPayload() != null && !resp.getPayload().isEmpty()) {
+                // attemptsLeft 키가 있는 경우만 PIN 오류 계열로 판별 — 403으로 전달
+                if (resp.getPayload() != null && resp.getPayload().containsKey("attemptsLeft")) {
                     Map<String, Object> errorBody = new HashMap<>(resp.getPayload());
                     errorBody.put("error", errorMsg);
                     return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorBody);
@@ -291,7 +291,9 @@ public class CardController {
             JsonCommandResponse resp = bizClient.sendToTransfer(BizCommands.TRANSFER_RESET_PIN_ATTEMPTS, payload, requestId);
             if (!resp.isSuccess()) {
                 return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                        .body(Map.of("error", resp.getError() != null ? resp.getError() : "PIN 초기화 실패"));
+                        .body(Map.of("error", resp.getError() != null ? resp.getError()
+                                : resp.getMessage() != null ? resp.getMessage()
+                                : "PIN 초기화 실패"));
             }
             return ResponseEntity.ok(Map.of("ok", true));
         } catch (IOException e) {

--- a/demo/bizApp/biz-common/src/main/java/com/example/bizcommon/BizCommands.java
+++ b/demo/bizApp/biz-common/src/main/java/com/example/bizcommon/BizCommands.java
@@ -42,6 +42,9 @@ public final class BizCommands {
     /** 즉시결제 처리: {userId, cardId, pin, amount, accountNumber} → {paidAmount, processedCount, completedAt} */
     public static final String TRANSFER_IMMEDIATE_PAY = "TRANSFER_IMMEDIATE_PAY";
 
+    /** PIN 시도 횟수 초기화: {userId, cardId} → {ok: true} */
+    public static final String TRANSFER_RESET_PIN_ATTEMPTS = "TRANSFER_RESET_PIN_ATTEMPTS";
+
     // ──────────────────────────────────────────────────────────────────────────
     // 계정계 Mock (mock-core, port 19300) — 인증AP/이체AP → 계정계
     // ──────────────────────────────────────────────────────────────────────────

--- a/demo/bizApp/biz-transfer/src/main/java/com/example/biztransfer/handler/TransferImmediatePayHandler.java
+++ b/demo/bizApp/biz-transfer/src/main/java/com/example/biztransfer/handler/TransferImmediatePayHandler.java
@@ -2,6 +2,7 @@ package com.example.biztransfer.handler;
 
 import com.example.bizcommon.BizCommands;
 import com.example.biztransfer.service.TransferService;
+import com.example.biztransfer.store.PinAttemptStore;
 import com.example.spidercommon.infra.tcp.handler.CommandHandler;
 import com.example.spidercommon.infra.tcp.model.JsonCommandRequest;
 import com.example.spidercommon.infra.tcp.model.JsonCommandResponse;
@@ -13,7 +14,6 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * TRANSFER_IMMEDIATE_PAY 커맨드 핸들러.
@@ -40,9 +40,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class TransferImmediatePayHandler implements CommandHandler<JsonCommandRequest, JsonCommandResponse> {
 
     private final TransferService transferService;
-
-    /** PIN 실패 횟수 추적 — 키: "userId:cardId", 값: 연속 실패 횟수 */
-    private final Map<String, Integer> pinAttemptStore = new ConcurrentHashMap<>();
+    private final PinAttemptStore pinAttemptStore;
 
     /** PIN 최대 허용 시도 횟수 */
     private static final int PIN_MAX_ATTEMPTS = 3;
@@ -63,24 +61,24 @@ public class TransferImmediatePayHandler implements CommandHandler<JsonCommandRe
         String pinKey = userId + ":" + cardId;
 
         // 이미 잠금 상태인지 확인
-        int attempts = pinAttemptStore.getOrDefault(pinKey, 0);
+        int attempts = pinAttemptStore.get(pinKey);
         if (attempts >= PIN_MAX_ATTEMPTS) {
             log.warn("[TransferImmediatePayHandler] PIN 잠금 — userId={}, cardId={}", userId, cardId);
             return JsonCommandResponse.builder()
                     .command(command)
                     .success(false)
                     .error("PIN 입력 횟수를 초과하였습니다.")
+                    .payload(Map.of("attemptsLeft", 0))
                     .build();
         }
 
         // 유효 PIN: 오늘 날짜의 MMDD (월·일 모두 두 자리 zero-padding)
-        // 서버 기본 시간대가 달라도 한국 시간 기준으로 PIN을 검증하기 위해 시간대 명시
+        // 서버 기반 시간대가 달라도 한국 시간 기준으로 PIN을 검증하기 위해 시간대 명시
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         String validPin = String.format("%02d%02d", today.getMonthValue(), today.getDayOfMonth());
 
         if (!validPin.equals(pin)) {
-            int updatedAttempts = attempts + 1;
-            pinAttemptStore.put(pinKey, updatedAttempts);
+            int updatedAttempts = pinAttemptStore.increment(pinKey);
             int remaining = PIN_MAX_ATTEMPTS - updatedAttempts;
 
             log.warn("[TransferImmediatePayHandler] PIN 불일치 — userId={}, cardId={}, 시도={}/{}",
@@ -89,12 +87,13 @@ public class TransferImmediatePayHandler implements CommandHandler<JsonCommandRe
             return JsonCommandResponse.builder()
                     .command(command)
                     .success(false)
-                    .error("PIN 번호가 올바르지 않습니다. 남은 시도 횟수: " + remaining)
+                    .error("PIN이 올바르지 않습니다.")
+                    .payload(Map.of("attemptsLeft", remaining))
                     .build();
         }
 
         // PIN 검증 성공 — 시도 횟수 초기화
-        pinAttemptStore.remove(pinKey);
+        pinAttemptStore.reset(pinKey);
         log.debug("[TransferImmediatePayHandler] PIN 검증 성공 — userId={}, cardId={}", userId, cardId);
 
         // mock-core에는 pin 필드를 포함하지 않고 전달 (보안)

--- a/demo/bizApp/biz-transfer/src/main/java/com/example/biztransfer/handler/TransferResetPinAttemptsHandler.java
+++ b/demo/bizApp/biz-transfer/src/main/java/com/example/biztransfer/handler/TransferResetPinAttemptsHandler.java
@@ -1,0 +1,49 @@
+package com.example.biztransfer.handler;
+
+import com.example.bizcommon.BizCommands;
+import com.example.biztransfer.store.PinAttemptStore;
+import com.example.spidercommon.infra.tcp.handler.CommandHandler;
+import com.example.spidercommon.infra.tcp.model.JsonCommandRequest;
+import com.example.spidercommon.infra.tcp.model.JsonCommandResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+/**
+ * TRANSFER_RESET_PIN_ATTEMPTS 커맨드 핸들러.
+ *
+ * <p>관리자 또는 사용자 본인 확인 후 PIN 실패 횟수를 초기화한다.
+ * {@link PinAttemptStore}에서 해당 "userId:cardId" 키를 삭제해
+ * 잠금 상태를 해제한다. mock-core 호출 없이 biz-transfer 내부에서 처리된다.</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TransferResetPinAttemptsHandler implements CommandHandler<JsonCommandRequest, JsonCommandResponse> {
+
+    private final PinAttemptStore pinAttemptStore;
+
+    @Override
+    public boolean supports(String command) {
+        return BizCommands.TRANSFER_RESET_PIN_ATTEMPTS.equals(command);
+    }
+
+    @Override
+    public JsonCommandResponse handle(String command, JsonCommandRequest request) {
+        Map<String, Object> payload = request.getPayload();
+        String userId = (String) payload.get("userId");
+        String cardId = (String) payload.get("cardId");
+
+        String pinKey = userId + ":" + cardId;
+        pinAttemptStore.reset(pinKey);
+        log.info("[TransferResetPinAttemptsHandler] PIN 시도 횟수 초기화 — userId={}, cardId={}", userId, cardId);
+
+        return JsonCommandResponse.builder()
+                .command(command)
+                .success(true)
+                .payload(Map.of("ok", true))
+                .build();
+    }
+}

--- a/demo/bizApp/biz-transfer/src/main/java/com/example/biztransfer/store/PinAttemptStore.java
+++ b/demo/bizApp/biz-transfer/src/main/java/com/example/biztransfer/store/PinAttemptStore.java
@@ -1,0 +1,36 @@
+package com.example.biztransfer.store;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 카드별 PIN 실패 횟수를 인메모리로 관리하는 공유 저장소.
+ *
+ * <p>키 형식: "userId:cardId" — 사용자·카드 복합 키로 독립 관리한다.</p>
+ *
+ * <p>{@link com.example.biztransfer.handler.TransferImmediatePayHandler}와
+ * {@link com.example.biztransfer.handler.TransferResetPinAttemptsHandler}가 동일 인스턴스를 주입받아
+ * 실패 횟수를 공유한다. 서버 재시작 시 초기화된다.</p>
+ */
+@Component
+public class PinAttemptStore {
+
+    private final Map<String, Integer> store = new ConcurrentHashMap<>();
+
+    /** 현재 실패 횟수를 반환한다. 기록이 없으면 0. */
+    public int get(String key) {
+        return store.getOrDefault(key, 0);
+    }
+
+    /** 실패 횟수를 1 증가시키고 변경된 값을 반환한다. */
+    public int increment(String key) {
+        return store.merge(key, 1, Integer::sum);
+    }
+
+    /** 해당 키의 실패 횟수를 초기화(삭제)한다. */
+    public void reset(String key) {
+        store.remove(key);
+    }
+}

--- a/demo/front/src/routes/RouteWrappers.tsx
+++ b/demo/front/src/routes/RouteWrappers.tsx
@@ -999,6 +999,8 @@ export function ImmediatePayMethodRoute() {
           // 시트를 닫아도 초과 상태는 유지되어야 페이지의 초기화 버튼이 표시된다
         }}
         onConfirm={async (pin) => {
+          // 횟수 초과 상태에서는 키패드를 잠그지 않고 검증 로직만 차단한다
+          if (pinExceeded) return;
           try {
             const { data } = await axiosInstance.post<{
               paidAmount: number;
@@ -1026,19 +1028,23 @@ export function ImmediatePayMethodRoute() {
             const status = response?.status;
             const data = response?.data;
 
-            if (data?.attemptsLeft === 0) {
-              // 횟수 소진 — 시트에 초과 메시지를 표시한 채로 유지하고,
-              // 페이지에 초기화 버튼을 준비한다 (시트를 닫으면 버튼이 보임)
-              setPinError(
-                "PIN 입력 횟수를 초과하였습니다. 초기화 후 다시 시도해 주세요.",
-              );
-              setPinExceeded(true);
-            } else if (data?.attemptsLeft !== undefined) {
-              setPinError(
-                `PIN이 올바르지 않습니다. (${data.attemptsLeft}회 남음)`,
-              );
+            if (status === 403) {
+              // 403은 항상 PIN 오류 — 완료 화면으로 이동하지 않고 시트 안에서 처리한다
+              if (data?.attemptsLeft === 0) {
+                setPinError(
+                  "PIN 입력 횟수를 초과하였습니다. 초기화 후 다시 시도해 주세요.",
+                );
+                setPinExceeded(true);
+              } else {
+                const remaining = data?.attemptsLeft;
+                setPinError(
+                  remaining !== undefined
+                    ? `PIN이 올바르지 않습니다. (${remaining}회 남음)`
+                    : (data?.error ?? "PIN이 올바르지 않습니다."),
+                );
+              }
             } else {
-              // PIN 오류 외의 예외는 완료 화면으로 이동해 오류 내용을 표시한다.
+              // PIN 검증 통과 후 결제 처리 중 발생한 오류는 완료 화면으로 이동해 표시한다.
               // 4xx(비즈니스 오류): 서버가 보낸 구체적인 사유를 그대로 노출한다.
               // 5xx(시스템 오류): 내부 오류를 사용자에게 노출하지 않고 일반 메시지를 사용한다.
               const isBusinessError =


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #319

## ✨ 변경 사항 (Changes)
즉시결제 PIN 실패 횟수 관리를 공유 가능한 Spring Bean으로 분리하고, PIN 시도 횟수 초기화 기능을 biz-transfer까지 연동합니다.

- `PinAttemptStore.java` (신규) — `"userId:cardId"` 키 기반 PIN 실패 횟수 인메모리 Bean (`get` / `increment` / `reset`)
- `TransferResetPinAttemptsHandler.java` (신규) — `TRANSFER_RESET_PIN_ATTEMPTS` 커맨드 수신 시 PIN 잠금 해제
- `BizCommands.java` — `TRANSFER_RESET_PIN_ATTEMPTS` 커맨드 상수 추가
- `TransferImmediatePayHandler.java` — `PinAttemptStore` Bean 주입으로 교체, 잠금·실패 응답에 `attemptsLeft` payload 포함
- `CardController.java` — yearMonth 하이픈 제거 버그 수정, PIN 오류 시 HTTP 403 + `attemptsLeft` 반환, PIN 초기화 API biz-transfer 연동
- `RouteWrappers.tsx` — 횟수 초과 시 키패드 비활성화(`pinExceeded` 가드), HTTP 403 기반 PIN 오류 분기 처리

## 🛠 기술적 의사결정 (선택)
`TransferImmediatePayHandler`(실패 기록)와 `TransferResetPinAttemptsHandler`(초기화)가 동일 저장소를 참조해야 합니다. 각 핸들러가 독립 Bean이므로 필드로는 공유 불가능하여 `PinAttemptStore`를 Singleton Bean으로 등록해 두 핸들러가 동일 인스턴스를 주입받도록 설계했습니다.

HTTP 403을 PIN 오류 전용 상태 코드로 사용합니다. 인증 실패(401)와 구분되므로 프론트엔드에서 PIN 오류와 결제 오류를 명확히 분기할 수 있습니다.

## ⚠️ 고려 및 주의 사항 (선택)
- `PinAttemptStore`는 인메모리 저장소이므로 서버 재시작 시 PIN 잠금 상태가 초기화됩니다. (데모 환경 허용 범위)
- yearMonth 필드: mock-core 고정길이 프로토콜의 C(6) 필드가 `"YYYY-MM"` 7자를 받으면 마지막 자리가 잘리는 버그를 수정했습니다.