### PR TITLE
✨ feat/#323-하나카드 결제일별 신용공여기간 계산 및 프론트엔드 billingPeriod 연동

### DIFF
--- a/demo/bizApp/mock-core/src/main/java/com/example/mockcore/repository/AccountRepository.java
+++ b/demo/bizApp/mock-core/src/main/java/com/example/mockcore/repository/AccountRepository.java
@@ -7,6 +7,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.YearMonth;
 import java.util.ArrayList;
@@ -322,9 +323,27 @@ public class AccountRepository {
             effectivePaymentDay = "25"; // 기본 결제일
         }
 
-        // 청구 기간: targetYearMonth 기준 전달 26일 ~ 당월 25일 (결제일 25일 기준 예시)
-        String billingFrom = getPrevMonthDay(targetYearMonth, "26");
-        String billingTo = targetYearMonth + effectivePaymentDay;
+        // 하나카드 결제일별 신용공여기간(일시불·할부) 기준:
+        // D <= 12: 전전월 (D+18)일 ~ 전월 (D+17)일
+        // D == 13: 전월 1일 ~ 전월 말일
+        // D >= 14: 전월 (D-12)일 ~ 당월 (D-13)일
+        YearMonth paymentYM  = YearMonth.parse(targetYearMonth, YEAR_MONTH_FMT);
+        YearMonth prevYM     = paymentYM.minusMonths(1);
+        YearMonth prevPrevYM = paymentYM.minusMonths(2);
+        int d = Integer.parseInt(effectivePaymentDay);
+        LocalDate billingFromDate, billingToDate;
+        if (d <= 12) {
+            billingFromDate = prevPrevYM.atDay(Math.min(d + 18, prevPrevYM.lengthOfMonth()));
+            billingToDate   = prevYM.atDay(Math.min(d + 17, prevYM.lengthOfMonth()));
+        } else if (d == 13) {
+            billingFromDate = prevYM.atDay(1);
+            billingToDate   = prevYM.atEndOfMonth();
+        } else {
+            billingFromDate = prevYM.atDay(d - 12);
+            billingToDate   = paymentYM.atDay(d - 13);
+        }
+        String billingFrom = billingFromDate.format(DATE_FMT);
+        String billingTo   = billingToDate.format(DATE_FMT);
 
         // dueDate: 결제 연월 + 결제일
         String dueDate = targetYearMonth + effectivePaymentDay;
@@ -372,7 +391,12 @@ public class AccountRepository {
         result.put("totalAmount", totalAmount);
         result.put("items", items);
         result.put("cardInfo", cardInfo);
-        result.put("billingPeriod", null); // 필요 시 확장 (현재 billingFrom~billingTo 미노출)
+        DateTimeFormatter displayFmt = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        Map<String, Object> billingPeriodMap = new HashMap<>();
+        billingPeriodMap.put("usageStart", billingFromDate.format(displayFmt));
+        billingPeriodMap.put("usageEnd",   billingToDate.format(displayFmt));
+        billingPeriodMap.put("dueDate",    LocalDate.parse(dueDate, DATE_FMT).format(displayFmt));
+        result.put("billingPeriod", billingPeriodMap);
         return result;
     }
 

