### PR TITLE
✨ feat/#325-긴급차단복구기능구현

### DIFF
--- a/html-cms/src/app/api/deploy/emergency-block/[pageId]/route.ts
+++ b/html-cms/src/app/api/deploy/emergency-block/[pageId]/route.ts
@@ -47,7 +47,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ pag
             }),
         );
 
-        return successResponse({ pageId, results }, '긴급차단이 완료되었습니다.');
+        return successResponse({ pageId, results, message: '긴급차단이 완료되었습니다.' });
     } catch (err: unknown) {
         console.error('긴급차단 처리 실패:', err);
         return errorResponse(getErrorMessage(err));

--- a/html-cms/src/app/api/deploy/emergency-block/[pageId]/route.ts
+++ b/html-cms/src/app/api/deploy/emergency-block/[pageId]/route.ts
@@ -1,0 +1,55 @@
+// src/app/api/deploy/emergency-block/[pageId]/route.ts
+// 긴급차단 API — IS_PUBLIC='N' 업데이트 + 배포된 HTML 파일 삭제
+
+import { NextRequest } from 'next/server';
+
+import { getServerList } from '@/db/repository/file-send.repository';
+import { getPageById, setPagePublic } from '@/db/repository/page.repository';
+import { canWriteCms, getCurrentUser } from '@/lib/current-user';
+import { errorResponse, getErrorMessage, successResponse } from '@/lib/api-response';
+import { buildServerUrl, deleteFromServer } from '@/lib/deploy-utils';
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ pageId: string }> }) {
+    try {
+        const currentUser = await getCurrentUser();
+        if (!canWriteCms(currentUser)) {
+            return errorResponse('권한이 없습니다.', 401);
+        }
+
+        const { pageId } = await params;
+        if (!pageId || typeof pageId !== 'string') {
+            return errorResponse('pageId가 필요합니다.', 400);
+        }
+
+        const page = await getPageById(pageId);
+        if (!page) {
+            return errorResponse('페이지를 찾을 수 없습니다.', 404);
+        }
+        if (page.IS_PUBLIC === 'N') {
+            return errorResponse('이미 긴급차단된 페이지입니다.', 400);
+        }
+
+        // DB IS_PUBLIC='N' 업데이트
+        await setPagePublic(pageId, 'N', currentUser.userId);
+
+        // 활성 서버의 배포 파일 삭제
+        const servers = await getServerList('Y');
+        const results = await Promise.all(
+            servers.map(async (server) => {
+                const serverUrl = buildServerUrl(server.INSTANCE_IP, server.INSTANCE_PORT, '/cms/api/deploy/receive');
+                try {
+                    await deleteFromServer(serverUrl, pageId);
+                    return { instanceId: server.INSTANCE_ID, success: true as const };
+                } catch (err: unknown) {
+                    console.error(`파일 삭제 실패 [${server.INSTANCE_ID}]:`, err);
+                    return { instanceId: server.INSTANCE_ID, success: false as const, error: getErrorMessage(err) };
+                }
+            }),
+        );
+
+        return successResponse({ pageId, results }, '긴급차단이 완료되었습니다.');
+    } catch (err: unknown) {
+        console.error('긴급차단 처리 실패:', err);
+        return errorResponse(getErrorMessage(err));
+    }
+}

--- a/html-cms/src/app/api/deploy/push/route.ts
+++ b/html-cms/src/app/api/deploy/push/route.ts
@@ -1,5 +1,5 @@
 // src/app/api/deploy/push/route.ts
-import { createHash, timingSafeEqual } from 'crypto';
+import { timingSafeEqual } from 'crypto';
 import { readFile, access } from 'fs/promises';
 import path from 'path';
 
@@ -14,14 +14,9 @@ import type { CmsPage } from '@/db/types';
 import { canWriteCms, getCurrentUser } from '@/lib/current-user';
 import { errorResponse, getErrorMessage, successResponse } from '@/lib/api-response';
 import { DEPLOY_SECRET } from '@/lib/env';
-import { sendToServer, buildServerUrl } from '@/lib/deploy-utils';
+import { sendToServer, buildServerUrl, buildDeployHtml, calcCrc } from '@/lib/deploy-utils';
 
 const OBJ = { outFormat: oracledb.OUT_FORMAT_OBJECT };
