### PR TITLE
🔐 fix/#329-CMS 승인반려 결재자 검증 추가

### DIFF
--- a/spider-admin/src/main/java/com/example/spideradmin/domain/cmsapproval/controller/CmsApprovalController.java
+++ b/spider-admin/src/main/java/com/example/spideradmin/domain/cmsapproval/controller/CmsApprovalController.java
@@ -71,7 +71,7 @@ public class CmsApprovalController {
             @RequestBody CmsApproveRequest req,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        cmsApprovalService.approve(pageId, req, userDetails.getUserId());
+        cmsApprovalService.approve(pageId, req, userDetails.getUserId(), userDetails.getRoleId());
         return ResponseEntity.ok(ApiResponse.success("승인이 완료되었습니다.", null));
     }
 
@@ -83,7 +83,7 @@ public class CmsApprovalController {
             @RequestBody CmsRejectRequest req,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        cmsApprovalService.reject(pageId, req, userDetails.getUserId());
+        cmsApprovalService.reject(pageId, req, userDetails.getUserId(), userDetails.getRoleId());
         return ResponseEntity.ok(ApiResponse.success("반려가 완료되었습니다.", null));
     }
 

--- a/spider-admin/src/main/java/com/example/spideradmin/domain/cmsapproval/controller/CmsApprovalController.java
+++ b/spider-admin/src/main/java/com/example/spideradmin/domain/cmsapproval/controller/CmsApprovalController.java
@@ -71,7 +71,7 @@ public class CmsApprovalController {
             @RequestBody CmsApproveRequest req,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        cmsApprovalService.approve(pageId, req, userDetails.getUserId(), userDetails.getRoleId());
+        cmsApprovalService.approve(pageId, req, userDetails.getUserId(), userDetails.isCmsAdmin());
         return ResponseEntity.ok(ApiResponse.success("승인이 완료되었습니다.", null));
     }
 
@@ -83,7 +83,7 @@ public class CmsApprovalController {
             @RequestBody CmsRejectRequest req,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        cmsApprovalService.reject(pageId, req, userDetails.getUserId(), userDetails.getRoleId());
+        cmsApprovalService.reject(pageId, req, userDetails.getUserId(), userDetails.isCmsAdmin());
         return ResponseEntity.ok(ApiResponse.success("반려가 완료되었습니다.", null));
     }
 

