### PR TITLE
🐛 fix/#332-에디터-세션-만료-저장-실패-처리

### DIFF
--- a/html-cms/src/app/api/builder/save/route.ts
+++ b/html-cms/src/app/api/builder/save/route.ts
@@ -5,7 +5,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createPage, getPageById, resetApproveStateToWork, updatePage } from '@/db/repository/page.repository';
 import { contentBuilderErrorResponse, getErrorMessage, successResponse } from '@/lib/api-response';
 import { nextApi } from '@/lib/api-url';
-import { canAccessCmsEdit, canManageCmsPage, getCurrentUser } from '@/lib/current-user';
+import { UnauthorizedError, canAccessCmsEdit, canManageCmsPage, getCurrentUser } from '@/lib/current-user';
 import { isValidBankId, isPageExpired } from '@/lib/validators';
 import { isTemplateCompatibleViewMode } from '@/lib/view-mode';
 
@@ -102,6 +102,10 @@ export async function POST(req: NextRequest) {
     } catch (err: unknown) {
         if (err instanceof PageNotFoundError) {
             return NextResponse.json({ ok: false, error: err.message, errorCode: 'PAGE_NOT_FOUND' });
+        }
+        // 세션 만료 — 클라이언트가 재로그인 유도 처리를 할 수 있도록 HTTP 401 반환
+        if (err instanceof UnauthorizedError) {
+            return NextResponse.json({ ok: false, error: err.message, errorCode: 'SESSION_EXPIRED' }, { status: 401 });
         }
 
         console.error('페이지 저장 실패:', err);

--- a/html-cms/src/components/edit/EditClient.tsx
+++ b/html-cms/src/components/edit/EditClient.tsx
@@ -230,6 +230,15 @@ function applyBrandTheme(html: string, theme: BrandTheme): string {
     );
 }
 
