### PR TITLE
♻️ refactor/#321-react-cms Vite dev 포트 변경 (5173 → 5273)

### DIFF
--- a/react-cms/README.md
+++ b/react-cms/README.md
@@ -198,7 +198,9 @@ npm install
 npm run dev
 ```
 
-빌더 UI는 `http://localhost:5173/builder` 에서 접근한다. 페이지는 파일시스템(`demo/front`)에 저장된다.
+빌더 UI는 `http://localhost:5273/builder` 에서 접근한다. 페이지는 파일시스템(`demo/front`)에 저장된다.
+
+> Vite dev server 포트는 `vite.config.ts`에서 `5273`으로 고정한다. 다른 Vite 프로젝트(데모 등)와 동시 실행 시 충돌을 피하기 위함이며, spider-admin nginx 프록시 설정도 같은 값을 가리킨다.
 
 > `cmsBankPlugin`이 `react-cms` Vite 서버에 `/__cms/create-page` 엔드포인트를 등록하므로,
 > 저장 기능을 사용하려면 `demo/front`가 실행 중일 필요 없이 `react-cms` dev 서버만 실행하면 된다.

--- a/react-cms/vite.config.ts
+++ b/react-cms/vite.config.ts
@@ -35,6 +35,9 @@ export default defineConfig(({ mode }) => {
   server: {
     // 모든 네트워크 인터페이스에 바인딩 — Docker(nginx)에서 host.docker.internal로 접근하기 위해 필요
     host: true,
+    // 다른 dev 도구(Vite default 5173)와 충돌을 피하기 위해 5273을 고정 사용.
+    // spider-admin/nginx/cms-local-proxy.conf의 proxy_pass와 동일 값을 유지해야 함.
+    port: 5273,
   },
   plugins: [
     react(),

--- a/spider-admin/nginx/cms-local-proxy.conf
+++ b/spider-admin/nginx/cms-local-proxy.conf
@@ -65,10 +65,12 @@ server {
         proxy_redirect http://localhost/ http://localhost:9000/;
     }
 
-    # /react-cms/** → react-cms Vite dev server (포트 5173)
+    # /react-cms/** → react-cms Vite dev server (포트 5273)
     # WebSocket 업그레이드 포함 — Vite HMR 필수
+    # 5173(Vite default)이 다른 dev 도구와 자주 충돌해 5273으로 분리.
+    # react-cms/vite.config.ts의 server.port와 동일 값 유지.
     location ^~ /react-cms/ {
-        proxy_pass http://host.docker.internal:5173;
+        proxy_pass http://host.docker.internal:5273;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #321

## ✨ 변경 사항
- `react-cms/vite.config.ts` — `server.port: 5273` 고정
- `spider-admin/nginx/cms-local-proxy.conf` — `/react-cms/` location의 `proxy_pass` 5173 → 5273
- `react-cms/README.md` — 단독 실행 가이드의 포트 안내 갱신 (`localhost:5173/builder` → `localhost:5273/builder`)

## 🛠 기술적 의사결정
- **5273 선정 이유**: Vite default(5173)와 +100 차이 — Vite가 자동 fallback으로 사용하는 5174/5175 등과도 겹치지 않음. 4자리라 입력 부담 적음
- **단독·프록시 모드 통일**: `vite.config.ts`에서 한 번만 정의하면 `npm run dev`와 `npm run dev:proxy` 양쪽 모두 5273에서 listening. 이후 nginx 설정과 일관성 확보

## ⚠️ 고려 및 주의 사항
- 적용 시 **spider-admin의 nginx 컨테이너 reload** 필요 (`docker compose restart` 또는 `nginx -s reload`)
- 로컬 환경에서 5273 포트가 사용 중이지 않은지 확인 권장

## 🔗 참고 사항
- 기존 5173은 demo/front(Vite default)가 그대로 사용
- spider-admin의 `application.yml`에 있는 `demo.frontend.url=...:5173`은 demo/front 참조이므로 변경 대상 아님