--- a/demo/bizApp/mock-core/src/main/java/com/example/mockcore/repository/AccountRepository.java
+++ b/demo/bizApp/mock-core/src/main/java/com/example/mockcore/repository/AccountRepository.java
@@ -346,8 +346,8 @@ public class AccountRepository {
         String billingFrom = billingFromDate.format(DATE_FMT);
         String billingTo   = billingToDate.format(DATE_FMT);
 
-        // dueDate: 결제 연월 + 결제일
-        String dueDate = targetYearMonth + effectivePaymentDay;
+        // %02d: 결제일 한 자리(예: 5) 시 7자리 문자열 방지 — 고정길이 전문 8자리 규격 준수
+        String dueDate = targetYearMonth + String.format("%02d", d);
 
         // 카드별 이용금액 집계 (해당 청구 기간 내 승인된 거래)
         List<Map<String, Object>> items = new ArrayList<>();

--- a/demo/bizApp/mock-core/src/main/java/com/example/mockcore/repository/AccountRepository.java
+++ b/demo/bizApp/mock-core/src/main/java/com/example/mockcore/repository/AccountRepository.java
@@ -330,7 +330,8 @@ public class AccountRepository {
         YearMonth paymentYM  = YearMonth.parse(targetYearMonth, YEAR_MONTH_FMT);
         YearMonth prevYM     = paymentYM.minusMonths(1);
         YearMonth prevPrevYM = paymentYM.minusMonths(2);
-        int d = Integer.parseInt(effectivePaymentDay);
+        // trim(): DB CHAR 컬럼 등에서 공백이 포함될 경우 NumberFormatException 방지
+        int d = Integer.parseInt(effectivePaymentDay.trim());
         LocalDate billingFromDate, billingToDate;
         if (d <= 12) {
             billingFromDate = prevPrevYM.atDay(Math.min(d + 18, prevPrevYM.lengthOfMonth()));
@@ -395,7 +396,8 @@ public class AccountRepository {
         Map<String, Object> billingPeriodMap = new HashMap<>();
         billingPeriodMap.put("usageStart", billingFromDate.format(displayFmt));
         billingPeriodMap.put("usageEnd",   billingToDate.format(displayFmt));
-        billingPeriodMap.put("dueDate",    LocalDate.parse(dueDate, DATE_FMT).format(displayFmt));
+        // paymentYM.atDay(d): 이미 계산된 변수 재사용 — LocalDate.parse(dueDate) 시 DateTimeParseException 방지
+        billingPeriodMap.put("dueDate",    paymentYM.atDay(Math.min(d, paymentYM.lengthOfMonth())).format(displayFmt));
         result.put("billingPeriod", billingPeriodMap);
         return result;
     }

--- a/demo/front/src/routes/RouteWrappers.tsx
+++ b/demo/front/src/routes/RouteWrappers.tsx
@@ -407,7 +407,8 @@ interface StmtApiItem {
   cardNo: string;
   cardName: string;
   amount: number;
-  dueDate: string;
+  /** 고정길이 파서가 MESSAGE_FIELD_ID "itemDueDate" 로 반환 (헤더 dueDate 와 충돌 방지) */
+  itemDueDate: string;
 }
 /** /api/payment-statement 응답 billingPeriod 타입 */
 interface StmtBillingPeriod {
@@ -429,7 +430,8 @@ interface StmtApiResponse {
 }
 
 /** YYMMDD or YYYYMMDD → "M월 D일 결제" 레이블 */
-function fmtDueDateLabel(raw: string): string {
+function fmtDueDateLabel(raw: string | undefined): string {
+  if (!raw) return "";
   if (raw.length === 6)
     return `${Number(raw.slice(2, 4))}월 ${Number(raw.slice(4, 6))}일 결제`;
   if (raw.length === 8)
@@ -465,7 +467,8 @@ function isPaymentUpcoming(
 }
 
 /** YYMMDD or YYYYMMDD → { dateFull, dateYM, dateMD } */
-function parseDueDate(raw: string) {
+function parseDueDate(raw: string | undefined) {
+  if (!raw) return { dateFull: "", dateYM: "", dateMD: "" };
   if (raw.length === 6) {
     const y = `20${raw.slice(0, 2)}`,
       m = raw.slice(2, 4),
@@ -592,15 +595,16 @@ export function PaymentStatementRoute() {
     statementData: StatementTabData;
   }>(() => {
     /* 결제예정금액 탭 — 백엔드가 청구월 기준으로 필터링한 allItems 사용 */
-    const paymentTotalAmt = allItems.reduce((s, i) => s + i.amount, 0);
-    const firstDue = allItems[0]?.dueDate ?? "";
+    /* Number() 변환: 고정길이 파서 N 타입이 String으로 반환되므로 숫자 합산 보정 */
+    const paymentTotalAmt = allItems.reduce((s, i) => s + Number(i.amount), 0);
+    const firstDue = allItems[0]?.itemDueDate ?? "";
     const { dateFull, dateYM, dateMD } = parseDueDate(firstDue);
     const paymentItems: CardPaymentEntry[] = allItems.map((item) => ({
-      id: `${item.cardNo}_${item.dueDate}`,
+      id: `${item.cardNo}_${item.itemDueDate}`,
       icon: <CreditCard className="size-5" />,
-      cardEnName: fmtDueDateLabel(item.dueDate),
+      cardEnName: fmtDueDateLabel(item.itemDueDate),
       cardName: item.cardName,
-      amount: item.amount,
+      amount: Number(item.amount),
     }));
 
     /* 이용대금명세서 탭 — 동일 항목 재사용 */

--- a/demo/front/src/routes/RouteWrappers.tsx
+++ b/demo/front/src/routes/RouteWrappers.tsx
@@ -340,7 +340,7 @@ export function UsageHistoryRoute() {
       .then((r) => {
         const data = r.data;
         setTransactions(data.transactions ?? []);
-        setTotalCount(data.totalCount ?? 0);
+        setTotalCount(Number(data.totalCount ?? 0));
         setPaymentSummary(data.paymentSummary ?? { date: "", totalAmount: 0 });
       })
       .catch(console.error);
@@ -364,7 +364,7 @@ export function UsageHistoryRoute() {
     ])
       .then(([txData, cardData]) => {
         setTransactions(txData.transactions ?? []);
-        setTotalCount(txData.totalCount ?? 0);
+        setTotalCount(Number(txData.totalCount ?? 0));
         setPaymentSummary(
           txData.paymentSummary ?? { date: "", totalAmount: 0 },
         );
@@ -809,13 +809,13 @@ export function ImmediatePayRequestRoute() {
         { signal: controller.signal },
       )
       .then((r) => {
-        setPayableAmount(r.data.payableAmount);
+        setPayableAmount(Number(r.data.payableAmount));
         // STEP 3 확인 시트에서 결제 후 이용가능한도 계산에 필요한 값을 세션에 저장한다.
         sessionStorage.setItem(
           "immediatePayAmountInfo",
           JSON.stringify({
-            payableAmount: r.data.payableAmount,
-            creditLimit: r.data.creditLimit,
+            payableAmount: Number(r.data.payableAmount),
+            creditLimit: Number(r.data.creditLimit),
           }),
         );
       })
@@ -913,10 +913,10 @@ export function ImmediatePayMethodRoute() {
     ? (JSON.parse(storedRequest) as { usageType: string; payAmount: number })
     : { usageType: "lump", payAmount: 0 };
   const { payableAmount: totalPayable, creditLimit } = storedAmountInfo
-    ? (JSON.parse(storedAmountInfo) as {
-        payableAmount: number;
-        creditLimit: number;
-      })
+    ? (() => {
+        const parsed = JSON.parse(storedAmountInfo) as { payableAmount: unknown; creditLimit: unknown };
+        return { payableAmount: Number(parsed.payableAmount), creditLimit: Number(parsed.creditLimit) };
+      })()
     : { payableAmount: 0, creditLimit: 0 };
 
   // 이용구분 코드 → 표시 문자열
@@ -1106,10 +1106,10 @@ export function ImmediatePayCompleteRoute() {
     ? (JSON.parse(storedAccount) as { bankName: string; maskedAccount: string })
     : { bankName: "", maskedAccount: "" };
   const amountInfo = storedAmountInfo
-    ? (JSON.parse(storedAmountInfo) as {
-        payableAmount: number;
-        creditLimit: number;
-      })
+    ? (() => {
+        const parsed = JSON.parse(storedAmountInfo) as { payableAmount: unknown; creditLimit: unknown };
+        return { payableAmount: Number(parsed.payableAmount), creditLimit: Number(parsed.creditLimit) };
+      })()
     : { payableAmount: 0, creditLimit: 0 };
 
   // 결제 후 이용가능한도 = 한도금액 - (미결제금액 - 결제금액)


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #323

## ✨ 변경 사항 (Changes)
mock-core의 청구기간 계산 로직을 결제일(D)별 하나카드 신용공여기간 기준으로 구현하고, 프론트엔드의 관련 버그를 수정합니다.

- `AccountRepository.java` — 결제일 D에 따른 청구기간 분기 계산 (D≤12 / D=13 / D≥14), `billingPeriod` 응답에 `usageStart`·`usageEnd`·`dueDate` 실제 데이터 반환 (기존: null)
- `RouteWrappers.tsx` — `StmtApiItem.dueDate` → `itemDueDate` 필드명 변경 (헤더 `dueDate` 키 충돌 방지), `amount` `Number()` 변환 (고정길이 파서 String 반환 대응), `fmtDueDateLabel`·`parseDueDate` `undefined` 방어 처리 추가

## 🛠 기술적 의사결정 (선택)
월말 날짜 초과 방지를 위해 `Math.min(d + 18, prevPrevYM.lengthOfMonth())` 패턴을 사용했습니다. `YearMonth.atDay()` 는 말일을 초과하면 예외를 던지므로 명시적 clamp가 필요합니다.

## ⚠️ 고려 및 주의 사항 (선택)
- `billingPeriod` 날짜 포맷은 `yyyy.MM.dd`로 통일 (프론트엔드 표시 포맷과 일치)
- 고정길이 파서 N 타입이 String으로 반환되는 문제는 `Number()` 변환으로 처리. 파서 레벨 수정은 별도 이슈로 관리 필요