-
-const CMS_BASE_URL = process.env.CMS_BASE_URL || 'http://localhost:3000';
-// Next.js basePath('/cms') 포함 — public/ 정적 파일·API 라우트 URL 기준
-const CMS_PATH_PREFIX = process.env.NEXT_PUBLIC_CMS_BASE_PATH ?? '/cms';
-const BASE = `${CMS_BASE_URL}${CMS_PATH_PREFIX}`;
 
 /** 타이밍 공격 방지 토큰 비교 */
 function isValidToken(token: string | null): boolean {
@@ -34,181 +29,6 @@ function isValidToken(token: string | null): boolean {
     } catch {
         return false;
     }
-}
-
-/** SHA-256 앞 16자리로 무결성 값 생성 */
-function calcCrc(content: string): string {
-    return createHash('sha256').update(content, 'utf8').digest('hex').slice(0, 16);
-}
-
-// 배포 HTML 렌더링에 필요한 레이아웃 CSS (globals.css 56~106행)
-const LAYOUT_CSS = `
-.is-container [data-cb-type] {
-    display: block;
-    width: 100%;
-    max-width: 100%;
-    box-sizing: border-box;
-}
-.is-container .is-col:has(> [data-cb-type]),
-.is-container .column:has(> [data-cb-type]),
-.is-container [class*="col"]:has(> [data-cb-type]),
-.is-container .column.spw-finance-col {
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-    width: 100% !important;
-    max-width: 100% !important;
-    flex: 0 0 100% !important;
-}
-.is-container .row {
-    margin-left: 0 !important;
-    margin-right: 0 !important;
-}
-`;
-
-/** HTML 프래그먼트 → 완전한 HTML 문서로 조립 (CSS 인라인 + 경로 치환 + 트래커 포함) */
-async function buildDeployHtml(fragment: string, pageId: string, pageName: string): Promise<string> {
-    // 1. ContentBuilder 런타임 CSS 읽기 — public/runtime 사용 (standalone 빌드 환경 호환)
-    let runtimeCss = '';
-    try {
-        const cssPath = path.join(process.cwd(), 'public', 'runtime', 'contentbuilder-runtime.css');
-        runtimeCss = await readFile(cssPath, 'utf8');
-    } catch {
-        throw new Error('ContentBuilder 런타임 CSS를 찾을 수 없습니다. public/runtime/ 디렉토리를 확인해주세요.');
-    }
-
-    // 2. 에셋 경로 치환 — CMS 서버 절대 URL로 변환 (basePath 포함)
-    // 선행 슬래시 유무·역슬래시(Windows), 큰따옴표·작은따옴표 모두 처리
-    const html = fragment
-        .replace(/src=(['"])\/?(assets|uploads)[\/\\]/g, `src=$1${BASE}/$2/`)
-        .replace(/url\((['"]?)\/?(assets|uploads)[\/\\]/g, `url($1${BASE}/$2/`)
-        .replace(/src=(['"])\/api\/assets\//g, `src=$1${BASE}/api/assets/`);
-
-    // 3. 완전한 HTML 문서 조립 — 스크립트 URL에 basePath 반영
-    return `<!DOCTYPE html>
-<html lang="ko">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <title>${pageName}</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <style>${runtimeCss}</style>
-    <style>${LAYOUT_CSS}</style>
-</head>
-<body class="is-container">
-${html}
-    <script src="${BASE}/runtime/contentbuilder-runtime.min.js"></script>
-    <script>
-    // ContentBuilder 런타임 초기화 — 플러그인 동적 로드 + mount
-    document.addEventListener('DOMContentLoaded', function() {
-        if (typeof ContentBuilderRuntime === 'undefined') return;
-        var base = '${BASE}';
-        var pluginNames = [
-            'logo-loop','click-counter','card-list','accordion','hero-animation',
-            'animated-stats','timeline','before-after-slider','more-info','social-share',
-            'pendulum','browser-mockup','hero-background','cta-buttons',
-            'media-slider','media-grid','particle-constellation','vector-force',
-            'aurora-glow','simple-stats','faq','callout-box','code','video-embed',
-            'swiper-slider','exchange-board','loan-calculator'
-        ];
-        var plugins = {};
-        pluginNames.forEach(function(name) {
-            plugins[name] = {
-                url: base + '/assets/plugins/' + name + '/index.js',
-                css: base + '/assets/plugins/' + name + '/style.css'
-            };
-        });
-        var runtime = new ContentBuilderRuntime({ plugins: plugins });
-        runtime.init();
-
-        // 인라인 스크립트 재실행 (dangerouslySetInnerHTML과 동일 이슈)
-        // data-card-slide-inited 등 inited 가드 초기화 — 에디터에서 설정된 채 저장된 경우 대비
-        document.querySelectorAll('[data-spw-block][data-card-slide-inited]').forEach(function(el) {
-            el.removeAttribute('data-card-slide-inited');
-        });
-        document.querySelectorAll('[data-spw-block] script').forEach(function(oldScript) {
-            var newScript = document.createElement('script');
-            newScript.textContent = oldScript.textContent;
-            oldScript.parentNode.replaceChild(newScript, oldScript);
-        });
-
-        // ── 금융 web 변형 컴포넌트 그리드 보장 ──────────────────────────────
-        // inline script가 없는 web 변형은 스크립트 재실행으로 처리되지 않으므로 직접 적용
-        // ContentBuilder가 inline style을 덮어쓴 경우도 여기서 복원됨
-
-        // product-gallery-web: data-pg-grid flex-row 3열 그리드
-        document.querySelectorAll('[data-pg-grid]').forEach(function(grid) {
-            grid.style.cssText =
-                'display:flex;flex-direction:row;flex-wrap:wrap;gap:12px;padding:4px 20px 20px;box-sizing:border-box;';
-            Array.from(grid.children).forEach(function(card) {
-                card.style.flex = '1';
-                card.style.minWidth = '260px';
-                card.style.boxSizing = 'border-box';
-            });
-        });
-
-        // benefit-card-web / responsive: data-bc-container flex-row 그리드
-        document.querySelectorAll('[data-component-id^="benefit-card"]').forEach(function(root) {
-            var compId = root.getAttribute('data-component-id') || '';
-            if (!compId.endsWith('-web') && !compId.endsWith('-responsive')) return;
-            var container = root.querySelector('[data-bc-container]');
-            if (!container) return;
-            if (compId.endsWith('-web')) {
-                // 외부 래퍼 max-width 제거 — 컨테이너 너비에 맞게 100% 채움
-                root.style.maxWidth = '';
-                root.style.margin = '0';
-                root.style.width = '100%';
-                root.style.boxSizing = 'border-box';
-                container.style.cssText = 'display:flex;flex-direction:row;gap:12px;';
-                Array.from(container.querySelectorAll(':scope > a')).forEach(function(card) {
-                    card.style.flex = '1';
-                    card.style.minWidth = '0';
-                });
-            } else {
-                container.style.cssText = 'display:flex;flex-wrap:wrap;gap:12px;';
-            }
-        });
-
-        // benefit-card-mobile: data-bc-track scroll-snap 슬라이더
-        document.querySelectorAll('[data-bc-track]').forEach(function(track) {
-            track.className = (track.className || '').replace(/\bflex(?:-col)?\b/g, '').trim();
-            track.style.cssText =
-                'display:flex;flex-direction:row;overflow-x:auto;scroll-snap-type:x mandatory;' +
-                '-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none;' +
-                'gap:0;padding:4px 0 8px;';
-            track.querySelectorAll('[data-bc-slide]').forEach(function(slide) {
-                slide.style.cssText =
-                    'flex-shrink:0;width:80%;scroll-snap-align:start;padding:0 8px;box-sizing:border-box;';
-            });
-        });
-
-        // info-card-slide-web: SLIDE_SCRIPT가 grid를 적용한 경우 scroll-snap 슬라이더로 교정
-        // (구버전 DB 레코드 대비 — 인라인 스크립트 재실행 이후 override)
-        document.querySelectorAll('[data-component-id="info-card-slide-web"]').forEach(function(root) {
-            // 외부 래퍼 max-width 제거 — 컨테이너 너비에 맞게 100% 채움
-            root.style.maxWidth = '';
-            root.style.margin = '0';
-            root.style.width = '100%';
-            root.style.boxSizing = 'border-box';
-            var track = root.querySelector('[data-card-track]');
-            if (!track) return;
-            track.style.cssText =
-                'display:flex;flex-direction:row;overflow-x:auto;scroll-snap-type:x proximity;' +
-                '-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none;' +
-                'gap:20px;padding:12px 0 20px;scroll-padding:0 2%;';
-            track.querySelectorAll('[data-card-item]').forEach(function(card) {
-                card.style.flex = '0 0 min(480px,46vw)';
-                card.style.width = 'min(480px,46vw)';
-                card.style.maxWidth = '';
-                card.style.minWidth = '0';
-                card.style.scrollSnapAlign = 'start';
-            });
-        });
-    });
-    </script>
-    <script src="${BASE}/cms-tracker.js" data-page-id="${pageId}" data-cms-url="${BASE}"></script>
-</body>
-</html>`;
 }
 
 export async function POST(req: NextRequest) {

--- a/html-cms/src/app/api/deploy/receive/route.ts
+++ b/html-cms/src/app/api/deploy/receive/route.ts
@@ -1,6 +1,6 @@
 // src/app/api/deploy/receive/route.ts
 // 데모 전용 수신 엔드포인트 — 실제 운영 환경에서는 별도 서버로 교체
-import { writeFile, mkdir } from 'fs/promises';
+import { writeFile, mkdir, unlink } from 'fs/promises';
 import { timingSafeEqual } from 'crypto';
 import path from 'path';
 
@@ -19,6 +19,37 @@ function isValidToken(token: string | null): boolean {
         return timingSafeEqual(expected, received);
     } catch {
         return false;
+    }
+}
+
+/** 긴급차단 시 배포된 HTML 파일 삭제 */
+export async function DELETE(req: NextRequest) {
+    if (!isValidToken(req.headers.get('x-deploy-token'))) {
+        return errorResponse('인증 토큰이 유효하지 않습니다.', 401);
+    }
+
+    try {
+        const { pageId } = (await req.json()) as { pageId?: string };
+
+        if (!pageId || typeof pageId !== 'string') {
+            return errorResponse('pageId가 필요합니다.', 400);
+        }
+        if (pageId.includes('..') || pageId.includes('/') || pageId.includes('\\')) {
+            return errorResponse('유효하지 않은 pageId입니다.', 400);
+        }
+
+        const filePath = path.join(process.cwd(), 'public', 'deployed', `${pageId}.html`);
+        try {
+            await unlink(filePath);
+        } catch (err: unknown) {
+            // 파일이 이미 없는 경우 — 이미 차단된 상태이므로 정상 처리
+            if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+        }
+
+        return successResponse({ pageId, deleted: true });
+    } catch (err: unknown) {
+        console.error('배포 파일 삭제 실패:', err);
+        return errorResponse(getErrorMessage(err));
     }
 }
 

--- a/html-cms/src/app/api/deploy/restore/[pageId]/route.ts
+++ b/html-cms/src/app/api/deploy/restore/[pageId]/route.ts
@@ -1,0 +1,89 @@
+// src/app/api/deploy/restore/[pageId]/route.ts
+// 긴급차단 복구 API — SPW_CMS_PAGE_HISTORY 마지막 버전 HTML로 파일 재생성 + IS_PUBLIC='Y'
+// 현재 페이지(SPW_CMS_PAGE)의 APPROVE_STATE·PAGE_HTML은 건드리지 않음
+
+import { readFile } from 'fs/promises';
+import path from 'path';
+
+import { NextRequest } from 'next/server';
+
+import { getServerList } from '@/db/repository/file-send.repository';
+import { getPageById, getLatestHistory, setPagePublic } from '@/db/repository/page.repository';
+import { canWriteCms, getCurrentUser } from '@/lib/current-user';
+import { errorResponse, getErrorMessage, successResponse } from '@/lib/api-response';
+import { buildServerUrl, sendToServer, buildDeployHtml } from '@/lib/deploy-utils';
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ pageId: string }> }) {
+    try {
+        const currentUser = await getCurrentUser();
+        if (!canWriteCms(currentUser)) {
+            return errorResponse('권한이 없습니다.', 401);
+        }
+
+        const { pageId } = await params;
+        if (!pageId || typeof pageId !== 'string') {
+            return errorResponse('pageId가 필요합니다.', 400);
+        }
+
+        const page = await getPageById(pageId);
+        if (!page) {
+            return errorResponse('페이지를 찾을 수 없습니다.', 404);
+        }
+        if (page.IS_PUBLIC !== 'N') {
+            return errorResponse('긴급차단 상태가 아닌 페이지입니다.', 400);
+        }
+
+        // 마지막 승인 이력 조회 — HISTORY는 APPROVED 시에만 생성되므로 latest == last approved
+        const history = await getLatestHistory(pageId);
+        if (!history?.PAGE_HTML) {
+            return errorResponse('복구할 승인 이력이 없습니다. 먼저 승인 후 배포하세요.', 400);
+        }
+
+        const pageName = page.PAGE_NAME ?? pageId;
+        const html = await buildDeployHtml(history.PAGE_HTML as string, pageId, pageName);
+
+        // 트래커 JS 읽기 (없어도 배포 진행)
+        const trackerJsPath = path.join(process.cwd(), 'public', 'cms-tracker.js');
+        let trackerJs: string | null = null;
+        try {
+            trackerJs = await readFile(trackerJsPath, 'utf8');
+        } catch {
+            console.warn('cms-tracker.js 파일을 찾을 수 없습니다. 트래커 없이 복구합니다.');
+        }
+
+        const servers = await getServerList('Y');
+        if (servers.length === 0) {
+            return errorResponse('활성화된 배포 서버가 없습니다.', 400);
+        }
+
+        // 각 서버에 HTML 파일 재생성
+        const results = await Promise.all(
+            servers.map(async (server) => {
+                const serverUrl = buildServerUrl(server.INSTANCE_IP, server.INSTANCE_PORT, '/cms/api/deploy/receive');
+                try {
+                    await sendToServer(serverUrl, pageId, html, trackerJs);
+                    return { instanceId: server.INSTANCE_ID, success: true as const };
+                } catch (err: unknown) {
+                    console.error(`파일 복구 실패 [${server.INSTANCE_ID}]:`, err);
+                    return { instanceId: server.INSTANCE_ID, success: false as const, error: getErrorMessage(err) };
+                }
+            }),
+        );
+
+        const successCount = results.filter((r) => r.success).length;
+        if (successCount === 0) {
+            return errorResponse('모든 서버에 복구 파일 전송이 실패했습니다.', 500);
+        }
+
+        // 하나 이상 성공 시 IS_PUBLIC='Y' 복원
+        await setPagePublic(pageId, 'Y', currentUser.userId);
+
+        return successResponse(
+            { pageId, historyVersion: history.VERSION, successCount, failCount: results.length - successCount, results },
+            '복구가 완료되었습니다.',
+        );
+    } catch (err: unknown) {
+        console.error('복구 처리 실패:', err);
+        return errorResponse(getErrorMessage(err));
+    }
+}

--- a/html-cms/src/app/api/deploy/restore/[pageId]/route.ts
+++ b/html-cms/src/app/api/deploy/restore/[pageId]/route.ts
@@ -79,7 +79,13 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ pag
         await setPagePublic(pageId, 'Y', currentUser.userId);
 
         return successResponse(
-            { pageId, historyVersion: history.VERSION, successCount, failCount: results.length - successCount, results },
+            {
+                pageId,
+                historyVersion: history.VERSION,
+                successCount,
+                failCount: results.length - successCount,
+                results,
+            },
             '복구가 완료되었습니다.',
         );
     } catch (err: unknown) {

--- a/html-cms/src/app/api/deploy/restore/[pageId]/route.ts
+++ b/html-cms/src/app/api/deploy/restore/[pageId]/route.ts
@@ -78,16 +78,14 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ pag
         // 하나 이상 성공 시 IS_PUBLIC='Y' 복원
         await setPagePublic(pageId, 'Y', currentUser.userId);
 
-        return successResponse(
-            {
-                pageId,
-                historyVersion: history.VERSION,
-                successCount,
-                failCount: results.length - successCount,
-                results,
-            },
-            '복구가 완료되었습니다.',
-        );
+        return successResponse({
+            pageId,
+            historyVersion: history.VERSION,
+            successCount,
+            failCount: results.length - successCount,
+            results,
+            message: '복구가 완료되었습니다.',
+        });
     } catch (err: unknown) {
         console.error('복구 처리 실패:', err);
         return errorResponse(getErrorMessage(err));

--- a/html-cms/src/lib/deploy-utils.ts
+++ b/html-cms/src/lib/deploy-utils.ts
@@ -1,7 +1,190 @@
 // src/lib/deploy-utils.ts
-// 배포 공통 유틸 — 운영 서버 전송 헬퍼
+// 배포 공통 유틸 — 운영 서버 전송·삭제 헬퍼 및 HTML 조립 로직
+
+import { createHash } from 'crypto';
+import { readFile } from 'fs/promises';
+import path from 'path';
 
 const DEPLOY_SECRET = process.env.DEPLOY_SECRET ?? '';
+
+const CMS_BASE_URL = process.env.CMS_BASE_URL || 'http://localhost:3000';
+const CMS_PATH_PREFIX = process.env.NEXT_PUBLIC_CMS_BASE_PATH ?? '/cms';
+const BASE = `${CMS_BASE_URL}${CMS_PATH_PREFIX}`;
+
+// 배포 HTML 렌더링에 필요한 레이아웃 CSS (globals.css 56~106행)
+const LAYOUT_CSS = `
+.is-container [data-cb-type] {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+}
+.is-container .is-col:has(> [data-cb-type]),
+.is-container .column:has(> [data-cb-type]),
+.is-container [class*="col"]:has(> [data-cb-type]),
+.is-container .column.spw-finance-col {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    flex: 0 0 100% !important;
+}
+.is-container .row {
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+}
+`;
+
+/** SHA-256 앞 16자리로 무결성 값 생성 */
+export function calcCrc(content: string): string {
+    return createHash('sha256').update(content, 'utf8').digest('hex').slice(0, 16);
+}
+
+/** HTML 프래그먼트 → 완전한 HTML 문서로 조립 (CSS 인라인 + 경로 치환 + 트래커 포함) */
+export async function buildDeployHtml(fragment: string, pageId: string, pageName: string): Promise<string> {
+    // 1. ContentBuilder 런타임 CSS 읽기 — public/runtime 사용 (standalone 빌드 환경 호환)
+    let runtimeCss = '';
+    try {
+        const cssPath = path.join(process.cwd(), 'public', 'runtime', 'contentbuilder-runtime.css');
+        runtimeCss = await readFile(cssPath, 'utf8');
+    } catch {
+        throw new Error('ContentBuilder 런타임 CSS를 찾을 수 없습니다. public/runtime/ 디렉토리를 확인해주세요.');
+    }
+
+    // 2. 에셋 경로 치환 — CMS 서버 절대 URL로 변환 (basePath 포함)
+    // 선행 슬래시 유무·역슬래시(Windows), 큰따옴표·작은따옴표 모두 처리
+    const html = fragment
+        .replace(/src=(['"])\/?(assets|uploads)[\/\\]/g, `src=$1${BASE}/$2/`)
+        .replace(/url\((['"]?)\/?(assets|uploads)[\/\\]/g, `url($1${BASE}/$2/`)
+        .replace(/src=(['"])\/api\/assets\//g, `src=$1${BASE}/api/assets/`);
+
+    // 3. 완전한 HTML 문서 조립 — 스크립트 URL에 basePath 반영
+    return `<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <title>${pageName}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>${runtimeCss}</style>
+    <style>${LAYOUT_CSS}</style>
+</head>
+<body class="is-container">
+${html}
+    <script src="${BASE}/runtime/contentbuilder-runtime.min.js"></script>
+    <script>
+    // ContentBuilder 런타임 초기화 — 플러그인 동적 로드 + mount
+    document.addEventListener('DOMContentLoaded', function() {
+        if (typeof ContentBuilderRuntime === 'undefined') return;
+        var base = '${BASE}';
+        var pluginNames = [
+            'logo-loop','click-counter','card-list','accordion','hero-animation',
+            'animated-stats','timeline','before-after-slider','more-info','social-share',
+            'pendulum','browser-mockup','hero-background','cta-buttons',
+            'media-slider','media-grid','particle-constellation','vector-force',
+            'aurora-glow','simple-stats','faq','callout-box','code','video-embed',
+            'swiper-slider','exchange-board','loan-calculator'
+        ];
+        var plugins = {};
+        pluginNames.forEach(function(name) {
+            plugins[name] = {
+                url: base + '/assets/plugins/' + name + '/index.js',
+                css: base + '/assets/plugins/' + name + '/style.css'
+            };
+        });
+        var runtime = new ContentBuilderRuntime({ plugins: plugins });
+        runtime.init();
+
+        // 인라인 스크립트 재실행 (dangerouslySetInnerHTML과 동일 이슈)
+        // data-card-slide-inited 등 inited 가드 초기화 — 에디터에서 설정된 채 저장된 경우 대비
+        document.querySelectorAll('[data-spw-block][data-card-slide-inited]').forEach(function(el) {
+            el.removeAttribute('data-card-slide-inited');
+        });
+        document.querySelectorAll('[data-spw-block] script').forEach(function(oldScript) {
+            var newScript = document.createElement('script');
+            newScript.textContent = oldScript.textContent;
+            oldScript.parentNode.replaceChild(newScript, oldScript);
+        });
+
+        // ── 금융 web 변형 컴포넌트 그리드 보장 ──────────────────────────────
+        // inline script가 없는 web 변형은 스크립트 재실행으로 처리되지 않으므로 직접 적용
+        // ContentBuilder가 inline style을 덮어쓴 경우도 여기서 복원됨
+
+        // product-gallery-web: data-pg-grid flex-row 3열 그리드
+        document.querySelectorAll('[data-pg-grid]').forEach(function(grid) {
+            grid.style.cssText =
+                'display:flex;flex-direction:row;flex-wrap:wrap;gap:12px;padding:4px 20px 20px;box-sizing:border-box;';
+            Array.from(grid.children).forEach(function(card) {
+                card.style.flex = '1';
+                card.style.minWidth = '260px';
+                card.style.boxSizing = 'border-box';
+            });
+        });
+
+        // benefit-card-web / responsive: data-bc-container flex-row 그리드
+        document.querySelectorAll('[data-component-id^="benefit-card"]').forEach(function(root) {
+            var compId = root.getAttribute('data-component-id') || '';
+            if (!compId.endsWith('-web') && !compId.endsWith('-responsive')) return;
+            var container = root.querySelector('[data-bc-container]');
+            if (!container) return;
+            if (compId.endsWith('-web')) {
+                // 외부 래퍼 max-width 제거 — 컨테이너 너비에 맞게 100% 채움
+                root.style.maxWidth = '';
+                root.style.margin = '0';
+                root.style.width = '100%';
+                root.style.boxSizing = 'border-box';
+                container.style.cssText = 'display:flex;flex-direction:row;gap:12px;';
+                Array.from(container.querySelectorAll(':scope > a')).forEach(function(card) {
+                    card.style.flex = '1';
+                    card.style.minWidth = '0';
+                });
+            } else {
+                container.style.cssText = 'display:flex;flex-wrap:wrap;gap:12px;';
+            }
+        });
+
+        // benefit-card-mobile: data-bc-track scroll-snap 슬라이더
+        document.querySelectorAll('[data-bc-track]').forEach(function(track) {
+            track.className = (track.className || '').replace(/\bflex(?:-col)?\b/g, '').trim();
+            track.style.cssText =
+                'display:flex;flex-direction:row;overflow-x:auto;scroll-snap-type:x mandatory;' +
+                '-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none;' +
+                'gap:0;padding:4px 0 8px;';
+            track.querySelectorAll('[data-bc-slide]').forEach(function(slide) {
+                slide.style.cssText =
+                    'flex-shrink:0;width:80%;scroll-snap-align:start;padding:0 8px;box-sizing:border-box;';
+            });
+        });
+
+        // info-card-slide-web: SLIDE_SCRIPT가 grid를 적용한 경우 scroll-snap 슬라이더로 교정
+        // (구버전 DB 레코드 대비 — 인라인 스크립트 재실행 이후 override)
+        document.querySelectorAll('[data-component-id="info-card-slide-web"]').forEach(function(root) {
+            // 외부 래퍼 max-width 제거 — 컨테이너 너비에 맞게 100% 채움
+            root.style.maxWidth = '';
+            root.style.margin = '0';
+            root.style.width = '100%';
+            root.style.boxSizing = 'border-box';
+            var track = root.querySelector('[data-card-track]');
+            if (!track) return;
+            track.style.cssText =
+                'display:flex;flex-direction:row;overflow-x:auto;scroll-snap-type:x proximity;' +
+                '-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none;' +
+                'gap:20px;padding:12px 0 20px;scroll-padding:0 2%;';
+            track.querySelectorAll('[data-card-item]').forEach(function(card) {
+                card.style.flex = '0 0 min(480px,46vw)';
+                card.style.width = 'min(480px,46vw)';
+                card.style.maxWidth = '';
+                card.style.minWidth = '0';
+                card.style.scrollSnapAlign = 'start';
+            });
+        });
+    });
+    </script>
+    <script src="${BASE}/cms-tracker.js" data-page-id="${pageId}" data-cms-url="${BASE}"></script>
+</body>
+</html>`;
+}
 
 /** 운영 서버 base URL 생성 — 포트 null 안전 처리 */
 export function buildServerUrl(ip: string | null, port: number | null, path: string): string {
@@ -27,5 +210,21 @@ export async function sendToServer(
     if (!res.ok) {
         const text = await res.text().catch(() => '응답 없음');
         throw new Error(`서버 전송 실패 (${res.status}): ${text}`);
+    }
+}
+
+/** 배포 대상 서버에서 페이지 HTML 파일 삭제 요청 */
+export async function deleteFromServer(serverUrl: string, pageId: string): Promise<void> {
+    const res = await fetch(serverUrl, {
+        method: 'DELETE',
+        headers: {
+            'Content-Type': 'application/json',
+            'x-deploy-token': DEPLOY_SECRET,
+        },
+        body: JSON.stringify({ pageId }),
+    });
+    if (!res.ok) {
+        const text = await res.text().catch(() => '응답 없음');
+        throw new Error(`서버 파일 삭제 실패 (${res.status}): ${text}`);
     }
 }

--- a/spider-admin/src/main/java/com/example/spideradmin/domain/cmsdeployment/config/CmsDeployProperties.java
+++ b/spider-admin/src/main/java/com/example/spideradmin/domain/cmsdeployment/config/CmsDeployProperties.java
@@ -40,4 +40,15 @@ public class CmsDeployProperties {
      * Admin 내부에 파일을 복사하지 않아 단일 소스를 유지한다.
      */
     private String expiredHtmlUrl;
+
+    /**
+     * CMS 배포 API base URL — pushUrl에서 마지막 경로 세그먼트('/push')를 제거한 값.
+     * 긴급차단·복구 API URL 조립 시 사용한다.
+     * 예: http://localhost:3000/cms/api/deploy/push → http://localhost:3000/cms/api/deploy
+     */
+    public String getDeployBaseUrl() {
+        if (pushUrl == null) return "";
+        int idx = pushUrl.lastIndexOf('/');
+        return idx > 0 ? pushUrl.substring(0, idx) : pushUrl;
+    }
 }

--- a/spider-admin/src/main/java/com/example/spideradmin/domain/cmsdeployment/config/CmsDeployProperties.java
+++ b/spider-admin/src/main/java/com/example/spideradmin/domain/cmsdeployment/config/CmsDeployProperties.java
@@ -49,6 +49,11 @@ public class CmsDeployProperties {
     public String getDeployBaseUrl() {
         if (pushUrl == null) return "";
         int idx = pushUrl.lastIndexOf('/');
-        return idx > 0 ? pushUrl.substring(0, idx) : pushUrl;
+        // idx <= 0: "/push"(idx=0) 또는 "push"(idx=-1) 같은 비정상 경로 처리
+        // 스킴(://)이 있으면 전체 URL로 간주해 그대로 반환, 없으면 빈 문자열
+        if (idx <= 0) {
+            return pushUrl.contains("://") ? pushUrl : "";
+        }
+        return pushUrl.substring(0, idx);
     }
 }

--- a/spider-admin/src/main/java/com/example/spideradmin/domain/cmsdeployment/controller/CmsDeployController.java
+++ b/spider-admin/src/main/java/com/example/spideradmin/domain/cmsdeployment/controller/CmsDeployController.java
@@ -18,6 +18,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -28,10 +29,12 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * <h4>API 엔드포인트:</h4>
  * <ul>
- *   <li>GET  /api/cms-admin/deployments/pages         — 배포 대상 페이지 목록 (APPROVED)</li>
- *   <li>GET  /api/cms-admin/deployments               — 배포 이력 조회 (모달용)</li>
- *   <li>POST /api/cms-admin/deployments/push          — 배포 실행</li>
- *   <li>POST /api/cms-admin/deployments/push-expired  — 만료수동처리 배포</li>
+ *   <li>GET  /api/cms-admin/deployments/pages                  — 배포 대상 페이지 목록 (APPROVED)</li>
+ *   <li>GET  /api/cms-admin/deployments                        — 배포 이력 조회 (모달용)</li>
+ *   <li>POST /api/cms-admin/deployments/push                   — 배포 실행</li>
+ *   <li>POST /api/cms-admin/deployments/push-expired           — 만료수동처리 배포</li>
+ *   <li>POST /api/cms-admin/deployments/{pageId}/emergency-block — 긴급차단</li>
+ *   <li>POST /api/cms-admin/deployments/{pageId}/restore       — 긴급차단 복구</li>
  * </ul>
  */
 @Slf4j
@@ -87,5 +90,21 @@ public class CmsDeployController {
 
         cmsDeployService.pushExpired(req.getPageId(), userDetails.getUserId());
         return ResponseEntity.ok(ApiResponse.success("만료 배포가 완료되었습니다.", null));
+    }
+
+    /** 긴급차단 — IS_PUBLIC='N' + 배포 파일 삭제 (CMS:W) */
+    @PostMapping("/api/cms-admin/deployments/{pageId}/emergency-block")
+    @PreAuthorize("hasAuthority('CMS:W')")
+    public ResponseEntity<ApiResponse<Void>> emergencyBlock(@PathVariable String pageId) {
+        cmsDeployService.emergencyBlock(pageId);
+        return ResponseEntity.ok(ApiResponse.success("긴급차단이 완료되었습니다.", null));
+    }
+
+    /** 긴급차단 복구 — 마지막 승인 이력 HTML로 파일 재생성 + IS_PUBLIC='Y' (CMS:W) */
+    @PostMapping("/api/cms-admin/deployments/{pageId}/restore")
+    @PreAuthorize("hasAuthority('CMS:W')")
+    public ResponseEntity<ApiResponse<Void>> restorePublic(@PathVariable String pageId) {
+        cmsDeployService.restorePublic(pageId);
+        return ResponseEntity.ok(ApiResponse.success("복구가 완료되었습니다.", null));
     }
 }

--- a/spider-admin/src/main/java/com/example/spideradmin/domain/cmsdeployment/service/CmsDeployService.java
+++ b/spider-admin/src/main/java/com/example/spideradmin/domain/cmsdeployment/service/CmsDeployService.java
@@ -207,6 +207,26 @@ public class CmsDeployService {
         }
     }
 
+    /**
+     * 긴급차단 — IS_PUBLIC='N' 업데이트 + 배포된 HTML 파일 삭제.
+     * CMS 긴급차단 API({baseUrl}/emergency-block/{pageId})를 호출한다.
+     */
+    public void emergencyBlock(String pageId) {
+        String url = deployProperties.getDeployBaseUrl() + "/emergency-block/" + pageId;
+        callCmsApi(url, "긴급차단");
+        log.info("긴급차단 요청 완료: pageId={}", pageId);
+    }
+
+    /**
+     * 긴급차단 복구 — SPW_CMS_PAGE_HISTORY 마지막 버전 HTML로 파일 재생성 + IS_PUBLIC='Y'.
+     * CMS 복구 API({baseUrl}/restore/{pageId})를 호출한다.
+     */
+    public void restorePublic(String pageId) {
+        String url = deployProperties.getDeployBaseUrl() + "/restore/" + pageId;
+        callCmsApi(url, "복구");
+        log.info("복구 요청 완료: pageId={}", pageId);
+    }
+
     /** CMS push API 호출 — x-deploy-token 서버 간 인증 사용 */
     @SuppressWarnings("unchecked")
     private void callCmsPush(String pageId, String userId) {
@@ -237,6 +257,34 @@ public class CmsDeployService {
             throw e;
         } catch (Exception e) {
             throw new InternalException("CMS 배포 서버 오류: " + e.getMessage(), e);
+        }
+    }
+
+    /** CMS API 공통 호출 (긴급차단·복구용) — POST, 빈 바디, x-deploy-token 인증 */
+    private void callCmsApi(String url, String actionName) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("x-deploy-token", deployProperties.getSecret());
+
+        try {
+            ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.POST,
+                    new HttpEntity<>(new HashMap<>(), headers),
+                    new ParameterizedTypeReference<Map<String, Object>>() {});
+
+            Map<String, Object> responseBody = response.getBody();
+            if (responseBody == null) {
+                throw new InternalException("CMS " + actionName + " 서버에서 빈 응답을 반환했습니다.");
+            }
+            if (!Boolean.TRUE.equals(responseBody.get("ok"))) {
+                Object error = responseBody.get("error");
+                throw new InternalException("CMS " + actionName + " 오류: " + error);
+            }
+        } catch (InternalException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new InternalException("CMS " + actionName + " 요청 오류: " + e.getMessage(), e);
         }
     }
 }

--- a/spider-admin/src/main/resources/templates/pages/cms-approval/cms-approval-script.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-approval/cms-approval-script.html
@@ -93,7 +93,7 @@
             const $tbody = $('#approvalTableBody');
             if (!rows || rows.length === 0) {
                 this.rowsByPageId = {};
-                $tbody.html('<tr><td colspan="11" class="text-center py-4 text-body-secondary">조회된 데이터가 없습니다.</td></tr>');
+                $tbody.html('<tr><td colspan="9" class="text-center py-4 text-body-secondary">조회된 데이터가 없습니다.</td></tr>');
                 return;
             }
 
@@ -106,28 +106,6 @@
                 const badge      = this.APPROVE_STATE_BADGE[row.displayState] || HtmlUtils.escape(row.displayState);
                 const expiredCls = this._isExpired(row.expiredDate) ? 'text-danger fw-bold' : '';
                 const pid        = HtmlUtils.escape(row.pageId);
-
-                // 공개여부 — 읽기 전용 배지 (#308: 변경 액션은 [긴급차단/복구] 버튼으로 일원화)
-                const isPublicBtn = `<span class="badge ${row.isPublic === 'Y' ? 'bg-primary' : 'bg-secondary'}">${row.isPublic === 'Y' ? '공개' : '비공개'}</span>`;
-
-                // 긴급차단/복구 컬럼 — APPROVED + 배포완료 + CMS:W 권한일 때만 노출 (#308)
-                // isDeployed=1: FILE_CRC_VALUE IS NOT NULL (배포 이력 존재)
-                // [긴급차단]: 노출 기간(beginningDate~expiredDate) 내에 있는 경우에만 노출 — 만료 상태 제외
-                // [복구]: displayState='비공개'(IS_PUBLIC=N + 미만료)인 경우에만 노출 — 만료 상태 제외
-                const isWithinPeriod = CmsApprovalPage._isWithinDisplayPeriod(row.beginningDate, row.expiredDate);
-                let tdEmergency = '-';
-                if (HAS_CMS_WRITE && row.approveState === 'APPROVED' && row.isDeployed === 1) {
-                    if (row.isPublic === 'Y' && isWithinPeriod) {
-                        tdEmergency = `<button class="btn btn-danger btn-xs"
-                               data-page-id="${pid}"
-                               onclick="CmsApprovalPage.emergencyBlock('${pid}')">긴급차단</button>`;
-                    } else if (row.displayState === '비공개') {
-                        // IS_PUBLIC='N' + 미만료 — 복구 버튼 노출
-                        tdEmergency = `<button class="btn btn-success btn-xs"
-                               data-page-id="${pid}"
-                               onclick="CmsApprovalPage.restorePublic('${pid}')">복구</button>`;
-                    }
-                }
 
                 // 결재 컬럼 — PENDING 상태 + CMS:W 권한일 때만 노출
                 const tdApproval = (HAS_CMS_WRITE && row.approveState === 'PENDING')
@@ -150,14 +128,11 @@
                     <td class="text-center">${HtmlUtils.escape(row.viewMode || '')}</td>
                     <td>${HtmlUtils.escape(row.createUserName || '')}</td>
                     <td class="text-center">${badge}</td>
-                    <!-- #308: 공개여부 — display:none (데이터는 유지, 향후 정책 변경 시 복원 가능) -->
-                    <td class="text-center" style="display:none">${isPublicBtn}</td>
                     <td class="text-center">${HtmlUtils.escape(row.beginningDate || '-')}</td>
                     <td class="text-center ${expiredCls}">${HtmlUtils.escape(row.expiredDate || '-')}</td>
                     <td class="text-center small">${HtmlUtils.escape(row.lastModifiedDtime || '-')}</td>
                     <td class="text-center">${tdApproval}</td>
                     <td class="text-center">${tdHistory}</td>
-                    <td class="text-center" style="display:none">${tdEmergency}</td>
                 </tr>`;
             }).join('');
 
@@ -294,53 +269,6 @@
                 .catch(() => Toast.error('반려 처리 중 오류가 발생했습니다.'));
         },
 
-        // ── 공개 상태 토글 (#308: 읽기 전용 배지로 전환 — 변경 액션은 긴급차단/복구 버튼으로 일원화) ──
-        // togglePublicState: function(pageId, currentState) {
-        //     const isPublic = currentState === 'Y' ? 'N' : 'Y';
-        //     const label    = isPublic === 'Y' ? '공개' : '비공개';
-        //     if (!confirm(`해당 페이지를 ${label} 처리하시겠습니까?`)) return;
-        //     fetch(`/api/cms-admin/pages/${pageId}/public-state`, {
-        //         method: 'PATCH',
-        //         headers: { 'Content-Type': 'application/json' },
-        //         body: JSON.stringify({ isPublic }),
-        //     })
-        //         .then(r => r.json())
-        //         .then(res => {
-        //             if (res.success) { Toast.success(res.message); this.load(); }
-        //             else             { Toast.error(res.message); }
-        //         })
-        //         .catch(() => Toast.error('공개 상태 변경 중 오류가 발생했습니다.'));
-        // },
-
-        // ── 긴급차단 (#308) ──
-        // 조건: APPROVED + 배포완료(isDeployed=1) + isPublic='Y' + CMS:W 권한
-        emergencyBlock: function(pageId) {
-            if (!confirm('이 콘텐츠를 즉시 차단하시겠습니까?\n(차단 시 대고객 서비스에서 즉시 사라집니다)')) return;
-            CmsApprovalPage._updatePublicState(pageId, 'N', '긴급차단');
-        },
-
-        // ── 복구 (#308) ──
-        // 조건: APPROVED + 배포완료(isDeployed=1) + isPublic='N' + CMS:W 권한
-        restorePublic: function(pageId) {
-            if (!confirm('서비스를 복구하시겠습니까?\n즉시 대고객 서비스에 노출됩니다.')) return;
-            CmsApprovalPage._updatePublicState(pageId, 'Y', '복구');
-        },
-
-        // IS_PUBLIC 변경 공통 처리 — emergencyBlock / restorePublic 에서 호출
-        _updatePublicState: function(pageId, isPublic, label) {
-            fetch(`/api/cms-admin/pages/${pageId}/public-state`, {
-                method: 'PATCH',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ isPublic }),
-            })
-                .then(r => r.json())
-                .then(res => {
-                    if (res.success) { Toast.success(`${label} 처리가 완료되었습니다.`); this.load(); }
-                    else             { Toast.error(res.message); }
-                })
-                .catch(() => Toast.error(`${label} 처리 중 오류가 발생했습니다.`));
-        },
-
         // ── 이력 / 롤백 모달 ──
         openHistoryModal: function(pageId) {
             $('#historyPageId').val(pageId);
@@ -414,24 +342,6 @@
             return expiredDate < new Date();
         },
 
-        /**
-         * 노출 기간 내 여부 확인 — [긴급차단] 버튼 노출 조건 (#308)
-         * 현재날짜 >= 노출시작일 AND 현재날짜 <= 노출종료일
-         * beginningDate / expiredDate 가 없으면 해당 조건을 만족한 것으로 간주
-         */
-        _isWithinDisplayPeriod: function(beginningDate, expiredDate) {
-            const now = new Date();
-            if (beginningDate) {
-                const start = new Date(beginningDate);
-                if (now < start) return false; // 아직 노출 시작 전
-            }
-            if (expiredDate) {
-                const end = new Date(expiredDate);
-                end.setHours(23, 59, 59, 999); // 종료일 당일 말까지 포함
-                if (now > end) return false;    // 만료됨
-            }
-            return true;
-        },
     };
 
     // ==================== 이벤트 바인딩 ====================

--- a/spider-admin/src/main/resources/templates/pages/cms-approval/cms-approval-table.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-approval/cms-approval-table.html
@@ -10,20 +10,16 @@
                 <th class="col-w-80 sortable" data-sort="viewMode">뷰모드</th>
                 <th class="col-w-90 sortable" data-sort="createUserName">작성자</th>
                 <th class="col-w-100 sortable" data-sort="approveState">승인상태</th>
-                <!-- #308: 공개여부 — display:none (데이터는 유지, 향후 정책 변경 시 복원 가능) -->
-                <th class="col-w-80 sortable" data-sort="isPublic" style="display:none">공개여부</th>
                 <th class="col-w-100 sortable" data-sort="beginningDate">노출시작일</th>
                 <th class="col-w-100 sortable" data-sort="expiredDate">노출종료일</th>
                 <th class="col-w-150 sortable" data-sort="lastModifiedDtime">최종수정일시</th>
                 <th class="col-w-70">결재</th>
                 <th class="col-w-60">이력</th>
-                <!-- #308: 긴급차단 컬럼 — 현재 display:none (nginx 미들웨어 우회 문제로 임시 비활성화) -->
-                <th class="col-w-80" style="display:none">긴급차단</th>
             </tr>
         </thead>
         <tbody id="approvalTableBody">
             <tr>
-                <td colspan="11" class="text-center py-4 text-body-secondary">
+                <td colspan="9" class="text-center py-4 text-body-secondary">
                     조회 버튼을 클릭하여 데이터를 불러오세요.
                 </td>
             </tr>

--- a/spider-admin/src/main/resources/templates/pages/cms-deployment/cms-deployment-script.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-deployment/cms-deployment-script.html
@@ -104,8 +104,8 @@
 
         renderTable: function(rows) {
             const $tbody = $('#deployPageTableBody');
-            // canWrite: 배포·만료수동처리 2컬럼 + URL 1컬럼 추가 → 9컬럼 / 미권한: 7컬럼
-            const colspan = this.canWrite ? 9 : 7;
+            // canWrite: 배포·만료수동처리·긴급차단/복구 3컬럼 + URL 1컬럼 + 공개여부 1컬럼 → 11컬럼 / 미권한: 8컬럼(공개여부 추가)
+            const colspan = this.canWrite ? 11 : 8;
 
             if (!rows || rows.length === 0) {
                 $tbody.html(`<tr><td colspan="${colspan}" class="text-center py-4 text-body-secondary">조회된 데이터가 없습니다.</td></tr>`);
@@ -131,13 +131,24 @@
                     : '-';
                 const periodCell = `<td class="small">${HtmlUtils.escape(beginStr)} ~ ${endStr}</td>`;
 
-                // 배포 미리보기: 앵커(target=_blank) → 버튼(window.open) 으로 변경
+                // 공개여부 뱃지 — IS_PUBLIC='N'이면 차단 뱃지
+                const isPublicCell = `<td class="text-center">
+                    ${row.isPublic === 'N'
+                        ? '<span class="badge bg-danger">차단</span>'
+                        : '<span class="badge bg-success">공개</span>'}
+                </td>`;
+
+                // 배포 미리보기: IS_PUBLIC='N'이면 비활성화 처리
                 // viewMode 에 맞춘 창 크기로 노출되도록 openDeployedPreview() 위임 (#278)
                 const previewBtn = row.deployedUrl
-                    ? `<button type="button" class="btn btn-info btn-xs"
-                               onclick="CmsDeployPage.openDeployedPreview('${jsDeployedUrl}', '${jsViewMode}')">
-                           <i class="bi bi-box-arrow-up-right"></i> 보기
-                       </button>`
+                    ? (row.isPublic === 'N'
+                        ? `<button type="button" class="btn btn-info btn-xs" disabled title="긴급차단된 페이지입니다.">
+                               <i class="bi bi-box-arrow-up-right"></i> 보기
+                           </button>`
+                        : `<button type="button" class="btn btn-info btn-xs"
+                                   onclick="CmsDeployPage.openDeployedPreview('${jsDeployedUrl}', '${jsViewMode}')">
+                               <i class="bi bi-box-arrow-up-right"></i> 보기
+                           </button>`)
                     : '<span class="text-body-secondary small">-</span>';
                 const deployedUrlCell = row.deployedUrl
                     ? `<td class="small">
@@ -172,15 +183,35 @@
                        </td>`
                     : '';
 
+                // 긴급차단/복구 버튼 — 배포된 페이지(deployedUrl 있음)에만 표시
+                // IS_PUBLIC='Y': 긴급차단 버튼 / IS_PUBLIC='N': 복구 버튼
+                const emergencyBtn = this.canWrite
+                    ? `<td class="text-center">
+                           ${!row.deployedUrl
+                               ? '<span class="text-body-secondary small">-</span>'
+                               : row.isPublic === 'N'
+                                   ? `<button class="btn btn-success btn-xs"
+                                               onclick="CmsDeployPage.confirmRestore('${pid}', '${jsPageName}')">
+                                          <i class="bi bi-arrow-counterclockwise"></i> 복구
+                                      </button>`
+                                   : `<button class="btn btn-danger btn-xs"
+                                               onclick="CmsDeployPage.confirmEmergencyBlock('${pid}', '${jsPageName}')">
+                                          <i class="bi bi-shield-exclamation"></i> 긴급차단
+                                      </button>`}
+                       </td>`
+                    : '';
+
                 return `<tr>
                     <td class="small">${pid}</td>
                     <td>${HtmlUtils.escape(row.pageName || '')}</td>
                     <td>${HtmlUtils.escape(row.createUserName || '')}</td>
                     ${periodCell}
+                    ${isPublicCell}
                     ${deployBtn}
                     <td class="text-center">${previewBtn}</td>
                     ${deployedUrlCell}
                     ${expireBtn}
+                    ${emergencyBtn}
                     <td class="text-center">
                         <button class="btn btn-outline-secondary btn-xs"
                                 onclick="CmsDeployPage.openHistoryModal('${pid}', '${jsPageName}')">
@@ -294,6 +325,46 @@
                     }
                 })
                 .catch(() => Toast.error('만료 배포 중 오류가 발생했습니다.'));
+        },
+
+        // ── 긴급차단 / 복구 ──
+
+        confirmEmergencyBlock: function(pageId, pageName) {
+            if (!confirm(`[${pageName}] 페이지를 긴급차단하시겠습니까?\n차단 즉시 대고객 페이지 접근이 불가합니다.`)) return;
+
+            fetch(`/api/cms-admin/deployments/${encodeURIComponent(pageId)}/emergency-block`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+            })
+                .then(r => r.json())
+                .then(res => {
+                    if (res.success) {
+                        Toast.success(res.message);
+                        this.load();
+                    } else {
+                        Toast.error(res.message);
+                    }
+                })
+                .catch(() => Toast.error('긴급차단 중 오류가 발생했습니다.'));
+        },
+
+        confirmRestore: function(pageId, pageName) {
+            if (!confirm(`[${pageName}] 페이지를 복구하시겠습니까?\n마지막 승인 버전으로 즉시 복구됩니다.`)) return;
+
+            fetch(`/api/cms-admin/deployments/${encodeURIComponent(pageId)}/restore`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+            })
+                .then(r => r.json())
+                .then(res => {
+                    if (res.success) {
+                        Toast.success(res.message);
+                        this.load();
+                    } else {
+                        Toast.error(res.message);
+                    }
+                })
+                .catch(() => Toast.error('복구 중 오류가 발생했습니다.'));
         },
 
         // ── 배포이력 상세 모달 ──

--- a/spider-admin/src/main/resources/templates/pages/cms-deployment/cms-deployment-table.html
+++ b/spider-admin/src/main/resources/templates/pages/cms-deployment/cms-deployment-table.html
@@ -10,23 +10,27 @@
                 <th class="sortable" data-sort="pageName">페이지명</th>
                 <th class="col-w-100 sortable" data-sort="createUserName">작성자</th>
                 <th class="col-w-220 sortable" data-sort="beginningDate">노출기간</th>
+                <th class="col-w-70 sortable" data-sort="isPublic">공개여부</th>
                 <th class="col-w-70"
                     th:if="${userAuthorities != null && userAuthorities.contains('CMS:W')}">배포</th>
                 <th class="col-w-90">배포 미리보기</th>
                 <th class="col-w-320">배포 URL</th>
                 <th class="col-w-90"
                     th:if="${userAuthorities != null && userAuthorities.contains('CMS:W')}">만료수동처리</th>
+                <!-- #325: 긴급차단/복구 — 배포된 페이지 노출 즉시 차단·복구 -->
+                <th class="col-w-90"
+                    th:if="${userAuthorities != null && userAuthorities.contains('CMS:W')}">긴급차단/복구</th>
                 <th class="col-w-80">배포이력 상세</th>
             </tr>
         </thead>
         <tbody id="deployPageTableBody">
             <tr>
-                <!-- canWrite 기준 9컬럼, 미권한 7컬럼 — JS renderTable()의 colspan과 일치해야 함 -->
-                <td colspan="9" class="text-center py-4 text-body-secondary"
+                <!-- canWrite 기준 11컬럼(공개여부+긴급차단/복구 추가), 미권한 8컬럼 — JS renderTable()의 colspan과 일치해야 함 -->
+                <td colspan="11" class="text-center py-4 text-body-secondary"
                     th:if="${userAuthorities != null && userAuthorities.contains('CMS:W')}">
                     조회 버튼을 클릭하여 데이터를 불러오세요.
                 </td>
-                <td colspan="7" class="text-center py-4 text-body-secondary"
+                <td colspan="8" class="text-center py-4 text-body-secondary"
                     th:unless="${userAuthorities != null && userAuthorities.contains('CMS:W')}">
                     조회 버튼을 클릭하여 데이터를 불러오세요.
                 </td>


### PR DESCRIPTION
## 📋 관련 이슈
closes #325

## 📝 작업 내용
- **html-cms**
  - `buildDeployHtml` / `calcCrc` / `LAYOUT_CSS`를 `deploy-utils.ts`로 분리 (복구 API와 공유)
  - 긴급차단 API 신규: `POST /api/deploy/emergency-block/[pageId]`
    - `IS_PUBLIC = 'N'` 업데이트
    - 활성 서버의 배포 HTML 파일 삭제
  - 복구 API 신규: `POST /api/deploy/restore/[pageId]`
    - `SPW_CMS_PAGE_HISTORY` 마지막 버전 `PAGE_HTML`로 파일 재생성
    - `IS_PUBLIC = 'Y'` 복원 (현재 페이지 `APPROVE_STATE` 불변)
  - `receive/route.ts`에 `DELETE` 엔드포인트 추가 (파일 삭제용)
  - `deploy-utils.ts`에 `deleteFromServer` 헬퍼 추가

- **spider-admin**
  - `CmsDeployProperties`에 `getDeployBaseUrl()` 헬퍼 추가
  - `CmsDeployController`: `emergency-block`, `restore` 엔드포인트 추가 (`CMS:W`)
  - `CmsDeployService`: `emergencyBlock()`, `restorePublic()`, `callCmsApi()` 추가
  - 배포관리 테이블: `공개여부` 컬럼 + `긴급차단/복구` 버튼 컬럼 추가
  - `IS_PUBLIC='N'` 시 배포 미리보기 버튼 비활성화 처리
  - 승인관리 페이지: `IS_PUBLIC` 컬럼·긴급차단/복구 버튼·관련 JS 함수 완전 제거

## 🛠 기술적 의사결정
- **파일 삭제 방식 선택**: nginx `auth_request` 방식은 레이턴시·설정 복잡도로 인해 제외. nginx가 `/data/deployed/`를 직접 서빙하므로 파일 삭제가 가장 확실한 차단 방법
- **기능 위치 변경 (승인관리 → 배포관리)**: 긴급차단은 배포된 페이지의 운영 제어 행위이므로 배포관리 페이지가 의미상 적합
- **복구 시 `deploy/push` 미사용**: `push` API는 `APPROVE_STATE='APPROVED'` 필수 조건 — 이후 편집(WORK 상태)된 페이지 복구 불가 문제 해결을 위해 별도 API 신규 작성
- **`FWK_CMS_FILE_SEND_HIS` 미갱신**: 이력 표시 전용으로 사용 중 — 긴급차단/복구 시 별도 업데이트 생략

## ⚠️ 고려 및 주의 사항
- **클라우드 환경에서만 차단 효과 확인 가능**: nginx가 `/data/deployed/` Docker 볼륨을 직접 서빙하는 구조이므로, 실제 URL 404 응답은 nginx + Docker Compose 환경(로컬 또는 운영 서버)에서 검증 필요
- `fail-open` 정책 유지: 복구 시 전체 서버 전송 실패인 경우 IS_PUBLIC='Y' 복원하지 않음
- 승인관리 페이지 `isPublic` 관련 백엔드 API(`/api/cms-admin/pages/{pageId}/public-state`)는 제거하지 않음 — 다른 용도 사용 가능성 보존

## 💬 리뷰 포인트
- `CmsDeployService.callCmsApi()` — x-deploy-token 인증으로 CMS API 호출. 긴급차단·복구가 세션 없이 토큰 인증으로 처리되는 흐름 확인 필요
- `restore/route.ts` — 복구 시 `getLatestHistory()`가 반환하는 이력이 항상 APPROVED 버전임을 전제 (HISTORY는 APPROVED 시에만 INSERT되는 설계)

🤖 Generated with [Claude Code](https://claude.com/claude-code)