+/** 세션 만료 전용 에러 — save() 에서 throw, handleSave/handlePreview 에서 instanceof 비교
+ *  컴포넌트 외부에 선언하여 리렌더링 시 재선언으로 인한 instanceof 오류 방지 */
+class SessionExpiredError extends Error {
+    constructor() {
+        super('세션이 만료되었습니다. 다시 로그인해 주세요.');
+        this.name = 'SessionExpiredError';
+    }
+}
+
 export default function EditClient({
     bank = 'ibk',
     userId,
@@ -1881,8 +1890,7 @@ export default function EditClient({
 
                     // 세션 만료로 임시저장된 드래프트가 있으면 복원 여부 확인
                     // 저장 성공 시 localStorage.removeItem()으로 자동 삭제되므로 남아있으면 미저장 상태
-                    const draftKey = `cms_draft_${bank}`;
-                    const draft = localStorage.getItem(draftKey);
+                    const draft = localStorage.getItem(DRAFT_STORAGE_KEY);
                     if (draft) {
                         const restore = window.confirm(
                             '이전 세션에서 저장하지 못한 작업 내용이 있습니다.\n복원하시겠습니까?\n\n(취소를 누르면 임시 저장 데이터가 삭제됩니다)',
@@ -1891,7 +1899,7 @@ export default function EditClient({
                             builderRef.current.loadHtml(draft);
                         }
                         // 복원 여부와 관계없이 임시저장 데이터 삭제
-                        localStorage.removeItem(draftKey);
+                        localStorage.removeItem(DRAFT_STORAGE_KEY);
                     }
                 }
                 // 로드 응답에서 탭 정보 등록 — 최근 접근 순(왼쪽), 최대 10개
@@ -2518,15 +2526,7 @@ export default function EditClient({
     }
 
     // ── 저장 / 미리보기 / HTML 보기 ──────────────────────────────────────
-    /** 세션 만료 전용 에러 — handleSave/handlePreview 에서 재로그인 유도에 사용 */
-    class SessionExpiredError extends Error {
-        constructor() {
-            super('세션이 만료되었습니다. 다시 로그인해 주세요.');
-            this.name = 'SessionExpiredError';
-        }
-    }
-
-    /** 세션 만료 임시저장 localStorage 키 (pageId별 관리) */
+    /** 세션 만료 임시저장 localStorage 키 — pageId별 관리, 파일 내 단일 출처 */
     const DRAFT_STORAGE_KEY = `cms_draft_${bank}`;
 
     const save = async () => {
@@ -2563,6 +2563,14 @@ export default function EditClient({
         localStorage.removeItem(DRAFT_STORAGE_KEY);
     };
 
+    /** 세션 만료 공통 처리 — confirm 후 로그인 페이지로 이동 (작업 내용은 이미 localStorage에 저장된 상태) */
+    function handleSessionExpired() {
+        const goLogin = window.confirm(
+            '세션이 만료되어 저장하지 못했습니다.\n작업 내용은 임시 저장되었습니다.\n\n로그인 페이지로 이동하시겠습니까?\n(취소를 누르면 에디터에 계속 있을 수 있습니다)',
+        );
+        if (goLogin) window.location.href = `/login?returnUrl=${encodeURIComponent(window.location.href)}`;
+    }
+
     async function handleSave() {
         const html = builderRef.current?.html() ?? '';
         if (!html.trim()) {
@@ -2575,12 +2583,7 @@ export default function EditClient({
         } catch (err: unknown) {
             console.error('저장 실패:', err);
             if (err instanceof SessionExpiredError) {
-                // 세션 만료 — 작업 내용은 localStorage에 임시저장된 상태
-                // 확인 클릭 시 로그인 페이지로 이동 (현재 에디터 URL을 returnUrl로 전달)
-                const goLogin = window.confirm(
-                    '세션이 만료되어 저장하지 못했습니다.\n작업 내용은 임시 저장되었습니다.\n\n로그인 페이지로 이동하시겠습니까?\n(취소를 누르면 에디터에 계속 있을 수 있습니다)',
-                );
-                if (goLogin) window.location.href = `/login?returnUrl=${encodeURIComponent(window.location.href)}`;
+                handleSessionExpired();
                 return;
             }
             alert('저장에 실패했습니다.\n다시 시도해 주세요.');
@@ -2599,10 +2602,7 @@ export default function EditClient({
         } catch (err: unknown) {
             console.error('저장 실패:', err);
             if (err instanceof SessionExpiredError) {
-                const goLogin = window.confirm(
-                    '세션이 만료되어 저장하지 못했습니다.\n작업 내용은 임시 저장되었습니다.\n\n로그인 페이지로 이동하시겠습니까?\n(취소를 누르면 에디터에 계속 있을 수 있습니다)',
-                );
-                if (goLogin) window.location.href = `/login?returnUrl=${encodeURIComponent(window.location.href)}`;
+                handleSessionExpired();
                 return;
             }
             alert('저장에 실패했습니다.\n다시 시도해 주세요.');

--- a/html-cms/src/components/edit/EditClient.tsx
+++ b/html-cms/src/components/edit/EditClient.tsx
@@ -1878,6 +1878,21 @@ export default function EditClient({
                         loadHtmlMs: roundMs(performance.now() - loadHtmlStart),
                         htmlBytes: response._timing?.htmlBytes,
                     });
+
+                    // 세션 만료로 임시저장된 드래프트가 있으면 복원 여부 확인
+                    // 저장 성공 시 localStorage.removeItem()으로 자동 삭제되므로 남아있으면 미저장 상태
+                    const draftKey = `cms_draft_${bank}`;
+                    const draft = localStorage.getItem(draftKey);
+                    if (draft) {
+                        const restore = window.confirm(
+                            '이전 세션에서 저장하지 못한 작업 내용이 있습니다.\n복원하시겠습니까?\n\n(취소를 누르면 임시 저장 데이터가 삭제됩니다)',
+                        );
+                        if (restore) {
+                            builderRef.current.loadHtml(draft);
+                        }
+                        // 복원 여부와 관계없이 임시저장 데이터 삭제
+                        localStorage.removeItem(draftKey);
+                    }
                 }
                 // 로드 응답에서 탭 정보 등록 — 최근 접근 순(왼쪽), 최대 10개
                 if (response.pageMissing) {
@@ -2503,6 +2518,17 @@ export default function EditClient({
     }
 
     // ── 저장 / 미리보기 / HTML 보기 ──────────────────────────────────────
+    /** 세션 만료 전용 에러 — handleSave/handlePreview 에서 재로그인 유도에 사용 */
+    class SessionExpiredError extends Error {
+        constructor() {
+            super('세션이 만료되었습니다. 다시 로그인해 주세요.');
+            this.name = 'SessionExpiredError';
+        }
+    }
+
+    /** 세션 만료 임시저장 localStorage 키 (pageId별 관리) */
+    const DRAFT_STORAGE_KEY = `cms_draft_${bank}`;
+
     const save = async () => {
         if (!builderRef.current) return;
         const builder = builderRef.current;
@@ -2521,8 +2547,20 @@ export default function EditClient({
                 removeCurrentTabAndRedirect('삭제되었거나 존재하지 않는 페이지입니다.');
                 return;
             }
+            // 세션 만료 — 현재 HTML을 localStorage에 임시저장 후 SessionExpiredError throw
+            // 호출자(handleSave/handlePreview)에서 재로그인 안내 처리
+            if (result.errorCode === 'SESSION_EXPIRED' || response.status === 401) {
+                try {
+                    localStorage.setItem(DRAFT_STORAGE_KEY, html);
+                } catch {
+                    // localStorage 용량 초과 등 실패 시 무시
+                }
+                throw new SessionExpiredError();
+            }
             throw new Error(result.error);
         }
+        // 저장 성공 시 임시저장 데이터 제거
+        localStorage.removeItem(DRAFT_STORAGE_KEY);
     };
 
     async function handleSave() {
@@ -2536,6 +2574,15 @@ export default function EditClient({
             alert('저장이 완료되었습니다.');
         } catch (err: unknown) {
             console.error('저장 실패:', err);
+            if (err instanceof SessionExpiredError) {
+                // 세션 만료 — 작업 내용은 localStorage에 임시저장된 상태
+                // 확인 클릭 시 로그인 페이지로 이동 (현재 에디터 URL을 returnUrl로 전달)
+                const goLogin = window.confirm(
+                    '세션이 만료되어 저장하지 못했습니다.\n작업 내용은 임시 저장되었습니다.\n\n로그인 페이지로 이동하시겠습니까?\n(취소를 누르면 에디터에 계속 있을 수 있습니다)',
+                );
+                if (goLogin) window.location.href = `/login?returnUrl=${encodeURIComponent(window.location.href)}`;
+                return;
+            }
             alert('저장에 실패했습니다.\n다시 시도해 주세요.');
         }
     }
@@ -2551,6 +2598,13 @@ export default function EditClient({
             window.open(nextApi(`/view?bank=${bank}&preview=1`), '_blank');
         } catch (err: unknown) {
             console.error('저장 실패:', err);
+            if (err instanceof SessionExpiredError) {
+                const goLogin = window.confirm(
+                    '세션이 만료되어 저장하지 못했습니다.\n작업 내용은 임시 저장되었습니다.\n\n로그인 페이지로 이동하시겠습니까?\n(취소를 누르면 에디터에 계속 있을 수 있습니다)',
+                );
+                if (goLogin) window.location.href = `/login?returnUrl=${encodeURIComponent(window.location.href)}`;
+                return;
+            }
             alert('저장에 실패했습니다.\n다시 시도해 주세요.');
         }
     }

--- a/html-cms/src/lib/current-user.ts
+++ b/html-cms/src/lib/current-user.ts
@@ -73,7 +73,14 @@ export async function getCurrentUser(): Promise<CurrentUser> {
             roleId: user.roleId,
             authorities: user.authorities ?? [],
         };
-    } catch {
+    } catch (err: unknown) {
+        // Java가 401/403을 반환한 경우 — 세션 만료 또는 인증 오류
+        // 호출자가 세션 만료와 일반 오류를 구분할 수 있도록 UnauthorizedError를 throw
+        const status = (err as Error & { status?: number }).status;
+        if (status === 401 || status === 403) {
+            throw new UnauthorizedError('세션이 만료되었습니다. 다시 로그인해 주세요.');
+        }
+        // 네트워크 오류·서버 장애 등 그 외 에러는 fail-open: GUEST_USER 반환
         return GUEST_USER;
     }
 }

--- a/html-cms/src/lib/java-admin-api.ts
+++ b/html-cms/src/lib/java-admin-api.ts
@@ -58,7 +58,10 @@ export async function fetchJavaAdminApi<T>(path: string, init: RequestInit = {})
 
     const body = (await response.json().catch(() => null)) as SpiderAdminApiResponse<T> | null;
     if (!response.ok || !body?.success || body.data === undefined) {
-        throw new Error(body?.message ?? `spider-admin API request failed. (${response.status})`);
+        const err = new Error(body?.message ?? `spider-admin API request failed. (${response.status})`);
+        // 인증 만료 여부를 호출자가 판별할 수 있도록 HTTP 상태코드를 attach
+        (err as Error & { status?: number }).status = response.status;
+        throw err;
     }
 
     return body.data;


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
Closes #332

## ✨ 변경 사항 (Changes)
- `java-admin-api.ts`: API 에러에 HTTP status 코드 attach — 호출자가 401/403 구분 가능하도록
- `current-user.ts`: Java 세션 만료(401/403) 시 `UnauthorizedError` throw, 네트워크 오류 등은 기존 fail-open(GUEST_USER 반환) 유지
- `save/route.ts`: `UnauthorizedError` catch 시 HTTP 200 대신 **HTTP 401** + `errorCode: SESSION_EXPIRED` 반환
- `EditClient.tsx`
  - 저장 API 401 응답 감지 → `localStorage`에 HTML 임시저장(`cms_draft_{pageId}`)
  - "세션이 만료되었습니다. 작업 내용이 임시 저장되었습니다." confirm 팝업 → 로그인 페이지 이동
  - 에디터 초기 로드 시 `localStorage` 드래프트 감지 → 복원 여부 사용자 확인

## 🛠 기술적 의사결정 (선택)
**기존 fail-open 정책 유지**
`getCurrentUser()`의 catch 블록은 네트워크 오류·서버 장애 시 `GUEST_USER`를 반환하는 fail-open 구조였다.
세션 만료(401/403)만 `UnauthorizedError`로 구분하고 나머지는 기존 동작을 유지하여 영향 범위를 최소화했다.

**HTTP 상태코드 분리**
기존 `contentBuilderErrorResponse`는 ContentBuilder 연동 규약상 항상 HTTP 200을 반환한다.
세션 만료는 ContentBuilder 에러가 아닌 인프라 수준 오류이므로 HTTP 401로 별도 분리하여 클라이언트가 명확히 구분할 수 있도록 했다.

## ⚠️ 고려 및 주의 사항 (선택)
- `AUTH_BYPASS=true` 환경에서는 Java `/api/auth/me` 호출 자체를 건너뛰므로 이 수정의 영향 없음
- 로그인 페이지 경로 `/login`은 spider-admin의 실제 로그인 URL과 일치하는지 배포 전 확인 필요

## 💬 리뷰 포인트 (선택)
- `EditClient.tsx` 내 `SessionExpiredError` 클래스를 함수 내부에 선언한 구조 — 외부 파일로 분리할지 여부
- 로그인 후 `returnUrl`로 돌아오는 처리가 spider-admin 로그인 페이지에서 지원되는지 확인 필요