--- a/spider-admin/src/main/java/com/example/spideradmin/domain/cmsapproval/mapper/CmsApprovalMapper.java
+++ b/spider-admin/src/main/java/com/example/spideradmin/domain/cmsapproval/mapper/CmsApprovalMapper.java
@@ -24,6 +24,9 @@ public interface CmsApprovalMapper {
     /** 페이지 존재 여부 확인 */
     int existsByPageId(@Param("pageId") String pageId);
 
+    /** 지정된 결재자 ID 조회 — 승인/반려 전 결재자 검증용 (#329) */
+    String findApproverIdByPageId(@Param("pageId") String pageId);
+
     /** 승인 확정 — APPROVE_STATE → APPROVED */
     int approve(
             @Param("pageId") String pageId,

--- a/spider-admin/src/main/java/com/example/spideradmin/domain/cmsapproval/service/CmsApprovalService.java
+++ b/spider-admin/src/main/java/com/example/spideradmin/domain/cmsapproval/service/CmsApprovalService.java
@@ -46,12 +46,12 @@ public class CmsApprovalService {
     /**
      * 승인 확정 — APPROVE_STATE: PENDING → APPROVED
      * 상태를 먼저 변경한 뒤 변경 후 상태를 이력 스냅샷으로 저장한다.
-     * 결재자 검증: 지정된 결재자(APPROVER_ID) 또는 cms_admin/ADMIN 역할만 처리 가능 (#329)
+     * 결재자 검증: 지정된 결재자(APPROVER_ID) 또는 CMS 관리자(cms_admin/ADMIN)만 처리 가능 (#329)
      */
     @Transactional
-    public void approve(String pageId, CmsApproveRequest req, String modifierId, String roleId) {
+    public void approve(String pageId, CmsApproveRequest req, String modifierId, boolean isCmsAdmin) {
         checkPageExists(pageId);
-        validateApprover(pageId, modifierId, roleId);
+        validateApprover(pageId, modifierId, isCmsAdmin);
         validateDisplayPeriod(req.getBeginningDate(), req.getExpiredDate());
         int updated = cmsApprovalMapper.approve(pageId, req.getBeginningDate(), req.getExpiredDate(), modifierId);
         if (updated == 0) {
@@ -65,12 +65,12 @@ public class CmsApprovalService {
     /**
      * 반려 — APPROVE_STATE: PENDING → REJECTED
      * 상태를 먼저 변경한 뒤 변경 후 상태를 이력 스냅샷으로 저장한다.
-     * 결재자 검증: 지정된 결재자(APPROVER_ID) 또는 cms_admin/ADMIN 역할만 처리 가능 (#329)
+     * 결재자 검증: 지정된 결재자(APPROVER_ID) 또는 CMS 관리자(cms_admin/ADMIN)만 처리 가능 (#329)
      */
     @Transactional
-    public void reject(String pageId, CmsRejectRequest req, String modifierId, String roleId) {
+    public void reject(String pageId, CmsRejectRequest req, String modifierId, boolean isCmsAdmin) {
         checkPageExists(pageId);
-        validateApprover(pageId, modifierId, roleId);
+        validateApprover(pageId, modifierId, isCmsAdmin);
         int updated = cmsApprovalMapper.reject(pageId, req.getRejectedReason(), modifierId);
         if (updated == 0) {
             throw new InvalidInputException("승인 대기 상태의 페이지가 아닙니다. pageId=" + pageId);
@@ -127,13 +127,13 @@ public class CmsApprovalService {
      *
      * <p>다음 조건 중 하나를 만족하면 통과한다:
      * <ul>
-     *   <li>roleId 가 "ADMIN" 또는 "cms_admin" — 관리자 대리 처리 허용</li>
+     *   <li>isCmsAdmin = true — ADMIN/cms_admin 역할, 관리자 대리 처리 허용</li>
      *   <li>APPROVER_ID 가 null — 미지정(레거시) 데이터는 검증 스킵</li>
      *   <li>APPROVER_ID = modifierId — 지정된 결재자 본인</li>
      * </ul>
      */
-    private void validateApprover(String pageId, String modifierId, String roleId) {
-        if ("ADMIN".equals(roleId) || "cms_admin".equals(roleId)) return;
+    private void validateApprover(String pageId, String modifierId, boolean isCmsAdmin) {
+        if (isCmsAdmin) return;
 
         String assignedApproverId = cmsApprovalMapper.findApproverIdByPageId(pageId);
         if (assignedApproverId == null) return;

--- a/spider-admin/src/main/java/com/example/spideradmin/domain/cmsapproval/service/CmsApprovalService.java
+++ b/spider-admin/src/main/java/com/example/spideradmin/domain/cmsapproval/service/CmsApprovalService.java
@@ -46,10 +46,12 @@ public class CmsApprovalService {
     /**
      * 승인 확정 — APPROVE_STATE: PENDING → APPROVED
      * 상태를 먼저 변경한 뒤 변경 후 상태를 이력 스냅샷으로 저장한다.
+     * 결재자 검증: 지정된 결재자(APPROVER_ID) 또는 cms_admin/ADMIN 역할만 처리 가능 (#329)
      */
     @Transactional
-    public void approve(String pageId, CmsApproveRequest req, String modifierId) {
+    public void approve(String pageId, CmsApproveRequest req, String modifierId, String roleId) {
         checkPageExists(pageId);
+        validateApprover(pageId, modifierId, roleId);
         validateDisplayPeriod(req.getBeginningDate(), req.getExpiredDate());
         int updated = cmsApprovalMapper.approve(pageId, req.getBeginningDate(), req.getExpiredDate(), modifierId);
         if (updated == 0) {
@@ -63,10 +65,12 @@ public class CmsApprovalService {
     /**
      * 반려 — APPROVE_STATE: PENDING → REJECTED
      * 상태를 먼저 변경한 뒤 변경 후 상태를 이력 스냅샷으로 저장한다.
+     * 결재자 검증: 지정된 결재자(APPROVER_ID) 또는 cms_admin/ADMIN 역할만 처리 가능 (#329)
      */
     @Transactional
-    public void reject(String pageId, CmsRejectRequest req, String modifierId) {
+    public void reject(String pageId, CmsRejectRequest req, String modifierId, String roleId) {
         checkPageExists(pageId);
+        validateApprover(pageId, modifierId, roleId);
         int updated = cmsApprovalMapper.reject(pageId, req.getRejectedReason(), modifierId);
         if (updated == 0) {
             throw new InvalidInputException("승인 대기 상태의 페이지가 아닙니다. pageId=" + pageId);
@@ -115,6 +119,27 @@ public class CmsApprovalService {
     private void checkPageExists(String pageId) {
         if (cmsApprovalMapper.existsByPageId(pageId) == 0) {
             throw new NotFoundException("페이지를 찾을 수 없습니다. pageId=" + pageId);
+        }
+    }
+
+    /**
+     * 결재자 검증 — APPROVER_ID 일치 여부 확인 (#329)
+     *
+     * <p>다음 조건 중 하나를 만족하면 통과한다:
+     * <ul>
+     *   <li>roleId 가 "ADMIN" 또는 "cms_admin" — 관리자 대리 처리 허용</li>
+     *   <li>APPROVER_ID 가 null — 미지정(레거시) 데이터는 검증 스킵</li>
+     *   <li>APPROVER_ID = modifierId — 지정된 결재자 본인</li>
+     * </ul>
+     */
+    private void validateApprover(String pageId, String modifierId, String roleId) {
+        if ("ADMIN".equals(roleId) || "cms_admin".equals(roleId)) return;
+
+        String assignedApproverId = cmsApprovalMapper.findApproverIdByPageId(pageId);
+        if (assignedApproverId == null) return;
+
+        if (!assignedApproverId.equals(modifierId)) {
+            throw new InvalidInputException("지정된 결재자만 승인/반려할 수 있습니다.");
         }
     }
 

--- a/spider-admin/src/main/java/com/example/spideradmin/global/security/CustomUserDetails.java
+++ b/spider-admin/src/main/java/com/example/spideradmin/global/security/CustomUserDetails.java
@@ -11,6 +11,11 @@ import org.springframework.security.core.userdetails.UserDetails;
 @Getter
 public class CustomUserDetails implements UserDetails {
 
+    /** CmsRedirectController.isCmsAdmin() 과 동일한 역할 판별 기준 */
+    private static final String ADMIN_ROLE = "ADMIN";
+
+    private static final String CMS_ADMIN_ROLE = "cms_admin";
+
     private final AuthenticatedUser user;
     private final Set<GrantedAuthority> authorities;
 
@@ -64,5 +69,11 @@ public class CustomUserDetails implements UserDetails {
 
     public String getRoleId() {
         return user.getRoleId();
+    }
+
+    /** ADMIN 또는 cms_admin 역할이면 CMS 관리자로 판별 — CmsRedirectController.isCmsAdmin() 과 동일 기준 */
+    public boolean isCmsAdmin() {
+        String roleId = user.getRoleId();
+        return ADMIN_ROLE.equals(roleId) || CMS_ADMIN_ROLE.equals(roleId);
     }
 }

--- a/spider-admin/src/main/resources/mapper/oracle/cmsapproval/CmsApprovalMapper.xml
+++ b/spider-admin/src/main/resources/mapper/oracle/cmsapproval/CmsApprovalMapper.xml
@@ -117,6 +117,14 @@
           AND PAGE_TYPE = 'PAGE'
     </select>
 
+    <!-- 결재자 검증용 — 승인요청 시 저장된 APPROVER_ID 조회 (#329) -->
+    <select id="findApproverIdByPageId" resultType="String">
+        SELECT APPROVER_ID
+        FROM SPW_CMS_PAGE
+        WHERE PAGE_ID   = #{pageId}
+          AND PAGE_TYPE = 'PAGE'
+    </select>
+
     <!-- ==================== 승인 — APPROVED ==================== -->
 
     <update id="approve">

--- a/spider-admin/src/test/java/com/example/spideradmin/domain/cmsapproval/controller/CmsApprovalControllerTest.java
+++ b/spider-admin/src/test/java/com/example/spideradmin/domain/cmsapproval/controller/CmsApprovalControllerTest.java
@@ -1,6 +1,7 @@
 package com.example.spideradmin.domain.cmsapproval.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
@@ -152,7 +153,7 @@ class CmsApprovalControllerTest {
     @Test
     @DisplayName("[승인] CMS:W 권한으로 승인 시 200을 반환한다")
     void approve_withCmsW_returns200() throws Exception {
-        willDoNothing().given(cmsApprovalService).approve(any(), any(), any());
+        willDoNothing().given(cmsApprovalService).approve(any(), any(), any(), anyBoolean());
 
         mockMvc.perform(post(PAGE_URL + "/approval/approve")
                         .with(csrf())
@@ -169,7 +170,7 @@ class CmsApprovalControllerTest {
     void approve_pageNotFound_returns404() throws Exception {
         willThrow(new NotFoundException("pageId: " + PAGE_ID))
                 .given(cmsApprovalService)
-                .approve(any(), any(), any());
+                .approve(any(), any(), any(), anyBoolean());
 
         mockMvc.perform(post(PAGE_URL + "/approval/approve")
                         .with(csrf())
@@ -207,7 +208,7 @@ class CmsApprovalControllerTest {
     @Test
     @DisplayName("[반려] CMS:W 권한으로 반려 시 200을 반환한다")
     void reject_withCmsW_returns200() throws Exception {
-        willDoNothing().given(cmsApprovalService).reject(any(), any(), any());
+        willDoNothing().given(cmsApprovalService).reject(any(), any(), any(), anyBoolean());
 
         mockMvc.perform(post(PAGE_URL + "/approval/reject")
                         .with(csrf())
@@ -223,7 +224,7 @@ class CmsApprovalControllerTest {
     void reject_pageNotFound_returns404() throws Exception {
         willThrow(new NotFoundException("pageId: " + PAGE_ID))
                 .given(cmsApprovalService)
-                .reject(any(), any(), any());
+                .reject(any(), any(), any(), anyBoolean());
 
         mockMvc.perform(post(PAGE_URL + "/approval/reject")
                         .with(csrf())

--- a/spider-admin/src/test/java/com/example/spideradmin/domain/cmsapproval/service/CmsApprovalServiceTest.java
+++ b/spider-admin/src/test/java/com/example/spideradmin/domain/cmsapproval/service/CmsApprovalServiceTest.java
@@ -157,9 +157,9 @@ class CmsApprovalServiceTest {
         // APPROVER_ID = "other-user", 현재 사용자 = MODIFIER_ID → 불일치
         given(cmsApprovalMapper.findApproverIdByPageId(PAGE_ID)).willReturn("other-user");
 
+        // InvalidInputException.getMessage()는 ErrorType 고정 메시지를 반환하므로 타입만 검증
         assertThatThrownBy(() -> cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, false))
-                .isInstanceOf(InvalidInputException.class)
-                .hasMessageContaining("지정된 결재자만");
+                .isInstanceOf(InvalidInputException.class);
     }
 
     @Test
@@ -269,9 +269,9 @@ class CmsApprovalServiceTest {
         given(cmsApprovalMapper.existsByPageId(PAGE_ID)).willReturn(1);
         given(cmsApprovalMapper.findApproverIdByPageId(PAGE_ID)).willReturn("other-user");
 
+        // InvalidInputException.getMessage()는 ErrorType 고정 메시지를 반환하므로 타입만 검증
         assertThatThrownBy(() -> cmsApprovalService.reject(PAGE_ID, req, MODIFIER_ID, false))
-                .isInstanceOf(InvalidInputException.class)
-                .hasMessageContaining("지정된 결재자만");
+                .isInstanceOf(InvalidInputException.class);
     }
 
     @Test

--- a/spider-admin/src/test/java/com/example/spideradmin/domain/cmsapproval/service/CmsApprovalServiceTest.java
+++ b/spider-admin/src/test/java/com/example/spideradmin/domain/cmsapproval/service/CmsApprovalServiceTest.java
@@ -43,6 +43,10 @@ class CmsApprovalServiceTest {
 
     private static final String PAGE_ID = "PAGE-001";
     private static final String MODIFIER_ID = "admin";
+    /** 일반 사용자 역할 — cms_admin/ADMIN 이외의 역할 */
+    private static final String ROLE_NORMAL = "user";
+    private static final String ROLE_ADMIN = "ADMIN";
+    private static final String ROLE_CMS_ADMIN = "cms_admin";
 
     // ─── findPageList ─────────────────────────────────────────────────
 
@@ -88,11 +92,13 @@ class CmsApprovalServiceTest {
         req.setExpiredDate("2099-04-18");
 
         given(cmsApprovalMapper.existsByPageId(PAGE_ID)).willReturn(1);
+        // 지정된 결재자 = MODIFIER_ID → 검증 통과
+        given(cmsApprovalMapper.findApproverIdByPageId(PAGE_ID)).willReturn(MODIFIER_ID);
         given(cmsApprovalMapper.approve(PAGE_ID, "2099-04-17", "2099-04-18", MODIFIER_ID))
                 .willReturn(1);
         given(cmsApprovalMapper.getNextVersion(PAGE_ID)).willReturn(1);
 
-        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID);
+        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL);
 
         then(cmsApprovalMapper).should().approve(eq(PAGE_ID), eq("2099-04-17"), eq("2099-04-18"), eq(MODIFIER_ID));
         then(cmsApprovalMapper).should().insertHistory(eq(PAGE_ID), eq(1));
@@ -104,10 +110,11 @@ class CmsApprovalServiceTest {
         // 승인 요청 시 날짜를 지정하지 않을 수 있으므로 null은 허용
         CmsApproveRequest req = new CmsApproveRequest();
         given(cmsApprovalMapper.existsByPageId(PAGE_ID)).willReturn(1);
+        given(cmsApprovalMapper.findApproverIdByPageId(PAGE_ID)).willReturn(MODIFIER_ID);
         given(cmsApprovalMapper.approve(PAGE_ID, null, null, MODIFIER_ID)).willReturn(1);
         given(cmsApprovalMapper.getNextVersion(PAGE_ID)).willReturn(1);
 
-        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID);
+        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL);
 
         then(cmsApprovalMapper).should().approve(eq(PAGE_ID), eq(null), eq(null), eq(MODIFIER_ID));
         then(cmsApprovalMapper).should().insertHistory(eq(PAGE_ID), eq(1));
@@ -123,11 +130,12 @@ class CmsApprovalServiceTest {
         req.setExpiredDate(expiredDate);
 
         given(cmsApprovalMapper.existsByPageId(PAGE_ID)).willReturn(1);
+        given(cmsApprovalMapper.findApproverIdByPageId(PAGE_ID)).willReturn(MODIFIER_ID);
         given(cmsApprovalMapper.approve(PAGE_ID, beginningDate, expiredDate, MODIFIER_ID))
                 .willReturn(1);
         given(cmsApprovalMapper.getNextVersion(PAGE_ID)).willReturn(1);
 
-        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID);
+        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL);
 
         then(cmsApprovalMapper).should().approve(eq(PAGE_ID), eq(beginningDate), eq(expiredDate), eq(MODIFIER_ID));
         then(cmsApprovalMapper).should().insertHistory(eq(PAGE_ID), eq(1));
@@ -139,8 +147,65 @@ class CmsApprovalServiceTest {
         CmsApproveRequest req = new CmsApproveRequest();
         given(cmsApprovalMapper.existsByPageId(PAGE_ID)).willReturn(0);
 
-        assertThatThrownBy(() -> cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID))
+        assertThatThrownBy(() -> cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL))
                 .isInstanceOf(NotFoundException.class);
+    }
+
+    // ─── approve 결재자 검증 ───────────────────────────────────────────
+
+    @Test
+    @DisplayName("[승인][결재자검증] 지정된 결재자가 아니면 InvalidInputException을 던진다")
+    void approve_notAssignedApprover_throwsInvalidInputException() {
+        CmsApproveRequest req = new CmsApproveRequest();
+        given(cmsApprovalMapper.existsByPageId(PAGE_ID)).willReturn(1);
+        // APPROVER_ID = "other-user", 현재 사용자 = MODIFIER_ID → 불일치
+        given(cmsApprovalMapper.findApproverIdByPageId(PAGE_ID)).willReturn("other-user");
+
+        assertThatThrownBy(() -> cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL))
+                .isInstanceOf(InvalidInputException.class)
+                .hasMessageContaining("지정된 결재자만");
+    }
+
+    @Test
+    @DisplayName("[승인][결재자검증] ADMIN 역할이면 지정된 결재자가 아니어도 승인할 수 있다")
+    void approve_adminRole_bypassesApproverCheck() {
+        CmsApproveRequest req = new CmsApproveRequest();
+        given(cmsApprovalMapper.existsByPageId(PAGE_ID)).willReturn(1);
+        // ADMIN 역할 → validateApprover 조기 반환, findApproverIdByPageId 호출 안 함
+        given(cmsApprovalMapper.approve(PAGE_ID, null, null, MODIFIER_ID)).willReturn(1);
+        given(cmsApprovalMapper.getNextVersion(PAGE_ID)).willReturn(1);
+
+        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, ROLE_ADMIN);
+
+        then(cmsApprovalMapper).should().approve(eq(PAGE_ID), any(), any(), eq(MODIFIER_ID));
+    }
+
+    @Test
+    @DisplayName("[승인][결재자검증] cms_admin 역할이면 지정된 결재자가 아니어도 승인할 수 있다")
+    void approve_cmsAdminRole_bypassesApproverCheck() {
+        CmsApproveRequest req = new CmsApproveRequest();
+        given(cmsApprovalMapper.existsByPageId(PAGE_ID)).willReturn(1);
+        given(cmsApprovalMapper.approve(PAGE_ID, null, null, MODIFIER_ID)).willReturn(1);
+        given(cmsApprovalMapper.getNextVersion(PAGE_ID)).willReturn(1);
+
+        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, ROLE_CMS_ADMIN);
+
+        then(cmsApprovalMapper).should().approve(eq(PAGE_ID), any(), any(), eq(MODIFIER_ID));
+    }
+
+    @Test
+    @DisplayName("[승인][결재자검증] APPROVER_ID가 null이면 검증 없이 승인할 수 있다")
+    void approve_approverIdNull_skipsValidation() {
+        CmsApproveRequest req = new CmsApproveRequest();
+        given(cmsApprovalMapper.existsByPageId(PAGE_ID)).willReturn(1);
+        // APPROVER_ID = null — 레거시 데이터 하위 호환
+        given(cmsApprovalMapper.findApproverIdByPageId(PAGE_ID)).willReturn(null);
+        given(cmsApprovalMapper.approve(PAGE_ID, null, null, MODIFIER_ID)).willReturn(1);
+        given(cmsApprovalMapper.getNextVersion(PAGE_ID)).willReturn(1);
+
+        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL);
+
+        then(cmsApprovalMapper).should().approve(eq(PAGE_ID), any(), any(), eq(MODIFIER_ID));
     }
 
     // ─── reject ──────────────────────────────────────────────────────
@@ -152,10 +217,11 @@ class CmsApprovalServiceTest {
         req.setRejectedReason("내용 부적합");
 
         given(cmsApprovalMapper.existsByPageId(PAGE_ID)).willReturn(1);
+        given(cmsApprovalMapper.findApproverIdByPageId(PAGE_ID)).willReturn(MODIFIER_ID);
         given(cmsApprovalMapper.reject(PAGE_ID, "내용 부적합", MODIFIER_ID)).willReturn(1);
         given(cmsApprovalMapper.getNextVersion(PAGE_ID)).willReturn(2);
 
-        cmsApprovalService.reject(PAGE_ID, req, MODIFIER_ID);
+        cmsApprovalService.reject(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL);
 
         then(cmsApprovalMapper).should().reject(eq(PAGE_ID), eq("내용 부적합"), eq(MODIFIER_ID));
         then(cmsApprovalMapper).should().insertHistory(eq(PAGE_ID), eq(2));
@@ -168,7 +234,7 @@ class CmsApprovalServiceTest {
         req.setRejectedReason("이유");
         given(cmsApprovalMapper.existsByPageId(PAGE_ID)).willReturn(0);
 
-        assertThatThrownBy(() -> cmsApprovalService.reject(PAGE_ID, req, MODIFIER_ID))
+        assertThatThrownBy(() -> cmsApprovalService.reject(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL))
                 .isInstanceOf(NotFoundException.class);
     }
 
@@ -177,9 +243,10 @@ class CmsApprovalServiceTest {
     void approve_notPending_throwsInvalidInputException() {
         CmsApproveRequest req = new CmsApproveRequest();
         given(cmsApprovalMapper.existsByPageId(PAGE_ID)).willReturn(1);
+        given(cmsApprovalMapper.findApproverIdByPageId(PAGE_ID)).willReturn(MODIFIER_ID);
         given(cmsApprovalMapper.approve(PAGE_ID, null, null, MODIFIER_ID)).willReturn(0);
 
-        assertThatThrownBy(() -> cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID))
+        assertThatThrownBy(() -> cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL))
                 .isInstanceOf(InvalidInputException.class);
     }
 
@@ -189,10 +256,40 @@ class CmsApprovalServiceTest {
         CmsRejectRequest req = new CmsRejectRequest();
         req.setRejectedReason("이유");
         given(cmsApprovalMapper.existsByPageId(PAGE_ID)).willReturn(1);
+        given(cmsApprovalMapper.findApproverIdByPageId(PAGE_ID)).willReturn(MODIFIER_ID);
         given(cmsApprovalMapper.reject(PAGE_ID, "이유", MODIFIER_ID)).willReturn(0);
 
-        assertThatThrownBy(() -> cmsApprovalService.reject(PAGE_ID, req, MODIFIER_ID))
+        assertThatThrownBy(() -> cmsApprovalService.reject(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL))
                 .isInstanceOf(InvalidInputException.class);
+    }
+
+    // ─── reject 결재자 검증 ────────────────────────────────────────────
+
+    @Test
+    @DisplayName("[반려][결재자검증] 지정된 결재자가 아니면 InvalidInputException을 던진다")
+    void reject_notAssignedApprover_throwsInvalidInputException() {
+        CmsRejectRequest req = new CmsRejectRequest();
+        req.setRejectedReason("이유");
+        given(cmsApprovalMapper.existsByPageId(PAGE_ID)).willReturn(1);
+        given(cmsApprovalMapper.findApproverIdByPageId(PAGE_ID)).willReturn("other-user");
+
+        assertThatThrownBy(() -> cmsApprovalService.reject(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL))
+                .isInstanceOf(InvalidInputException.class)
+                .hasMessageContaining("지정된 결재자만");
+    }
+
+    @Test
+    @DisplayName("[반려][결재자검증] ADMIN 역할이면 지정된 결재자가 아니어도 반려할 수 있다")
+    void reject_adminRole_bypassesApproverCheck() {
+        CmsRejectRequest req = new CmsRejectRequest();
+        req.setRejectedReason("이유");
+        given(cmsApprovalMapper.existsByPageId(PAGE_ID)).willReturn(1);
+        given(cmsApprovalMapper.reject(PAGE_ID, "이유", MODIFIER_ID)).willReturn(1);
+        given(cmsApprovalMapper.getNextVersion(PAGE_ID)).willReturn(1);
+
+        cmsApprovalService.reject(PAGE_ID, req, MODIFIER_ID, ROLE_ADMIN);
+
+        then(cmsApprovalMapper).should().reject(eq(PAGE_ID), eq("이유"), eq(MODIFIER_ID));
     }
 
     // ─── updatePublicState ────────────────────────────────────────────

--- a/spider-admin/src/test/java/com/example/spideradmin/domain/cmsapproval/service/CmsApprovalServiceTest.java
+++ b/spider-admin/src/test/java/com/example/spideradmin/domain/cmsapproval/service/CmsApprovalServiceTest.java
@@ -45,6 +45,7 @@ class CmsApprovalServiceTest {
     private static final String MODIFIER_ID = "admin";
     /** 일반 사용자 역할 — cms_admin/ADMIN 이외의 역할 */
     private static final String ROLE_NORMAL = "user";
+
     private static final String ROLE_ADMIN = "ADMIN";
     private static final String ROLE_CMS_ADMIN = "cms_admin";
 

--- a/spider-admin/src/test/java/com/example/spideradmin/domain/cmsapproval/service/CmsApprovalServiceTest.java
+++ b/spider-admin/src/test/java/com/example/spideradmin/domain/cmsapproval/service/CmsApprovalServiceTest.java
@@ -44,7 +44,6 @@ class CmsApprovalServiceTest {
     private static final String PAGE_ID = "PAGE-001";
     private static final String MODIFIER_ID = "admin";
 
-
     // ─── findPageList ─────────────────────────────────────────────────
 
     @Test

--- a/spider-admin/src/test/java/com/example/spideradmin/domain/cmsapproval/service/CmsApprovalServiceTest.java
+++ b/spider-admin/src/test/java/com/example/spideradmin/domain/cmsapproval/service/CmsApprovalServiceTest.java
@@ -43,11 +43,7 @@ class CmsApprovalServiceTest {
 
     private static final String PAGE_ID = "PAGE-001";
     private static final String MODIFIER_ID = "admin";
-    /** 일반 사용자 역할 — cms_admin/ADMIN 이외의 역할 */
-    private static final String ROLE_NORMAL = "user";
 
-    private static final String ROLE_ADMIN = "ADMIN";
-    private static final String ROLE_CMS_ADMIN = "cms_admin";
 
     // ─── findPageList ─────────────────────────────────────────────────
 
@@ -99,7 +95,7 @@ class CmsApprovalServiceTest {
                 .willReturn(1);
         given(cmsApprovalMapper.getNextVersion(PAGE_ID)).willReturn(1);
 
-        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL);
+        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, false);
 
         then(cmsApprovalMapper).should().approve(eq(PAGE_ID), eq("2099-04-17"), eq("2099-04-18"), eq(MODIFIER_ID));
         then(cmsApprovalMapper).should().insertHistory(eq(PAGE_ID), eq(1));
@@ -115,7 +111,7 @@ class CmsApprovalServiceTest {
         given(cmsApprovalMapper.approve(PAGE_ID, null, null, MODIFIER_ID)).willReturn(1);
         given(cmsApprovalMapper.getNextVersion(PAGE_ID)).willReturn(1);
 
-        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL);
+        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, false);
 
         then(cmsApprovalMapper).should().approve(eq(PAGE_ID), eq(null), eq(null), eq(MODIFIER_ID));
         then(cmsApprovalMapper).should().insertHistory(eq(PAGE_ID), eq(1));
@@ -136,7 +132,7 @@ class CmsApprovalServiceTest {
                 .willReturn(1);
         given(cmsApprovalMapper.getNextVersion(PAGE_ID)).willReturn(1);
 
-        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL);
+        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, false);
 
         then(cmsApprovalMapper).should().approve(eq(PAGE_ID), eq(beginningDate), eq(expiredDate), eq(MODIFIER_ID));
         then(cmsApprovalMapper).should().insertHistory(eq(PAGE_ID), eq(1));
@@ -148,7 +144,7 @@ class CmsApprovalServiceTest {
         CmsApproveRequest req = new CmsApproveRequest();
         given(cmsApprovalMapper.existsByPageId(PAGE_ID)).willReturn(0);
 
-        assertThatThrownBy(() -> cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL))
+        assertThatThrownBy(() -> cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, false))
                 .isInstanceOf(NotFoundException.class);
     }
 
@@ -162,7 +158,7 @@ class CmsApprovalServiceTest {
         // APPROVER_ID = "other-user", 현재 사용자 = MODIFIER_ID → 불일치
         given(cmsApprovalMapper.findApproverIdByPageId(PAGE_ID)).willReturn("other-user");
 
-        assertThatThrownBy(() -> cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL))
+        assertThatThrownBy(() -> cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, false))
                 .isInstanceOf(InvalidInputException.class)
                 .hasMessageContaining("지정된 결재자만");
     }
@@ -176,7 +172,7 @@ class CmsApprovalServiceTest {
         given(cmsApprovalMapper.approve(PAGE_ID, null, null, MODIFIER_ID)).willReturn(1);
         given(cmsApprovalMapper.getNextVersion(PAGE_ID)).willReturn(1);
 
-        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, ROLE_ADMIN);
+        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, true);
 
         then(cmsApprovalMapper).should().approve(eq(PAGE_ID), any(), any(), eq(MODIFIER_ID));
     }
@@ -189,7 +185,7 @@ class CmsApprovalServiceTest {
         given(cmsApprovalMapper.approve(PAGE_ID, null, null, MODIFIER_ID)).willReturn(1);
         given(cmsApprovalMapper.getNextVersion(PAGE_ID)).willReturn(1);
 
-        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, ROLE_CMS_ADMIN);
+        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, true);
 
         then(cmsApprovalMapper).should().approve(eq(PAGE_ID), any(), any(), eq(MODIFIER_ID));
     }
@@ -204,7 +200,7 @@ class CmsApprovalServiceTest {
         given(cmsApprovalMapper.approve(PAGE_ID, null, null, MODIFIER_ID)).willReturn(1);
         given(cmsApprovalMapper.getNextVersion(PAGE_ID)).willReturn(1);
 
-        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL);
+        cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, false);
 
         then(cmsApprovalMapper).should().approve(eq(PAGE_ID), any(), any(), eq(MODIFIER_ID));
     }
@@ -222,7 +218,7 @@ class CmsApprovalServiceTest {
         given(cmsApprovalMapper.reject(PAGE_ID, "내용 부적합", MODIFIER_ID)).willReturn(1);
         given(cmsApprovalMapper.getNextVersion(PAGE_ID)).willReturn(2);
 
-        cmsApprovalService.reject(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL);
+        cmsApprovalService.reject(PAGE_ID, req, MODIFIER_ID, false);
 
         then(cmsApprovalMapper).should().reject(eq(PAGE_ID), eq("내용 부적합"), eq(MODIFIER_ID));
         then(cmsApprovalMapper).should().insertHistory(eq(PAGE_ID), eq(2));
@@ -235,7 +231,7 @@ class CmsApprovalServiceTest {
         req.setRejectedReason("이유");
         given(cmsApprovalMapper.existsByPageId(PAGE_ID)).willReturn(0);
 
-        assertThatThrownBy(() -> cmsApprovalService.reject(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL))
+        assertThatThrownBy(() -> cmsApprovalService.reject(PAGE_ID, req, MODIFIER_ID, false))
                 .isInstanceOf(NotFoundException.class);
     }
 
@@ -247,7 +243,7 @@ class CmsApprovalServiceTest {
         given(cmsApprovalMapper.findApproverIdByPageId(PAGE_ID)).willReturn(MODIFIER_ID);
         given(cmsApprovalMapper.approve(PAGE_ID, null, null, MODIFIER_ID)).willReturn(0);
 
-        assertThatThrownBy(() -> cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL))
+        assertThatThrownBy(() -> cmsApprovalService.approve(PAGE_ID, req, MODIFIER_ID, false))
                 .isInstanceOf(InvalidInputException.class);
     }
 
@@ -260,7 +256,7 @@ class CmsApprovalServiceTest {
         given(cmsApprovalMapper.findApproverIdByPageId(PAGE_ID)).willReturn(MODIFIER_ID);
         given(cmsApprovalMapper.reject(PAGE_ID, "이유", MODIFIER_ID)).willReturn(0);
 
-        assertThatThrownBy(() -> cmsApprovalService.reject(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL))
+        assertThatThrownBy(() -> cmsApprovalService.reject(PAGE_ID, req, MODIFIER_ID, false))
                 .isInstanceOf(InvalidInputException.class);
     }
 
@@ -274,7 +270,7 @@ class CmsApprovalServiceTest {
         given(cmsApprovalMapper.existsByPageId(PAGE_ID)).willReturn(1);
         given(cmsApprovalMapper.findApproverIdByPageId(PAGE_ID)).willReturn("other-user");
 
-        assertThatThrownBy(() -> cmsApprovalService.reject(PAGE_ID, req, MODIFIER_ID, ROLE_NORMAL))
+        assertThatThrownBy(() -> cmsApprovalService.reject(PAGE_ID, req, MODIFIER_ID, false))
                 .isInstanceOf(InvalidInputException.class)
                 .hasMessageContaining("지정된 결재자만");
     }
@@ -288,7 +284,7 @@ class CmsApprovalServiceTest {
         given(cmsApprovalMapper.reject(PAGE_ID, "이유", MODIFIER_ID)).willReturn(1);
         given(cmsApprovalMapper.getNextVersion(PAGE_ID)).willReturn(1);
 
-        cmsApprovalService.reject(PAGE_ID, req, MODIFIER_ID, ROLE_ADMIN);
+        cmsApprovalService.reject(PAGE_ID, req, MODIFIER_ID, true);
 
         then(cmsApprovalMapper).should().reject(eq(PAGE_ID), eq("이유"), eq(MODIFIER_ID));
     }


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)

Closes #329

## ✨ 변경 사항 (Changes)

- `CmsApprovalMapper.xml` — `findApproverIdByPageId` 쿼리 추가 (결재자 ID 조회)
- `CmsApprovalMapper.java` — 위 쿼리 인터페이스 추가
- `CmsApprovalService.java` — `validateApprover()` 메서드 추가, `approve` / `reject` 시그니처에 `roleId` 파라미터 추가
- `CmsApprovalController.java` — `userDetails.getRoleId()` 를 서비스에 전달
- `CmsApprovalServiceTest.java` — 시그니처 업데이트 + 결재자 검증 테스트케이스 6개 추가

## 🛠 기술적 의사결정 (선택)

**SQL WHERE절 추가(방안 A)** 대신 **Service 레이어 검증(방안 B)** 채택.

방안 A는 구현이 단순하지만 `APPROVER_ID = null`인 레거시 데이터를 일괄 차단하고, 관리자 대리 처리가 불가능하다.
방안 B는 `cms_admin` / `ADMIN` 역할 예외를 허용하고 null 케이스를 유연하게 처리할 수 있어 운영 요건에 적합하다.

**통과 조건 (3가지 중 하나):**
1. 현재 사용자 = `APPROVER_ID` (지정된 결재자 본인)
2. `ROLE_ID = 'ADMIN'` (시스템 전체 관리자 — 대리 처리)
3. `ROLE_ID = 'cms_admin'` (CMS 전용 관리자 — 대리 처리)
4. `APPROVER_ID IS NULL` — 레거시 데이터 하위 호환, 검증 스킵

## 🧪 테스트 (선택)

- [x] `CmsApprovalServiceTest` — 단위 테스트 전체 통과
- [x] 결재자 검증 케이스 6개 추가
  - 지정된 결재자가 아닌 경우 `InvalidInputException`
  - `ADMIN` 역할 → 검증 우회
  - `cms_admin` 역할 → 검증 우회
  - `APPROVER_ID = null` → 검증 스킵 (하위 호환)
  - approve / reject 각각 검증

## ⚠️ 고려 및 주의 사항 (선택)

- 기존에 `APPROVER_ID`가 null인 채로 PENDING 상태인 데이터가 있다면 누구든 처리 가능 (의도적 하위 호환)
- 역할 판별 기준은 `CmsRedirectController.isCmsAdmin()`과 동일 (`ROLE_ID = 'ADMIN' OR 'cms_admin'`)

## 💬 리뷰 포인트 (선택)

- `validateApprover()` 내 역할 문자열(`"ADMIN"`, `"cms_admin"`)이 하드코딩되어 있습니다. 추후 상수 또는 enum으로 분리 여부 의견 부탁드립니다.